### PR TITLE
Add helper function for max clock on HSI for f100

### DIFF
--- a/include/libopencm3/stm32/f1/rcc.h
+++ b/include/libopencm3/stm32/f1/rcc.h
@@ -408,6 +408,11 @@ void rcc_set_usbpre(u32 usbpre);
 u32 rcc_get_system_clock_source(int i);
 void rcc_clock_setup_in_hsi_out_64mhz(void);
 void rcc_clock_setup_in_hsi_out_48mhz(void);
+
+/**
+ * Maximum speed possible for F100 (Value Line) on HSI
+ */
+void rcc_clock_setup_in_hsi_out_24mhz(void);
 void rcc_clock_setup_in_hse_8mhz_out_24mhz(void);
 void rcc_clock_setup_in_hse_8mhz_out_72mhz(void);
 void rcc_clock_setup_in_hse_12mhz_out_72mhz(void);

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -436,6 +436,53 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 	rcc_ppre2_frequency = 48000000;
 }
 
+void rcc_clock_setup_in_hsi_out_24mhz(void) {
+	/* Enable internal high-speed oscillator. */
+	rcc_osc_on(HSI);
+	rcc_wait_for_osc_ready(HSI);
+
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
+
+	/*
+	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Do this before touching the PLL (TODO: why?).
+	 */
+	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV); /* Set. 24MHz Max. 24MHz */
+	rcc_set_adcpre(RCC_CFGR_ADCPRE_PCLK2_DIV2); /* Set. 12MHz Max. 12MHz */
+	rcc_set_ppre1(RCC_CFGR_PPRE1_HCLK_NODIV); /* Set. 24MHz Max. 24MHz */
+	rcc_set_ppre2(RCC_CFGR_PPRE2_HCLK_NODIV); /* Set. 24MHz Max. 24MHz */
+
+	/*
+	 * Sysclk is (will be) running with 24MHz -> 2 waitstates.
+	 * 0WS from 0-24MHz
+	 * 1WS from 24-48MHz
+	 * 2WS from 48-72MHz
+	 */
+	flash_set_ws(FLASH_LATENCY_0WS);
+
+	/*
+	 * Set the PLL multiplication factor to 6.
+	 * 8MHz (internal) * 6 (multiplier) / 2 (PLLSRC_HSI_CLK_DIV2) = 24MHz
+	 */
+	rcc_set_pll_multiplication_factor(RCC_CFGR_PLLMUL_PLL_CLK_MUL6);
+
+	/* Select HSI/2 as PLL source. */
+	rcc_set_pll_source(RCC_CFGR_PLLSRC_HSI_CLK_DIV2);
+
+	/* Enable PLL oscillator and wait for it to stabilize. */
+	rcc_osc_on(PLL);
+	rcc_wait_for_osc_ready(PLL);
+
+	/* Select PLL as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
+
+	/* Set the peripheral clock frequencies used */
+	rcc_ppre1_frequency = 24000000;
+	rcc_ppre2_frequency = 24000000;
+}
+
+
 void rcc_clock_setup_in_hse_8mhz_out_24mhz(void)
 {
 	/* Enable internal high-speed oscillator. */


### PR DESCRIPTION
Based on existing HSI code. Tested with f100c8, on custom board with no
external crystals or resonators.
