### PR TITLE
Minor fix to compile functions in rtc.h

### DIFF
--- a/lib/stm32/f4/Makefile
+++ b/lib/stm32/f4/Makefile
@@ -34,7 +34,7 @@ CFLAGS		= -Os -g \
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
 
-OBJS		= adc.o can.o gpio.o exti2.o flash.o pwr.o rcc.o
+OBJS		= adc.o can.o gpio.o exti2.o flash.o pwr.o rcc.o rtc.o
 
 OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    gpio_common_all.o gpio_common_f24.o i2c_common_all.o \


### PR DESCRIPTION
I'm not sure if the functions there have been made obsolete by the
move to more common rtc headers.  If so, we should delete
the functions.  If not, then this fix should be applied to
compile them.

**The referenced functions are:**
void rtc_enable_wakeup_timer(void);
void rtc_disable_wakeup_timer(void);
void rtc_enable_wakeup_timer_interrupt(void);
void rtc_disable_wakeup_timer_interrupt(void);
