### PR TITLE
Add GPIO configuration helper function

### DIFF
--- a/include/libopencm3/stm32/f1/gpio.h
+++ b/include/libopencm3/stm32/f1/gpio.h
@@ -927,10 +927,19 @@ Line Devices only
 
 BEGIN_DECLS
 
+struct gpio_port_config {
+        u32 port;
+        u16 pins;
+        u8 cnf;
+        u8 mode;
+        u8 level;
+};
+
 void gpio_set_mode(u32 gpioport, u8 mode, u8 cnf, u16 gpios);
 void gpio_set_eventout(u8 evoutport, u8 evoutpin);
 void gpio_primary_remap(u32 swjenable, u32 maps);
 void gpio_secondary_remap(u32 maps);
+void gpio_set_port_config(const struct gpio_port_config *config, int num_config);
 
 END_DECLS
 

--- a/lib/stm32/f1/gpio.c
+++ b/lib/stm32/f1/gpio.c
@@ -128,6 +128,31 @@ void gpio_set_mode(u32 gpioport, u8 mode, u8 cnf, u16 gpios)
 }
 
 /*-----------------------------------------------------------------------------*/
+/** @brief Set GPIO Pin Mode from configuration table
+
+Sets the mode (input/output) and configuration (analog/digitial and
+open drain/push pull), for a set of GPIO pins for all the GPIO ports
+specified in the GPIO configuration table.
+
+@param[in] config Const struct gpio_port_config *. GPIO port
+configuration table.
+@param[in] num_config Int. Configuration table length.
+*/
+void gpio_set_port_config(const struct gpio_port_config *config, int num_config)
+{
+        int i;
+        for (i = 0; i < num_config; i++) {
+                gpio_set_mode(config[i].port, config[i].mode,
+			      config[i].cnf, config[i].pins);
+
+                if (config[i].level)
+			gpio_set(config[i].port, config[i].pins);
+                else
+			gpio_clear(config[i].port, config[i].pins);
+        }
+}
+
+/*-----------------------------------------------------------------------------*/
 /** @brief Map the EVENTOUT signal
 
 Enable the EVENTOUT signal and select the port and pin to be used.


### PR DESCRIPTION
This commit adds a 'gpio_set_port_config' function that allows user
to define all required pin configuration for a project in a single
table instead of using multiple 'gpio_set_mode' calls.
