### PR TITLE
Scb

### DIFF
--- a/include/libopencm3/cm3/scb.h
+++ b/include/libopencm3/cm3/scb.h
@@ -382,8 +382,8 @@ struct scb_exception_stack_frame {
 			      : [frameptr]"=r" (f));			\
 	} while (0)
 
-void scb_reset_core(void);
-void scb_reset_system(void);
+void scb_reset_core(void) __attribute__((noreturn, naked));
+void scb_reset_system(void) __attribute__((noreturn, naked));
 void scb_set_priority_grouping(u32 prigroup);
 
 /* TODO: */

--- a/lib/cm3/scb.c
+++ b/lib/cm3/scb.c
@@ -17,16 +17,22 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdlib.h>
+
 #include <libopencm3/cm3/scb.h>
 
 void scb_reset_core(void)
 {
 	SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_VECTRESET;
+
+	exit(1);
 }
 
 void scb_reset_system(void)
 {
 	SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_SYSRESETREQ;
+
+	exit(1);
 }
 
 void scb_set_priority_grouping(u32 prigroup)


### PR DESCRIPTION
This commit add a structure definition that represents the stack frame
layout as it is upon entering exception handler. This is useful when
one wants to alter the exception return address, or get information
about registers state saved by the CPU.

Also fixes compiler warnings for scb_reset_system.
