### PR TITLE
[make] Use less shell variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ else
 DESTDIR		?= $(shell dirname $(shell readlink -f $(shell which $(PREFIX)-gcc)))/..
 endif
 
-INCDIR		= $(DESTDIR)/$(PREFIX)/include
-LIBDIR		= $(DESTDIR)/$(PREFIX)/lib
-SHAREDIR	= $(DESTDIR)/$(PREFIX)/share/libopencm3/scripts
-INSTALL		= install
+INCDIR		:= $(DESTDIR)/$(PREFIX)/include
+LIBDIR		:= $(DESTDIR)/$(PREFIX)/lib
+SHAREDIR	:= $(DESTDIR)/$(PREFIX)/share/libopencm3/scripts
+INSTALL		:= install
 
-SRCLIBDIR = $(shell pwd)/lib
-TARGETS = stm32/f1 stm32/f2 stm32/f4 stm32/l1 lpc13xx lpc17xx lpc43xx lm3s lm4f efm32/efm32tg efm32/efm32g efm32/efm32lg efm32/efm32gg sam3x
+SRCLIBDIR:= $(realpath lib)
+TARGETS:= stm32/f1 stm32/f2 stm32/f4 stm32/l1 lpc13xx lpc17xx lpc43xx lm3s lm4f efm32/efm32tg efm32/efm32g efm32/efm32lg efm32/efm32gg sam3x
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)

--- a/lib/Makefile.include
+++ b/lib/Makefile.include
@@ -29,20 +29,19 @@ OBJS += vector.o systick.o scb.o nvic.o assert.o sync.o
 all: $(SRCLIBDIR)/$(LIBNAME).a
 
 $(SRCLIBDIR)/$(LIBNAME).a: $(SRCLIBDIR)/$(LIBNAME).ld $(OBJS)
-	@printf "  AR      $(shell basename $(@))\n"
-	$(Q)$(AR) $(ARFLAGS) $(SRCLIBDIR)/$(shell basename $(@)) $(OBJS)
+	@printf "  AR      $(@F)\n"
+	$(Q)$(AR) $(ARFLAGS) $@ $(OBJS)
 
 $(SRCLIBDIR)/$(LIBNAME).ld: $(LIBNAME).ld
-	@printf "  CP      $(LIBNAME).ld\n"
+	@printf "  CP      $(@F)\n"
 	$(Q)cp $^ $@
 	$(Q)if [ -f $(LIBNAME)_rom_to_ram.ld ]; then cp $(LIBNAME)_rom_to_ram.ld $(SRCLIBDIR); fi
 
 %.o: %.c
-	@printf "  CC      $(subst $(shell pwd)/,,$(@))\n"
+	@printf "  CC      $(<F)\n"
 	$(Q)$(CC) $(CFLAGS) -o $@ -c $<
 
 clean:
-	@printf "  CLEAN   lib$(subst $(shell cd $(dir $(lastword $(MAKEFILE_LIST))) && pwd),,$(shell pwd))\n"
 	$(Q)rm -f *.o *.d ../*.o ../*.d
 	$(Q)rm -f $(SRCLIBDIR)/$(LIBNAME).a
 	$(Q)rm -f $(SRCLIBDIR)/$(LIBNAME).ld


### PR DESCRIPTION
Use fixed variables for things that can't change, instead of variables
like SRCLIBDIR that was causing a shell call for every single use.

Use less functions in general and less shell expansions.

Use builtin functions like $(realpath blah) instead of $(shell
pwd)/blah  In particular, this was important for me trying to build on
windows with git-shell  (powershell) and git-bash in the windows git distribution. This should help a lot on smaller build machines, but doesn't make a huge difference on my own.

This should really get tested on osx, but it works well on both windows and linux for me.
