### PR TITLE
Added small improvements to use internal flash memory in stm32f1XX

### DIFF
--- a/include/libopencm3/stm32/f1/flash.h
+++ b/include/libopencm3/stm32/f1/flash.h
@@ -103,6 +103,7 @@ void flash_clear_eop_flag(void);
 void flash_clear_wrprterr_flag(void);
 void flash_clear_bsy_flag(void);
 void flash_clear_status_flags(void);
+u32 flash_get_status_flags(void);
 void flash_unlock_option_bytes(void);
 void flash_erase_all_pages(void);
 void flash_erase_page(u32 page_address);

--- a/include/libopencm3/stm32/f1/memorymap.h
+++ b/include/libopencm3/stm32/f1/memorymap.h
@@ -25,6 +25,7 @@
 /* --- STM32 specific peripheral definitions ------------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			((u32)0x08000000)
 #define PERIPH_BASE			((u32)0x40000000)
 #define INFO_BASE			((u32)0x1ffff000)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)

--- a/lib/stm32/f1/flash.c
+++ b/lib/stm32/f1/flash.c
@@ -93,6 +93,11 @@ void flash_clear_status_flags(void)
 	flash_clear_bsy_flag();
 }
 
+u32 flash_get_status_flags(void)
+{
+	return (FLASH_SR &= (FLASH_SR_PGERR | FLASH_SR_EOP | FLASH_SR_WRPRTERR | FLASH_SR_BSY));
+}
+
 void flash_unlock_option_bytes(void)
 {
 	/* F1 uses same keys for flash and option */
@@ -102,8 +107,7 @@ void flash_unlock_option_bytes(void)
 
 void flash_wait_for_last_operation(void)
 {
-	while ((FLASH_SR & FLASH_SR_BSY) == FLASH_SR_BSY)
-		;
+	while ((FLASH_SR & FLASH_SR_BSY) == FLASH_SR_BSY);
 }
 
 void flash_program_word(u32 address, u32 data)


### PR DESCRIPTION
Please merge it. It is needed by an example I want to commit: https://github.com/millerd/libopencm3-examples/blob/master/examples/stm32/f1/stm32-h107/flash_rw_example/flash_rw_example.c
