### PR TITLE
Add __attribute__ ((naked)) to reset_handler()

### DIFF
--- a/lib/cm3/vector.c
+++ b/lib/cm3/vector.c
@@ -63,7 +63,7 @@ vector_table_t vector_table = {
 	}
 };
 
-void WEAK reset_handler(void)
+void WEAK __attribute__ ((naked)) reset_handler(void)
 {
 	volatile unsigned *src, *dest;
 


### PR DESCRIPTION
See discussion on mailing list: http://sourceforge.net/mailarchive/forum.php?thread_name=216B56E4-9F61-4D83-A8F9-41347DDCDE7D%40gmail.com&forum_name=libopencm3-devel

In the current versions of libopencm3 and the SAT toolchain, this bug can be triggered by choosing optimization level -O2 (in lib/stm32/f4/Makefile). A disassembly of reset_handler then looks like

Dump of assembler code for function reset_handler:
<code>
    0x08000224 <+0>:    push    {r4}
    0x08000226 <+2>:    ldr    r3, [pc, #80]    ; (0x8000278 <reset_handler+84>)
    0x08000228 <+4>:    msr    MSP, r3
[...]
</code>

As you can see, gcc generates code to push r4 to the stack, _before_ the stack pointer is set up. This behavior actually makes sense, as, per the ARM ABI, registers r0 - r3 are caller-saved, whereas r4-... are callee-saved.

While I had to use -O2 to trigger this, there is obviously nothing to prevent other versions of gcc to exhibit the same behavior on -Os, or -O0, as nothing tells the compiler that it must not use the stack (yet).

A fix that worked for me was to add __attribute__((naked)) to reset_handler (in lib/cm3/vector.c):

<code>void WEAK __attribute__ ((naked)) reset_handler(void)</code>

As reset_handler is only called once, and should never return, this is probably OK. However, I am not really sure if __attribute__((naked)) is the right solution here.
