### PR TITLE
Added BEGIN_DECLS and END_DECLS to stm32/common/gpio_common_all.h and stm32/l1/rcc.h

### DIFF
--- a/include/libopencm3/stm32/common/gpio_common_all.h
+++ b/include/libopencm3/stm32/common/gpio_common_all.h
@@ -60,6 +60,8 @@
 #define GPIO_ALL			0xffff
 /**@}*/
 
+BEGIN_DECLS
+
 void gpio_set(u32 gpioport, u16 gpios);
 void gpio_clear(u32 gpioport, u16 gpios);
 u16 gpio_get(u32 gpioport, u16 gpios);
@@ -67,6 +69,8 @@ void gpio_toggle(u32 gpioport, u16 gpios);
 u16 gpio_port_read(u32 gpioport);
 void gpio_port_write(u32 gpioport, u16 data);
 void gpio_port_config_lock(u32 gpioport, u16 gpios);
+
+END_DECLS
 
 /**@}*/
 #endif

--- a/include/libopencm3/stm32/l1/rcc.h
+++ b/include/libopencm3/stm32/l1/rcc.h
@@ -418,6 +418,8 @@ typedef enum {
 	PLL, HSE, HSI, MSI, LSE, LSI
 } osc_t;
 
+BEGIN_DECLS
+
 void rcc_osc_ready_int_clear(osc_t osc);
 void rcc_osc_ready_int_enable(osc_t osc);
 void rcc_osc_ready_int_disable(osc_t osc);
@@ -451,6 +453,8 @@ void rcc_clock_setup_msi(const clock_scale_t *clock);
 void rcc_clock_setup_hsi(const clock_scale_t *clock);
 void rcc_clock_setup_pll(const clock_scale_t *clock);
 void rcc_backupdomain_reset(void);
+
+END_DECLS
 
 /**@}*/
 


### PR DESCRIPTION
Fixed:
stm32/common/gpio_common_all.h
stm32/l1/rcc.h

Added BEGIN_DECLS and END_DECLS to function prototypes list to avoid the following errors when use funcs from c++:

undefined reference to `gpio_set(unsigned long, unsigned short)'
collect2: error: ld returned 1 exit status
make: **\* [stm32lib_cpp_dev_f2x.elf] Error 1
