### PR TITLE
EXTI: Added function to get flag status

### DIFF
--- a/include/libopencm3/stm32/exti.h
+++ b/include/libopencm3/stm32/exti.h
@@ -71,6 +71,7 @@ void exti_enable_request(u32 extis);
 void exti_disable_request(u32 extis);
 void exti_reset_request(u32 extis);
 void exti_select_source(u32 exti, u32 gpioport);
+u32 exti_get_flag_status(u32 exti);
 
 END_DECLS
 

--- a/lib/stm32/f1/exti.c
+++ b/lib/stm32/f1/exti.c
@@ -66,6 +66,14 @@ void exti_reset_request(u32 extis)
 }
 
 /*
+ * Check the flag of a given EXTI interrupt.
+ * */
+u32 exti_get_flag_status(u32 exti)
+{
+	return EXTI_PR & exti;
+}
+
+/*
  * Remap an external interrupt line to the corresponding pin on the
  * specified GPIO port.
  *


### PR DESCRIPTION
This commit adds a function to check the status of the EXTI interrupt flag for a given GPIO.
