### PR TITLE
fix deprecation attributes in adc for GCC < 4.5

### DIFF
--- a/include/libopencm3/stm32/f1/adc.h
+++ b/include/libopencm3/stm32/f1/adc.h
@@ -708,7 +708,11 @@ void adc_calibration(u32 adc);
 void adc_set_continuous_conversion_mode(u32 adc);
 void adc_set_single_conversion_mode(u32 adc);
 #ifdef __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR_ > 4)
 void adc_on(u32 adc) __attribute__ ((deprecated ("will be removed in the first release")));
+#else
+void adc_on(u32 adc) __attribute__ ((deprecated));
+#endif
 #else
 void adc_on(u32 adc);
 #endif
@@ -721,11 +725,19 @@ void adc_set_regular_sequence(u32 adc, u8 length, u8 channel[]);
 void adc_set_injected_sequence(u32 adc, u8 length, u8 channel[]);
 
 #ifdef __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR_ > 4)
 void adc_set_continous_conversion_mode(u32 adc) __attribute__ ((deprecated ("change to adc_set_continuous_conversion_mode")));
 void adc_set_conversion_time(u32 adc, u8 channel, u8 time) __attribute__ ((deprecated ("change to adc_set_sample_time")));
 void adc_set_conversion_time_on_all_channels(u32 adc, u8 time) __attribute__ ((deprecated ("change to adc_set_sample_time_on_all_channels")));
 void adc_enable_jeoc_interrupt(u32 adc) __attribute__ ((deprecated ("change to adc_enable_eoc_interrupt_injected")));
 void adc_disable_jeoc_interrupt(u32 adc) __attribute__ ((deprecated ("change to adc_disable_eoc_interrupt_injected")));
+#else
+void adc_set_continous_conversion_mode(u32 adc) __attribute__ ((deprecated));
+void adc_set_conversion_time(u32 adc, u8 channel, u8 time) __attribute__ ((deprecated));
+void adc_set_conversion_time_on_all_channels(u32 adc, u8 time) __attribute__ ((deprecated));
+void adc_enable_jeoc_interrupt(u32 adc) __attribute__ ((deprecated));
+void adc_disable_jeoc_interrupt(u32 adc) __attribute__ ((deprecated));
+#endif
 #endif
 END_DECLS
 


### PR DESCRIPTION
GCC < 4.5 that does not accept any argument for the deprecated attribute.
