### PR TITLE
Fix L1 voltage range selection and tidy up the clock setup

### DIFF
--- a/lib/stm32/l1/pwr.c
+++ b/lib/stm32/l1/pwr.c
@@ -35,20 +35,24 @@ LGPL License Terms @ref lgpl_license
  */
 
 #include <libopencm3/stm32/pwr.h>
+#include <libopencm3/stm32/rcc.h>
 
 void pwr_set_vos_scale(vos_scale_t scale)
 {
-	PWR_CR &= ~(PWR_CR_VOS_MASK);
+	/* You are not allowed to write zeros here, don't try and optimize! */
+	u32 reg = PWR_CR;
+	reg &= ~(PWR_CR_VOS_MASK);
 	switch (scale) {
 	case RANGE1:
-		PWR_CR |= PWR_CR_VOS_RANGE1;
+		reg |= PWR_CR_VOS_RANGE1;
 		break;
 	case RANGE2:
-		PWR_CR |= PWR_CR_VOS_RANGE2;
+		reg |= PWR_CR_VOS_RANGE2;
 		break;
 	case RANGE3:
-		PWR_CR |= PWR_CR_VOS_RANGE3;
+		reg |= PWR_CR_VOS_RANGE3;
 		break;
 	}
+	PWR_CR = reg;
 }
 

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -466,6 +466,7 @@ void rcc_clock_setup_msi(const clock_scale_t *clock)
 	rcc_set_ppre1(clock->ppre1);
 	rcc_set_ppre2(clock->ppre2);
 
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
 	pwr_set_vos_scale(clock->voltage_scale);
 
 	// I guess this should be in the settings?
@@ -496,6 +497,7 @@ void rcc_clock_setup_hsi(const clock_scale_t *clock)
 	rcc_set_ppre1(clock->ppre1);
 	rcc_set_ppre2(clock->ppre2);
 
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
 	pwr_set_vos_scale(clock->voltage_scale);
 
 	// I guess this should be in the settings?
@@ -523,6 +525,7 @@ void rcc_clock_setup_pll(const clock_scale_t *clock)
 	rcc_set_ppre1(clock->ppre1);
 	rcc_set_ppre2(clock->ppre2);
 
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
 	pwr_set_vos_scale(clock->voltage_scale);
 
 	// I guess this should be in the settings?


### PR DESCRIPTION
Ran into a nasty bug in the way the voltage regulator is setup in the L1 code.  Removed some pointless distractions at the same time.  (Actual commits have proper commit messages)

Want to let someone else look at this before just merging it myself.  I'm quite surprised we never saw this on revision W silicon, it shouldn't have ever worked really.  But the new revision V silicon gets very upset at trying to run at 32Mhz from flash in voltage range 3.
