### PR TITLE
Add basic support for stm32 hash processor.

### DIFF
--- a/include/libopencm3/stm32/common/hash_common_f24.h
+++ b/include/libopencm3/stm32/common/hash_common_f24.h
@@ -1,0 +1,177 @@
+/** @addtogroup hash_defines
+
+@author @htmlonly &copy; @endhtmlonly 2013 Mikhail Avkhimenia <mikhail@avkhimenia.net>
+
+*/
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Mikhail Avkhimenia <mikhail@avkhimenia.net>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+#ifdef LIBOPENCM3_HASH_H
+#ifndef LIBOPENCM3_HASH_COMMON_F24_H
+#define LIBOPENCM3_HASH_COMMON_F24_H
+
+#include <libopencm3/cm3/common.h>
+
+/* --- Convenience macros -------------------------------------------------- */
+
+/****************************************************************************/
+/** @defgroup hash_reg_base HASH register base addresses
+@ingroup STM32F_hash_defines
+
+@{*/
+#define HASH_BASE 	(PERIPH_BASE_AHB2 + 0x60400)
+#define HASH		HASH_BASE
+/**@}*/
+
+/* --- HASH registers ------------------------------------------------------ */
+
+/* HASH control register (HASH_CR) */
+#define HASH_CR 	MMIO32(HASH + 0x00)
+
+/* HASH data input register (HASH_DIR) */
+#define HASH_DIN 	MMIO32(HASH + 0x04)
+
+/* HASH start register (HASH_STR) */
+#define HASH_STR 	MMIO32(HASH + 0x08)
+
+/* HASH digest registers (HASH_HR[5]) */
+#define HASH_HR 	((volatile uint32_t*)(HASH + 0x0C)) //x5
+
+/* HASH interrupt enable register (HASH_IMR) */
+#define HASH_IMR 	MMIO32(HASH + 0x20)
+
+/* HASH status register (HASH_SR) */
+#define HASH_SR 	MMIO32(HASH + 0x28)
+
+/* HASH context swap registers (HASH_CSR[51]) */
+#define HASH_CSR 	((volatile uint32_t*)(HASH + 0xF8)) //x51
+
+/* --- HASH_CR values ------------------------------------------------------ */
+
+/* INIT: Initialize message digest calculation */
+#define HASH_CR_INIT		(1 << 2)
+
+/* DMAE: DMA enable */
+#define HASH_CR_DMAE		(1 << 3)
+
+/* DATATYPE: Data type selection */
+/****************************************************************************/
+/** @defgroup hash_data_type HASH Data Type
+@ingroup hash_defines
+
+@{*/
+#define HASH_DATA_32BIT			(0 << 4)
+#define HASH_DATA_16BIT			(1 << 4)
+#define HASH_DATA_8BIT			(2 << 4)
+#define HASH_DATA_BITSTRING		(3 << 4)
+/**@}*/
+#define HASH_CR_DATATYPE	(3 << 4)
+
+/* MODE: Mode selection */
+/****************************************************************************/
+/** @defgroup hash_mode HASH Mode
+@ingroup hash_defines
+
+@{*/
+#define HASH_MODE_HASH		(0 << 6)
+#define HASH_MODE_HMAC		(1 << 6)
+/**@}*/
+#define HASH_CR_MODE		(1 << 6)
+
+/* ALGO: Algorithm selection */
+/****************************************************************************/
+/** @defgroup hash_algorithm HASH Algorithm
+@ingroup hash_defines
+
+@{*/
+#define HASH_ALGO_SHA1		(0 << 7)
+#define HASH_ALGO_MD5		(1 << 7)
+/**@}*/
+#define HASH_CR_ALGO		(1 << 7)
+
+/* NBW: Number of words already pushed */
+#define HASH_CR_NBW			(15 << 8)
+
+/* DINNE: DIN(Data input register) not empty */
+#define HASH_CR_DINNE		(1 << 12)
+
+/* LKEY: Long key selection */
+/****************************************************************************/
+/** @defgroup hash_key_length HASH Key length
+@ingroup hash_defines
+
+@{*/
+#define HASH_KEY_SHORT		(0 << 16)
+#define HASH_KEY_LONG		(1 << 16)
+/**@}*/
+#define HASH_CR_LKEY		(1 << 16)
+
+/* --- HASH_STR values ----------------------------------------------------- */
+
+/* NBLW: Number of valid bits in the last word of the message in the bit string */
+#define HASH_STR_NBW		(31 << 0)
+
+/* DCAL: Digest calculation */
+#define HASH_STR_DCAL		(1 << 8)
+
+/* --- HASH_IMR values ----------------------------------------------------- */
+
+/* DINIE: Data input interrupt enable */
+#define HASH_IMR_DINIE		(1 << 0)
+
+/* DCIE: Digest calculation completion interrupt enable */
+#define HASH_IMR_DCIE		(1 << 1)
+
+/* --- HASH_SR values ------------------------------------------------------ */
+
+/* DINIS: Data input interrupt status */
+#define HASH_SR_DINIS		(1 << 0)
+
+/* DCIS: Digest calculation completion interrupt status */
+#define HASH_SR_DCIS		(1 << 1)
+
+/* DMAS: DMA Status */
+#define HASH_SR_DMAS		(1 << 2)
+
+/* BUSY: Busy bit */
+#define HASH_SR_BUSY		(1 << 3)
+
+/* --- HASH function prototypes ------------------------------------------------------- */
+
+BEGIN_DECLS
+
+void hash_set_mode(u8 mode);
+void hash_set_algorithm(u8 algorithm);
+void hash_set_data_type(u8 datatype);
+void hash_set_key_length(u8 keylength);
+void hash_set_last_word_valid_bits(u8 validbits);
+void hash_init();
+void hash_add_data(u32 data);
+void hash_digest();
+void hash_get_result(u32 *data);
+
+END_DECLS
+/**@}*/
+#endif
+#else
+#warning "hash_common_f24.h should not be included explicitly, only via hash.h"
+#endif

--- a/include/libopencm3/stm32/f2/hash.h
+++ b/include/libopencm3/stm32/f2/hash.h
@@ -1,0 +1,37 @@
+/** @defgroup hash_defines HASH Defines
+
+@ingroup STM32F2xx_defines
+
+@brief Defined Constants and Types for the STM32F2xx HASH Controller
+
+@version 1.0.0
+
+@date 31 May 2013
+
+LGPL License Terms @ref lgpl_license
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_HASH_H
+#define LIBOPENCM3_HASH_H
+
+#include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/common/hash_common_f24.h>
+
+#endif

--- a/include/libopencm3/stm32/f4/hash.h
+++ b/include/libopencm3/stm32/f4/hash.h
@@ -1,0 +1,37 @@
+/** @defgroup hash_defines HASH Defines
+
+@ingroup STM32F4xx_defines
+
+@brief Defined Constants and Types for the STM32F4xx HASH Controller
+
+@version 1.0.0
+
+@date 31 May 2013
+
+LGPL License Terms @ref lgpl_license
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_HASH_H
+#define LIBOPENCM3_HASH_H
+
+#include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/common/hash_common_f24.h>
+
+#endif

--- a/include/libopencm3/stm32/hash.h
+++ b/include/libopencm3/stm32/hash.h
@@ -1,0 +1,26 @@
+/* This provides unification of code over STM32F subfamilies */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if defined(STM32F2)
+#       include <libopencm3/stm32/f2/hash.h>
+#elif defined(STM32F4)
+#       include <libopencm3/stm32/f4/hash.h>
+#else
+#       error "hash processor is supported only in stm32f21, stm32f41 and stm32f43 families."
+#endif

--- a/lib/stm32/common/hash_common_f24.c
+++ b/lib/stm32/common/hash_common_f24.c
@@ -1,0 +1,159 @@
+/** @addtogroup hash_file
+
+@author @htmlonly &copy; @endhtmlonly 2013 Mikhail Avkhimenia <mikhail@avkhimenia.net>
+
+This library supports the HASH processor in the STM32F2 and STM32F4
+series of ARM Cortex Microcontrollers by ST Microelectronics.
+
+LGPL License Terms @ref lgpl_license
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Mikhail Avkhimenia <mikhail@avkhimenia.net>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+#include <libopencm3/stm32/hash.h>
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Set Mode
+
+Sets up the specified mode - either HASH or HMAC.
+
+@param[in] mode unsigned int8. Hash processor mode: @ref hash_mode
+*/
+
+void hash_set_mode(u8 mode)
+{
+	HASH_CR &= ~HASH_CR_MODE;
+	HASH_CR |= mode;
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Set Algorithm
+
+Sets up the specified algorithm - either MD5 or SHA1.
+
+@param[in] algorithm unsigned int8. Hash algorithm: @ref hash_algorithm
+*/
+
+void hash_set_algorithm(u8 algorithm)
+{
+	HASH_CR &= ~HASH_CR_ALGO;
+	HASH_CR |= algorithm;
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Set Data Type
+
+Sets up the specified data type: 32Bit, 16Bit, 8Bit, Bitstring.
+
+@param[in] datatype unsigned int8. Hash data type: @ref hash_data_type
+*/
+
+void hash_set_data_type(u8 datatype)
+{
+	HASH_CR &= ~HASH_CR_DATATYPE;
+	HASH_CR |= datatype;	
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Set Key Length
+
+Sets up the specified key length: Long, Short.
+
+@param[in] keylength unsigned int8. Hash data type: @ref hash_key_length
+*/
+
+void hash_set_key_length(u8 keylength)
+{
+	HASH_CR &= ~HASH_CR_LKEY;
+	HASH_CR |= keylength;	
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Set Last Word Valid Bits
+
+Specifies the number of valid bits in the last word.
+
+@param[in] validbits unsigned int8. Number of valid bits.
+*/
+
+void hash_set_last_word_valid_bits(u8 validbits)
+{
+	HASH_STR &= ~(HASH_STR_NBW);
+	HASH_STR |= 32 - validbits;
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Init
+
+Initializes the HASH processor.
+
+*/
+
+void hash_init()
+{
+	HASH_CR |= HASH_CR_INIT;
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Add data
+
+Puts data into the HASH processor's queue.
+
+@param[in] data unsigned int32. Hash input data.
+*/
+
+void hash_add_data(u32 data)
+{
+	HASH_DIN = data;
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Digest
+
+Starts the processing of the last data block.
+
+*/
+
+void hash_digest()
+{
+	HASH_STR |= HASH_STR_DCAL;
+}
+
+/*-----------------------------------------------------------------------------*/
+/** @brief HASH Get Hash Result
+
+Makes a copy of the resulting hash.
+
+@param[out] data unsigned int32. Hash 4\5 words long depending on the algorithm.
+@param[in] algorithm unsigned int8. Hash algorithm: @ref hash_algorithm
+*/
+
+void hash_get_result(u32 *data)
+{
+	data[0] = HASH_HR[0];
+	data[1] = HASH_HR[1];
+	data[2] = HASH_HR[2];
+	data[3] = HASH_HR[3];
+
+	if ((HASH_CR & HASH_CR_ALGO) == HASH_ALGO_SHA1)
+		data[4] = HASH_HR[4];
+}

--- a/lib/stm32/f2/Makefile
+++ b/lib/stm32/f2/Makefile
@@ -39,7 +39,7 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    gpio_common_all.o gpio_common_f24.o i2c_common_all.o \
                    iwdg_common_all.o rtc_common_bcd.o spi_common_all.o \
                    timer_common_all.o timer_common_f24.o usart_common_all.o \
-									 flash_common_f24.o
+									 flash_common_f24.o hash_common_f24.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/f4/Makefile
+++ b/lib/stm32/f4/Makefile
@@ -40,7 +40,7 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    gpio_common_all.o gpio_common_f24.o i2c_common_all.o \
                    iwdg_common_all.o pwr_common_all.o rtc_common_bcd.o \
                    spi_common_all.o timer_common_all.o timer_common_f24.o \
-                   usart_common_all.o flash_common_f24.o
+                   usart_common_all.o flash_common_f24.o hash_common_f24.o
 
 OBJS            += usb.o usb_standard.o usb_control.o usb_fx07_common.o \
 		   usb_f107.o usb_f207.o


### PR DESCRIPTION
Added hash processor register definitions and main functions. Hash
processor is supported in stm32f21, stm32f41 and stm32f43 and can be
used to calculate Md5 and Sha1. Usage example: http://pastebin.com/C0jRzVLX
