### PR TITLE
Remove assembly forcing stack.

### DIFF
--- a/lib/cm3/vector.c
+++ b/lib/cm3/vector.c
@@ -67,8 +67,6 @@ void WEAK __attribute__ ((naked)) reset_handler(void)
 {
 	volatile unsigned *src, *dest;
 
-	__asm__("MSR msp, %0" : : "r"(&_stack));
-
 	for (src = &_data_loadaddr, dest = &_data; dest < &_edata; src++, dest++)
 		*dest = *src;
 


### PR DESCRIPTION
Fixes #51

There should be no reason for manually trying to load the stack.  Cortex
devices can be programmed with only C, and any code that needed this
would indicate broken vectors.
