### PR TITLE
Use same flags to compile STM32F1 library as for whose examples

### DIFF
--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -24,7 +24,7 @@ PREFIX		?= arm-none-eabi
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 -msoft-float -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSTM32F1
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs


### PR DESCRIPTION
We use a compiler witch defaults to --with-fpu=fpv4-sp-d16. Therefor the STM32F1 library was compiled using this FPU support, but the examples for STM32F1 have the fpu set tosoft since  -msoft-float is used. When the library is compiled with that flag too, we can compile those examples.
