### PR TITLE
Implement SPI clean disable from TODO comment

### DIFF
--- a/include/libopencm3/stm32/common/spi_common_all.h
+++ b/include/libopencm3/stm32/common/spi_common_all.h
@@ -350,6 +350,7 @@ void spi_reset(u32 spi_peripheral);
 int spi_init_master(u32 spi, u32 br, u32 cpol, u32 cpha, u32 dff, u32 lsbfirst);
 void spi_enable(u32 spi);
 void spi_disable(u32 spi);
+void spi_clean_disable(u32 spi);
 void spi_write(u32 spi, u16 data);
 void spi_send(u32 spi, u16 data);
 u16 spi_read(u32 spi);


### PR DESCRIPTION
Prevent data corruption and busy flag becoming unreliable by waiting for RXNE, TXE, and BSY flags as recommended in section 23.3.8 of the STM32F100XX Reference Manual.
