### PR TITLE
Basic helper routines for CRC (STM32F1)

### DIFF
--- a/include/libopencm3/stm32/crc.h
+++ b/include/libopencm3/stm32/crc.h
@@ -55,4 +55,24 @@
 
 /* TODO */
 
+/**
+ * Reset the CRC calculator to initial values.
+ */
+void crc_reset(void);
+
+/**
+ * Add a word to the crc calculator and return the result.
+ * @param data new word to add to the crc calculator
+ * @return final crc calculator value
+ */
+u32 crc_calculate(u32 data);
+
+/**
+ * Add a block of data to the CRC calculator and return the final result
+ * @param datap pointer to the start of a block of 32bit data words
+ * @param size length of data, in 32bit increments
+ * @return final CRC calculator value
+ */
+u32 crc_calculate_block(u32 *datap, int size);
+
 #endif

--- a/lib/stm32/crc.c
+++ b/lib/stm32/crc.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Karl Palsson <karlp@remake.is>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/crc.h>
+
+void crc_reset(void)
+{
+	CRC_CR |= CRC_CR_RESET;
+}
+
+u32 crc_calculate(u32 data)
+{
+	CRC_DR = data;
+	// Data sheet says this blocks until it's ready....
+	return CRC_DR;
+}
+
+u32 crc_calculate_block(u32 *datap, int size)
+{
+	int i;
+	for (i = 0; i < size; i++) {
+		CRC_DR = datap[i];
+	}
+	return CRC_DR;
+}
+
+
+

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -31,7 +31,7 @@ ARFLAGS		= rcs
 OBJS		= vector.o rcc.o gpio.o usart.o adc.o spi.o flash.o nvic.o \
 		  rtc.o i2c.o dma.o systick.o exti.o scb.o ethernet.o \
 		  usb_f103.o usb.o usb_control.o usb_standard.o can.o \
-		  timer.o usb_f107.o desig.o
+		  timer.o usb_f107.o desig.o crc.o
 
 VPATH += ../../usb:../
 


### PR DESCRIPTION
Note, the CRC block is pretty useless for interoperability.  It only operates on 32bit
chunks, and in a different bit order.  No attempt to make full helpers for compatibility
with other implementations has been done.

https://my.st.com/public/STe2ecommunities/mcu/Lists/cortex_mx_stm32/Flat.aspx?RootFolder=%2Fpublic%2FSTe2ecommunities%2Fmcu%2FLists%2Fcortex_mx_stm32%2FCRC%20computation&FolderCTID=0x01200200770978C69A1141439FE559EB459D7580009C4E14902C3CDE46A77F0FFD06506F5B&currentviews=2006
