### PR TITLE
Updated alignment issues

### DIFF
--- a/lib/stm32/f4/libopencm3_stm32f4.ld
+++ b/lib/stm32/f4/libopencm3_stm32f4.ld
@@ -48,7 +48,7 @@ SECTIONS
 	__exidx_end = .;
 
 
-	_etext = .;
+	_etext = ALIGN(8);
 
 	.data : {
 		_data = .;

--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -27,7 +27,7 @@ static struct usb_control_state {
 		DATA_IN, LAST_DATA_IN, STATUS_IN,
 		DATA_OUT, LAST_DATA_OUT, STATUS_OUT,
 	} state;
-	struct usb_setup_data req;
+	struct usb_setup_data req __attribute__((aligned(4)));
 	u8 *ctrl_buf;
 	u16 ctrl_len;
 	void (*complete)(struct usb_setup_data *req);


### PR DESCRIPTION
Both these issues caused me days of grief. I tracked the USB core alignment issue after enabling hardware_faults, and tracing the code. The enum size is only one byte, so the address of usb_setup_data is not guaranteed to be aligned.

The second issue was when a colleague ported over bsd printf, sscanf was broken and he figured it out as the cause being an alignment issue in the etext section. The table compiled and needed by scanf was not aligned properly. Adding the linker flag fixed the issue.

Thanks so much.

Sincerely,
Jason
