### PR TITLE
Add Device Electronic Signature support.

### DIFF
--- a/include/libopencm3/stm32/f1/desig.h
+++ b/include/libopencm3/stm32/f1/desig.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_DESIG_H
+#define LIBOPENCM3_DESIG_H
+
+#include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/cm3/common.h>
+
+/* --- Device Electronic Signature -------------------------------- */
+
+/* Flash size register */
+#define DESIG_FLASH_SIZE		MMIO16(DESIG_FLASH_SIZE_BASE + 0x00)
+
+/* Unique ID register (96 bits) */
+/* Note: ST says these may be accessed in any width if you choose */
+#define DESIG_UID_15_0			MMIO16(DESIG_UNIQUE_ID_BASE + 0x00)
+/* Listed as "This field value is also reserved for a future feature" WTH?! */
+#define DESIG_UID_31_16			MMIO16(DESIG_UNIQUE_ID_BASE + 0x02)
+#define DESIG_UID_63_32			MMIO32(DESIG_UNIQUE_ID_BASE + 0x04)
+#define DESIG_UID_95_64			MMIO32(DESIG_UNIQUE_ID_BASE + 0x08)
+
+/**
+ * Read the onboard flash size
+ * @return flash size in KB
+ */
+u16 desig_get_flash_size(void);
+
+/**
+ * Read the full 96 bit unique identifier
+ * Note: ST specifies that bits 31..16 are _also_ reserved for future use
+ * @param result pointer to at least 3xu32s (96 bits)
+ */
+void desig_get_unique_id(u32 result[]);
+
+#endif

--- a/include/libopencm3/stm32/f1/memorymap.h
+++ b/include/libopencm3/stm32/f1/memorymap.h
@@ -26,6 +26,7 @@
 
 /* Memory map for all busses */
 #define PERIPH_BASE			((u32)0x40000000)
+#define INFO_BASE			((u32)0x1ffff000)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)
 #define PERIPH_BASE_APB2		(PERIPH_BASE + 0x10000)
 #define PERIPH_BASE_AHB			(PERIPH_BASE + 0x18000)
@@ -109,5 +110,9 @@
 
 /* FSMC */
 #define FSMC_BASE			(PERIPH_BASE +  0x60000000)
+
+/* Device Electronic Signature */
+#define DESIG_FLASH_SIZE_BASE           (INFO_BASE + 0x7e0)
+#define DESIG_UNIQUE_ID_BASE            (INFO_BASE + 0x7e8)
 
 #endif

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -31,7 +31,7 @@ ARFLAGS		= rcs
 OBJS		= vector.o rcc.o gpio.o usart.o adc.o spi.o flash.o nvic.o \
 		  rtc.o i2c.o dma.o systick.o exti.o scb.o ethernet.o \
 		  usb_f103.o usb.o usb_control.o usb_standard.o can.o \
-		  timer.o usb_f107.o
+		  timer.o usb_f107.o desig.o
 
 VPATH += ../../usb:../
 

--- a/lib/stm32/f1/desig.c
+++ b/lib/stm32/f1/desig.c
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Karl Palsson <karlp@ŧweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/f1/desig.h>
+
+u16 desig_get_flash_size(void)
+{
+    return DESIG_FLASH_SIZE;
+}
+
+void desig_get_unique_id(u32 result[])
+{
+    // Could also just return a pointer to the start? read it as they wish?
+    u16 bits15_0 = DESIG_UID_15_0;
+    u32 bits31_16 = DESIG_UID_31_16;
+    u32 bits63_32 = DESIG_UID_63_32;
+    u32 bits95_64 = DESIG_UID_95_64;
+    result[0] = bits95_64;
+    result[1] = bits63_32;
+    result[2] = bits31_16 << 16 | bits15_0;
+}


### PR DESCRIPTION
Working unique id support, but not 100% convinced that this is the "least surprise"
path.  ST's docs provide the bits from low to high, in 2xu16 and 2xu32.
But to get it back as a "u96" the highest bits should be first?

Note: this only applies to F1 at this point
