### PR TITLE
lm4f: Fix include guard in nvic.h

### DIFF
--- a/include/libopencm3/lm4f/nvic.h
+++ b/include/libopencm3/lm4f/nvic.h
@@ -32,8 +32,8 @@ LGPL License Terms @ref lgpl_license
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBOPENCM3_LM3S_NVIC_H
-#define LIBOPENCM3_LM3S_NVIC_H
+#ifndef LIBOPENCM3_LM4F_NVIC_H
+#define LIBOPENCM3_LM4F_NVIC_H
 
 /**@{*/
 
@@ -50,4 +50,4 @@ LGPL License Terms @ref lgpl_license
 
 /**@}*/
 
-#endif /* LIBOPENCM3_LM3S_NVIC_H */
+#endif /* LIBOPENCM3_LM4F_NVIC_H */


### PR DESCRIPTION
The lm4f/nvic.h include guard was wrongfully named LIBOPENCM3_LM3S_NVIC_H.
This caused the lm3s/nvic.h include a few lines down to not be compiled.
Rename the inlcude guard to the more appropriate LIBOPENCM3_LM4F_NVIC_H.

Signed-off-by: Alexandru Gagniuc mr.nuke.me@gmail.com
