### PR TITLE
Change the way buffer for control requests data is allocated

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -40,18 +40,12 @@ extern const usbd_driver stm32f207_usb_driver;
 #define otgfs_usb_driver stm32f107_usb_driver
 #define otghs_usb_driver stm32f207_usb_driver
 
-/* Static buffer for control transactions:
- * This is defined as weak in the library, applicaiton
- * may provide if a larger buffer is requred. */
-extern u8 usbd_control_buffer[];
-
 /* <usb.c> */
 extern usbd_device *usbd_init(const usbd_driver *driver,
 			      const struct usb_device_descriptor *dev,
 			      const struct usb_config_descriptor *conf,
-			      const char **strings, int num_strings);
-
-extern void usbd_set_control_buffer_size(usbd_device *usbd_dev, u16 size);
+			      const char **strings, int num_strings,
+			      u8 *control_buffer, u16 control_buffer_size);
 
 extern void usbd_register_reset_callback(usbd_device *usbd_dev,
 					 void (*callback)(void));

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -21,8 +21,6 @@
 #include <libopencm3/usb/usbd.h>
 #include "usb_private.h"
 
-u8 usbd_control_buffer[128] __attribute__((weak));
-
 /**
  * Main initialization entry point.
  *
@@ -39,12 +37,17 @@ u8 usbd_control_buffer[128] __attribute__((weak));
  *             array is determined by the bNumConfigurations field in the
  *             device descriptor.
  * @param strings TODO
+ * @param control_buffer Pointer to array that would hold the data
+ *                       received during control requests with DATA
+ *                       stage
+ * @param control_buffer_size Size of control_buffer
  * @return Zero on success (currently cannot fail).
  */
 usbd_device *usbd_init(const usbd_driver *driver,
 	      	       const struct usb_device_descriptor *dev,
 	      	       const struct usb_config_descriptor *conf,
-		       const char **strings, int num_strings)
+		       const char **strings, int num_strings,
+		       u8 *control_buffer, u16 control_buffer_size)
 {
 	usbd_device *usbd_dev;
 
@@ -55,8 +58,8 @@ usbd_device *usbd_init(const usbd_driver *driver,
 	usbd_dev->config = conf;
 	usbd_dev->strings = strings;
 	usbd_dev->num_strings = num_strings;
-	usbd_dev->ctrl_buf = usbd_control_buffer;
-	usbd_dev->ctrl_buf_len = sizeof(usbd_control_buffer);
+	usbd_dev->ctrl_buf = control_buffer;
+	usbd_dev->ctrl_buf_len = control_buffer_size;
 
 	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_SETUP] =
 	    _usbd_control_setup;
@@ -88,11 +91,6 @@ void usbd_register_resume_callback(usbd_device *usbd_dev,
 void usbd_register_sof_callback(usbd_device *usbd_dev, void (*callback)(void))
 {
 	usbd_dev->user_callback_sof = callback;
-}
-
-void usbd_set_control_buffer_size(usbd_device *usbd_dev, u16 size)
-{
-	usbd_dev->ctrl_buf_len = size;
 }
 
 void _usbd_reset(usbd_device *usbd_dev)


### PR DESCRIPTION
Current way of having a globally, but weakly defined static buffer has
several shortcomings:
- It forces user to have a certain "magic" byte array variable if
  they want to have a control buffer of different size.
- Having a globally defined static array and a separate function to
  tell USB core about its size is error prone.
- Its inner workings are not easily understandable form cursory look
  at API and one needs to go and look at the implementation code to
  connect all the pieces into a solid picture of how it works

This commit adds two parameters to 'usbd_init' call that allow user to
specify the pointer to the area of memory and a size of that memory
which would be used by the USB core to store the data received during
DATA stage of control requests. This approach, while further
complicating the prototype of 'usbd_init', provides user with more
flexibility allowing for any custom area of memory of any size to be
used as control buffer. It also forces user to provide both address
and memory size at the same time thus avoiding the possibility of user
redefining 'usbd_control_buffer', but not calling
'usbd_set_control_buffer_size' after that.
