### PR TITLE
Added functions for enabling/disabling USART interrupts

### DIFF
--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -49,6 +49,11 @@ specific memorymap.h header before including this header file.*/
 #define UART4				UART4_BASE
 #define UART5				UART5_BASE
 
+/* --- USART control registers labels -------------------------------------- */
+#define USART_CR1_REG 1
+#define USART_CR2_REG 2
+#define USART_CR3_REG 3
+
 /* --- USART registers ----------------------------------------------------- */
 
 /* Status register (USARTx_SR) */
@@ -370,6 +375,8 @@ void usart_enable_error_interrupt(u32 usart);
 void usart_disable_error_interrupt(u32 usart);
 bool usart_get_flag(u32 usart, u32 flag);
 bool usart_get_interrupt_source(u32 usart, u32 flag);
+void usart_enable_flag(u32 usart, u32 flag, u8 cr);
+void usart_disable_flag(u32 usart, u32 flag, u8 cr);
 
 END_DECLS
 

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -417,6 +417,58 @@ bool usart_get_flag(u32 usart, u32 flag)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Enable Flag.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref usart_reg_base
+@param[in] flag Unsigned int32. Status register flag  @ref usart_sr_flags.
+@param[in] flag Unsigned int8. Number of control register (1,2,3)
+*/
+
+void usart_enable_flag(u32 usart, u32 flag, u8 cr)
+{
+	switch (cr)
+	  {
+	    case USART_CR1_REG:
+	      USART_CR1(usart) |= flag;
+	      break;
+	    case USART_CR2_REG:
+	      USART_CR2(usart) |= flag;
+	      break;
+	    case USART_CR3_REG:
+	      USART_CR3(usart) |= flag;
+	      break;
+	    default:
+	      break;
+	  }
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief USART Disable Flag.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref usart_reg_base
+@param[in] flag Unsigned int32. Status register flag  @ref usart_sr_flags.
+@param[in] flag Unsigned int8. Number of control register (1,2,3)
+*/
+
+void usart_disable_flag(u32 usart, u32 flag, u8 cr)
+{
+	switch (cr)
+	  {
+	    case USART_CR1_REG:
+	      USART_CR1(usart) &= ~flag;
+	      break;
+	    case USART_CR2_REG:
+	      USART_CR2(usart) &= ~flag;
+	      break;
+	    case USART_CR3_REG:
+	      USART_CR3(usart) &= ~flag;
+	      break;
+	    default:
+	      break;
+	  }
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Return Interrupt Source.
 
 Returns true if the specified interrupt flag (IDLE, RXNE, TC, TXE or OE) was


### PR DESCRIPTION
Enable/disable the interrupt by setting the flag in the proper control register.
