### PR TITLE
Fix link flags to specify cpu instead of (wrong) arch.

### DIFF
--- a/examples/stm32/f1/Makefile.include
+++ b/examples/stm32/f1/Makefile.include
@@ -28,13 +28,14 @@ GDB		= $(PREFIX)-gdb
 # Uncomment this line if you want to use the installed (not local) library.
 #TOOLCHAIN_DIR := $(shell dirname `which $(CC)`)/../$(PREFIX)
 TOOLCHAIN_DIR   = ../../../../..
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m3 -msoft-float
 CFLAGS		+= -Os -g -Wall -Wextra -I$(TOOLCHAIN_DIR)/include \
-		   -fno-common -mcpu=cortex-m3 -mthumb -msoft-float -MD -DSTM32F1
+		   -fno-common $(ARCH_FLAGS) -MD -DSTM32F1
 LDSCRIPT	?= $(BINARY).ld
 LDFLAGS		+= -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group \
 		   -L$(TOOLCHAIN_DIR)/lib -L$(TOOLCHAIN_DIR)/lib/stm32/f1 \
 		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections \
-		   -mthumb -march=armv7 -mfix-cortex-m3-ldrd -msoft-float
+		   $(ARCH_FLAGS) -mfix-cortex-m3-ldrd
 OBJS		+= $(BINARY).o
 
 OOCD		?= openocd


### PR DESCRIPTION
-march=armv7 is NOT right for cortex-m3, and results in unexpected
arm code being linked in when using multilib toolchains

(Note, this should be applied to the f2 tree as well, but I don't have any f2 devices to double check)
