### PR TITLE
Don't include examples in doxygen output.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -610,7 +610,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = examples include lib
+INPUT                  = include lib
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is


### PR DESCRIPTION
There's no point, and it makes everything bigger and slower
