### PR TITLE
[cm3] fix doxygen for systick_get_value, add systick_get_reload

### DIFF
--- a/examples/stm32/f1/lisa-m-1/can/can.c
+++ b/examples/stm32/f1/lisa-m-1/can/can.c
@@ -91,7 +91,8 @@ void systick_setup(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 9000000/9000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(9000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(8999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/lisa-m-1/usb_hid/usbhid.c
+++ b/examples/stm32/f1/lisa-m-1/usb_hid/usbhid.c
@@ -241,7 +241,8 @@ static void hid_set_config(usbd_device *usbd_dev, u16 wValue)
 #endif
 
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
-	systick_set_reload(100000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(99999);
 	systick_interrupt_enable();
 	systick_counter_enable();
 }

--- a/examples/stm32/f1/lisa-m-2/can/can.c
+++ b/examples/stm32/f1/lisa-m-2/can/can.c
@@ -91,7 +91,8 @@ void systick_setup(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 9000000/9000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(9000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(8999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/lisa-m-2/usart_irq_printf/usart_irq_printf.c
+++ b/examples/stm32/f1/lisa-m-2/usart_irq_printf/usart_irq_printf.c
@@ -223,7 +223,8 @@ void systick_setup(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 9000000/9000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(9000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(8999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/obldc-strip/can/can.c
+++ b/examples/stm32/f1/obldc-strip/can/can.c
@@ -75,7 +75,8 @@ void systick_setup(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 8000000/8000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(8000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(7999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/obldc-strip/systick/systick.c
+++ b/examples/stm32/f1/obldc-strip/systick/systick.c
@@ -68,7 +68,8 @@ int main(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 8000000/8000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(8000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(7999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/obldc/can/can.c
+++ b/examples/stm32/f1/obldc/can/can.c
@@ -79,7 +79,8 @@ void systick_setup(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 9000000/9000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(9000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(8999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/obldc/systick/systick.c
+++ b/examples/stm32/f1/obldc/systick/systick.c
@@ -77,7 +77,8 @@ int main(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 9000000/9000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(9000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(8999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/other/systick/systick.c
+++ b/examples/stm32/f1/other/systick/systick.c
@@ -62,7 +62,8 @@ int main(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 9000000/9000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(9000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(8999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/other/usb_hid/usbhid.c
+++ b/examples/stm32/f1/other/usb_hid/usbhid.c
@@ -238,7 +238,8 @@ static void hid_set_config(usbd_device *usbd_dev, u16 wValue)
 #endif
 
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
-	systick_set_reload(100000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(99999);
 	systick_interrupt_enable();
 	systick_counter_enable();
 }

--- a/examples/stm32/f1/stm32-h103/usart_irq_printf/usart_irq_printf.c
+++ b/examples/stm32/f1/stm32-h103/usart_irq_printf/usart_irq_printf.c
@@ -222,7 +222,8 @@ void systick_setup(void)
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 
 	/* 9000000/9000 = 1000 overflows per second - every 1ms one interrupt */
-	systick_set_reload(9000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(8999);
 
 	systick_interrupt_enable();
 

--- a/examples/stm32/f1/stm32-h103/usb_hid/usbhid.c
+++ b/examples/stm32/f1/stm32-h103/usb_hid/usbhid.c
@@ -236,7 +236,8 @@ static void hid_set_config(usbd_device *usbd_dev, u16 wValue)
 #endif
 
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
-	systick_set_reload(100000);
+	/* SysTick interrupt every N clock pulses: set reload to N-1 */
+	systick_set_reload(99999);
 	systick_interrupt_enable();
 	systick_counter_enable();
 }

--- a/lib/cm3/systick.c
+++ b/lib/cm3/systick.c
@@ -60,9 +60,20 @@ void systick_set_reload(u32 value)
 @returns 24 bit reload value as u32.
 */
 
+u32 systick_get_reload(void)
+{
+	return (STK_LOAD & 0x00FFFFFF);
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief Get the current SysTick counter value.
+
+@returns 24 bit current value as u32.
+*/
+
 u32 systick_get_value(void)
 {
-	return STK_VAL;
+	return (STK_VAL & 0x00FFFFFF);
 }
 
 /*-----------------------------------------------------------------------------*/


### PR DESCRIPTION
Also fix the reload value in the examples:
to get a SysTick interrupt every N clock pulses: set reload to N-1
see http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/BGBEEJHC.html#BABGACGG
