### PR TITLE
Added I2S, USB Audio, and Isochronous IN USB xfer

### DIFF
--- a/include/libopencm3/stm32/common/spi_common_all.h
+++ b/include/libopencm3/stm32/common/spi_common_all.h
@@ -350,7 +350,6 @@ void spi_reset(u32 spi_peripheral);
 int spi_init_master(u32 spi, u32 br, u32 cpol, u32 cpha, u32 dff, u32 lsbfirst);
 void spi_enable(u32 spi);
 void spi_disable(u32 spi);
-u16 spi_clean_disable(u32 spi);
 void spi_write(u32 spi, u16 data);
 void spi_send(u32 spi, u16 data);
 u16 spi_read(u32 spi);
@@ -392,6 +391,12 @@ void spi_enable_tx_dma(u32 spi);
 void spi_disable_tx_dma(u32 spi);
 void spi_enable_rx_dma(u32 spi);
 void spi_disable_rx_dma(u32 spi);
+u16 spi_clean_disable(u32 spi);
+void i2s_set_baud(u32 spi, u32 mck_enable, u32 odd, u32 div);
+void i2s_init(u32 spi, u32 standard, u32 pcmsync, u32 data_length,
+	u32 ck_polarity, u32 channel_length, u32 mode);
+void i2s_enable(u32 spi);
+void i2s_disable(u32 spi);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/otg_hs.h
+++ b/include/libopencm3/stm32/otg_hs.h
@@ -343,7 +343,8 @@
 /* OTG_FS Device Control OUT Endpoint 0 Control Register (OTG_HS_DOEPCTL0) */
 #define OTG_HS_DOEPCTL0_EPENA		(1 << 31)
 #define OTG_HS_DOEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
+#define OTG_HS_DOEPCTLX_SETODDFRM	(1 << 29)
+#define OTG_HS_DOEPCTLX_SEVNFRM		(1 << 28) /* Name in ISOC context */
 #define OTG_HS_DOEPCTLX_SD0PID		(1 << 28)
 #define OTG_HS_DOEPCTL0_SNAK		(1 << 27)
 #define OTG_HS_DOEPCTL0_CNAK		(1 << 26)
@@ -351,6 +352,7 @@
 #define OTG_HS_DOEPCTL0_STALL		(1 << 21)
 #define OTG_HS_DOEPCTL0_SNPM		(1 << 20)
 #define OTG_HS_DOEPCTL0_EPTYP_MASK	(0x3 << 18)
+#define OTG_HS_DOEOCTL0_EPTYPE_ISOC 	(1 << 18)
 #define OTG_HS_DOEPCTL0_NAKSTS		(1 << 17)
 /* Bit 16 - Reserved */
 #define OTG_HS_DOEPCTL0_USBAEP		(1 << 15)
@@ -360,6 +362,10 @@
 #define OTG_HS_DOEPCTL0_MPSIZ_32	(0x1 << 0)
 #define OTG_HS_DOEPCTL0_MPSIZ_16	(0x2 << 0)
 #define OTG_HS_DOEPCTL0_MPSIZ_8		(0x3 << 0)
+
+/* Mask for removing frame bits from register for ISOC handling */
+#define OTG_HS_DOEPCTL0_RM_FRM_MSK 	0xCFFFFFFF
+#define FNSOF_MASK 			(0x1 << 8)
 
 /* OTG_FS Device IN Endpoint Interrupt Register (OTG_HS_DIEPINTx) */
 /* Bits 31:8 - Reserved */

--- a/include/libopencm3/stm32/spi.h
+++ b/include/libopencm3/stm32/spi.h
@@ -28,4 +28,3 @@
 #else
 #       error "stm32 family not defined."
 #endif
-

--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -76,6 +76,9 @@ extern int usbd_register_control_callback(usbd_device *usbd_dev, u8 type,
 extern void usbd_register_set_config_callback(usbd_device *usbd_dev,
 		void (*callback)(usbd_device *usbd_dev, u16 wValue));
 
+extern void usbd_register_set_altsetting_callback(usbd_device *usbd_dev,
+						  void (*callback)(usbd_device *usbd_dev, u16 wIndex, u16 wValue));
+
 /* Functions to be provided by the hardware abstraction layer */
 extern void usbd_poll(usbd_device *usbd_dev);
 extern void usbd_disconnect(usbd_device *usbd_dev, bool disconnected);

--- a/include/libopencm3/usb/usbstd.h
+++ b/include/libopencm3/usb/usbstd.h
@@ -139,8 +139,9 @@ struct usb_config_descriptor {
 	u8 bMaxPower;
 
 	/* Descriptor ends here.  The following are used internally: */
-	const struct usb_interface {
-		int num_altsetting;
+	struct usb_interface {
+		u8 cur_altsetting;
+		u8 num_altsetting;
 		const struct usb_iface_assoc_descriptor *iface_assoc;
 		const struct usb_interface_descriptor *altsetting;
 	} *interface;
@@ -182,8 +183,25 @@ struct usb_endpoint_descriptor {
 	u8 bmAttributes;
 	u16 wMaxPacketSize;
 	u8 bInterval;
+	const void *append;
+	const void *extra;
+	int extralen;
 } __attribute__((packed));
 #define USB_DT_ENDPOINT_SIZE		sizeof(struct usb_endpoint_descriptor)
+
+/* USB ISOC Endpoint Descriptor - Table 9-13 */
+struct usb_isoc_endpoint_descriptor {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bEndpointAddress;
+	u8 bmAttributes;
+	u16 wMaxPacketSize;
+	u8 bInterval;
+	u8 bRefresh;
+	u8 bSynchAddress;
+	const void *extra;
+	int extralen;
+} __attribute__((packed));
 
 /* USB Endpoint Descriptor bmAttributes bit definitions */
 #define USB_ENDPOINT_ATTR_CONTROL		0x00
@@ -220,10 +238,98 @@ struct usb_iface_assoc_descriptor {
 	u8 bFunctionProtocol;
 	u8 iFunction;
 } __attribute__((packed));
+
 #define USB_DT_INTERFACE_ASSOCIATION_SIZE \
 				sizeof(struct usb_iface_assoc_descriptor)
 
 enum usb_language_id {
 	USB_LANGID_ENGLISH_US = 0x409,
 };
+
+/* Interface Header Audio Class descriptor */
+
+struct usb_audio_class_header_descriptor {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDescriptorSubType;
+	u16 bcdADC;
+	u16 wTotalLength;
+	u8 bInCollection;
+	u8 baInterfaceNr;
+} __attribute__((packed));
+
+#define USB_AUDIO_HEADER_SIZE \
+	sizeof(struct usb_audio_class_header_descriptor)
+
+/* Input Terminal Audio Class descriptor */
+struct usb_audio_class_input_terminal_descriptor {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDescriptorSubType;
+	u8 bTerminalID;
+	u16 wTerminalType;
+	u8 bAssocTerminal;
+	u8 bNrChannels;
+	u16 wChannelConfig;
+	u8 iChannelNames;
+	u8 iTerminal;
+} __attribute__((packed));
+
+#define USB_INPUT_TERMINAL_SIZE \
+	sizeof(struct usb_audio_class_input_terminal_descriptor)
+
+/* Output Terminal Audio Class descriptor */
+struct usb_audio_class_output_terminal_descriptor {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDescriptorSubtype;
+	u8 bTerminalID;
+	u16 wTerminalType;
+	u8 bAssocTerminal;
+	u8 bSourceID;
+	u8 iTerminal;
+} __attribute__((packed));
+
+#define USB_OUTPUT_TERMINAL_SIZE \
+	        sizeof(struct usb_audio_class_output_terminal_descriptor)
+
+/*  USB Format Type Descriptor */
+struct usb_format_type_descriptor {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDescriptorSubtype;
+	u8 bFormatType;
+	u8 bNrChannels;
+	u8 bSubframeSize;
+	u8 bBitResolution;
+	u8 bSamFreqType;
+	u8 tSamFreq[3];
+} __attribute__((packed));
+
+#define USB_AUDIO_FORMAT_SIZE \
+	sizeof(struct usb_microphone_type_1_format_type_descriptor)
+
+/*Class-specific Isoc. Audio Data Endpoint Descriptor*/
+struct usb_audio_isoc_descriptor {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDescriptorSubtype;
+	u8 bmAttributes;
+	u8 bLockDelayUnits;
+	u16 wLockDelay;
+} __attribute__((packed));
+
+#define USB_AUDIO_ISOC_SIZE \
+	sizeof(struct usb_audio_isoc_descriptor)
+
+/*Class-specific AS General Interface Descriptor */
+struct usb_class_as_general_interface_descriptor {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDescriptorSubtype;
+	u8 bTerminalLink;
+	u8 bDelay;
+	u16 wFormatTag;
+} __attribute__((packed));
+
 #endif

--- a/lib/stm32/common/i2c_common_all.c
+++ b/lib/stm32/common/i2c_common_all.c
@@ -282,7 +282,7 @@ void i2c_send_data(u32 i2c, u8 data)
 
 @param[in] i2c Unsigned int32. I2C register base address @ref i2c_reg_base.
 */
-uint8_t i2c_get_data(u32 i2c)
+u8 i2c_get_data(u32 i2c)
 {
 	return I2C_DR(i2c) & 0xff;
 }

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -69,6 +69,13 @@ struct _usbd_device {
 	/* User callback function for some standard USB function hooks */
 	void (*user_callback_set_config)(usbd_device *usbd_dev, u16 wValue);
 
+	void (*user_callback_set_altsetting)(usbd_device *usbd_dev,
+			u16 wIndex, u16 wValue);
+	void (*user_callback_class)(usbd_device *usbd_dev, u16 bmRequestType,
+			u8 bRequest, u16 wValue, u16 wLength);
+        void (*user_callback_vendor)(usbd_device *usbd_dev, u16 bmRequestType,
+			u8 bRequest, u16 wValue, u16 wLength);
+
 	const struct _usbd_driver *driver;
 
 	/* private driver data */


### PR DESCRIPTION
This commit extends libopencm3 usb to allow for USB audio devices and Isochronous In USB transfers. Also add's I2S functionality.

Added I2S enable and disable commands.
Added USB audio class descriptors and related functions.
Added Isochronous IN USB transfer functionality.
