### PR TITLE
Use ODR instead of IDR to toggle an output GPIO

### DIFF
--- a/lib/stm32/f2/gpio.c
+++ b/lib/stm32/f2/gpio.c
@@ -111,7 +111,7 @@ u16 gpio_get(u32 gpioport, u16 gpios)
 
 void gpio_toggle(u32 gpioport, u16 gpios)
 {
-	GPIO_ODR(gpioport) = GPIO_IDR(gpioport) ^ gpios;
+	GPIO_ODR(gpioport) ^= gpios;
 }
 
 u16 gpio_port_read(u32 gpioport)

--- a/lib/stm32/f4/gpio.c
+++ b/lib/stm32/f4/gpio.c
@@ -111,7 +111,7 @@ u16 gpio_get(u32 gpioport, u16 gpios)
 
 void gpio_toggle(u32 gpioport, u16 gpios)
 {
-	GPIO_ODR(gpioport) = GPIO_IDR(gpioport) ^ gpios;
+	GPIO_ODR(gpioport) ^= gpios;
 }
 
 u16 gpio_port_read(u32 gpioport)


### PR DESCRIPTION
IDR represents the level on pin input while ODR is the value requested by the
programmer. This makes a difference for example when using the output as open
drain.
