### PR TITLE
[RFC] Use Kconfig as configuration system

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,22 @@
+
+mainmenu "libopencm3 Configuration"
+
+choice
+	prompt "Microcontroller Family"
+
+config STM32
+	bool "STM32F1/2/3/4, L1"
+
+config LPC
+	bool "LPC13XX, LPC17XX, LPC43XX"
+
+config LM
+	bool "LM3S, LM4F"
+
+config EFM32
+	bool "EFM32TG/G/LG/GG"
+endchoice
+
+config EXAMPLES
+       bool "Build usage examples"
+


### PR DESCRIPTION
This is more of a RFC rather that a real pull request, since the work proposed here is far from being complete, but I wanted to start the ball rolling and discuss this proposal to see if there would be and support for it.

This proof-of-concept commit adds a very rudimentary support of Kconfig(Linux kernel configuration system). This has become not only possible but also easy to accomplish due to emergence of kconfig-frontends project, source for which can be obtained at http://ymorin.is-a-geek.org/projects/kconfig-frontends

I think it is fair to say that libopencm3 has become a project encompassing a large choice of microcontrollers and development kits and most of its use cases involve only small subset of what the library can really offer. Given that, it seems reasonable to introduce some sort of configuration system that would allow user to have only selected few features build.

My proposition is to use Kconfig it's language and corresponding infrastructure to achieve aforementioned goal.

As it is the case with any significant change this one has its pros and cons.

Pros:
- Easy to use, well known configuration system
- More target specific builds which means faster build times and less useless information  in output

Cons:
- Additional build dependency which, unfortunately, has to be build form the source code
- Additional complication introduced to the build system of the project

All in all I think it is a worthy change, and I there's support for this change form the majority of significant contributors I would proceed with implementing it(It is not a small task and I'd rather avoid doing useless work)

Any questions, comments or suggestions are more then welcome!
