### PR TITLE
Update makefile for stm32f4 examples so usb_cdcacm example now compiles

### DIFF
--- a/examples/stm32/f4/Makefile.include
+++ b/examples/stm32/f4/Makefile.include
@@ -45,7 +45,7 @@ CFLAGS		+= -Os -g -Wall -Wextra -I$(TOOLCHAIN_DIR)/include \
 LDSCRIPT	?= $(BINARY).ld
 LDFLAGS		+= --static -lc -lnosys \
 		   -L$(TOOLCHAIN_DIR)/lib/thumb/cortex-m4/float-abi-hard/fpuv4-sp-d16 \
-		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections \
+		   -L$(TOOLCHAIN_DIR)/lib -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections \
 		   -mthumb -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
 OBJS		+= $(BINARY).o
 


### PR DESCRIPTION
On three different computers (two Ubuntu and one Fedora), the STM32F4 USB CDC example wouldn't compile; it gave a linker error about VFP registers not being used by libc.a. This is described in Issue #59.

I found that the linker was using arm-none-eabi/lib/libc.a when it should have been using arm-none-eabi/lib/thumb/cortex-m4/float-abi-hard/fpuv4-sp-d16/libc.a for the Cortex M4 hard-float version of the library. I modified the LDFLAGS -L directives to use the hard-float path.

I compiled all of the STM32F4 examples using the modified makefile and ran each one on my STM32F4Discovery board. They all ran as expected (although I don't have UART2 hooked up to check that, the LEDs blinked properly on the UART examples), even the USB CDC example which had previously given me linker errors.
