### PR TITLE
Global: Allow building with soft-float on M4F cores

### DIFF
--- a/README
+++ b/README
@@ -44,7 +44,7 @@ For Fedora
  $ [sudo] yum install PyYAML
 
 For Windows
- Download and install: 
+ Download and install:
  msys - sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.11/MSYS-1.0.11.exe
  Python - http://www.python.org/ftp/python/2.7/python-2.7.msi (use installer to get the right registry keys for PyYAML)
  PyYAML - http://pyyaml.org/download/pyyaml/PyYAML-3.10.win32-py2.7.exe
@@ -66,6 +66,22 @@ For a more verbose build you can use
 
  $ make V=1
 
+Fine-tuning the build
+---------------------
+
+The build may be fine-tuned with a limited number of parameters, by specifying
+them as environment variables, for example:
+
+ $ VARIABLE=value make
+
+* FP_FLAGS - Control the floating-point ABI
+   If the Cortex-M core supports a hard float ABI, it will be compiled with
+   floating-point support by default. In cases where this is not desired, the
+   behavior can be specified by setting FP_FLAGS. Currently, M4F cores default
+   to "-mfloat-abi=hard -mfpu=fpv4-sp-d16" and others to no FP flags
+   Examples:
+     $ FP_FLAGS="-mfloat-abi=soft" make               # No hardfloat
+     $ FP_FLAGS="-mfloat-abi=hard -mfpu=magic" make   # New FPU we don't know of
 
 Example projects
 ----------------

--- a/lib/efm32/efm32g/Makefile
+++ b/lib/efm32/efm32g/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 $(FP_FLAGS) -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -D$(FAMILY)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/efm32/efm32gg/Makefile
+++ b/lib/efm32/efm32gg/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 $(FP_FLAGS) -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -D$(FAMILY)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/efm32/efm32lg/Makefile
+++ b/lib/efm32/efm32lg/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 $(FP_FLAGS) -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -D$(FAMILY)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/efm32/efm32tg/Makefile
+++ b/lib/efm32/efm32tg/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 $(FP_FLAGS) -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -D$(FAMILY)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/lm3s/Makefile
+++ b/lib/lm3s/Makefile
@@ -20,7 +20,7 @@
 LIBNAME		= libopencm3_lm3s
 
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,7 +28,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DLM3S
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/lm4f/Makefile
+++ b/lib/lm4f/Makefile
@@ -2,6 +2,7 @@
 ## This file is part of the libopencm3 project.
 ##
 ## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2013 Alexandru Gagniuc <mr.nuke.me@gmail.com>
 ##
 ## This library is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU Lesser General Public License as published by
@@ -19,8 +20,9 @@
 
 LIBNAME		= libopencm3_lm4f
 
+FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,7 +30,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../include -fno-common \
-		  -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -Wstrict-prototypes \
+		  -mcpu=cortex-m4 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DLM4F
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/lpc13xx/Makefile
+++ b/lib/lpc13xx/Makefile
@@ -20,7 +20,7 @@
 LIBNAME		= libopencm3_lpc13xx
 
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,7 +28,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DLPC13XX
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/lpc17xx/Makefile
+++ b/lib/lpc17xx/Makefile
@@ -20,7 +20,7 @@
 LIBNAME		= libopencm3_lpc17xx
 
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -O0 -g \
@@ -28,7 +28,7 @@ CFLAGS		= -O0 -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DLPC17XX
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/lpc43xx/m4/Makefile
+++ b/lib/lpc43xx/m4/Makefile
@@ -4,6 +4,7 @@
 ## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
 ## Copyright (C) 2012 Michael Ossmann <mike@ossmann.com>
 ## Copyright (C) 2012 Benjamin Vernoux <titanmkd@gmail.com>
+## Copyright (C) 2013 Alexandru Gagniuc <mr.nuke.me@gmail.com>
 ##
 ## This library is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU Lesser General Public License as published by
@@ -21,8 +22,9 @@
 
 LIBNAME		= libopencm3_lpc43xx
 
+FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -O2 -g3 \
@@ -32,8 +34,8 @@ CFLAGS		= -O2 -g3 \
 		  -I../../../include -fno-common \
 		  -mcpu=cortex-m4 -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD \
-		  -mfloat-abi=hard -mfpu=fpv4-sp-d16 -DLPC43XX -DLPC43XX_M4
-# ARFLAGS	= rcsv
+		  $(FP_FLAGS) -DLPC43XX -DLPC43XX_M4
+
 ARFLAGS		= rcs
 
 # LPC43xx common files for M4 / M0

--- a/lib/sam/3n/Makefile
+++ b/lib/sam/3n/Makefile
@@ -20,11 +20,11 @@
 LIBNAME		= libopencm3_sam3n
 
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSAM3N
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/sam/3x/Makefile
+++ b/lib/sam/3x/Makefile
@@ -20,11 +20,11 @@
 LIBNAME		= libopencm3_sam3x
 
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSAM3X
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -20,7 +20,7 @@
 LIBNAME		= libopencm3_stm32f1
 
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,7 +28,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -msoft-float -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 $(FP_FLAGS) -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSTM32F1
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/stm32/f2/Makefile
+++ b/lib/stm32/f2/Makefile
@@ -19,8 +19,8 @@
 
 LIBNAME		= libopencm3_stm32f2
 
-PREFIX          ?= arm-none-eabi
-# PREFIX	?= arm-elf
+PREFIX		?= arm-none-eabi
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,7 +28,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSTM32F2
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs

--- a/lib/stm32/f3/Makefile
+++ b/lib/stm32/f3/Makefile
@@ -19,8 +19,9 @@
 
 LIBNAME		= libopencm3_stm32f3
 
+FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX	        ?= arm-none-eabi
-# PREFIX	?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,10 +29,9 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
-		  -Wstrict-prototypes \
+		  -mcpu=cortex-m4 -mthumb $(FP_FLAGS) -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSTM32F3
-# ARFLAGS	= rcsv
+
 ARFLAGS		= rcs
 
 OBJS		= rcc.o gpio.o adc.o exti.o i2c.o spi.o usart.o

--- a/lib/stm32/f4/Makefile
+++ b/lib/stm32/f4/Makefile
@@ -2,6 +2,7 @@
 ## This file is part of the libopencm3 project.
 ##
 ## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2013 Alexandru Gagniuc <mr.nuke.me@gmail.com>
 ##
 ## This library is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU Lesser General Public License as published by
@@ -19,8 +20,9 @@
 
 LIBNAME		= libopencm3_stm32f4
 
+FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX	        ?= arm-none-eabi
-# PREFIX	?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,7 +30,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
+		  -mcpu=cortex-m4 -mthumb $(FP_FLAGS) \
 		  -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSTM32F4
 # ARFLAGS	= rcsv

--- a/lib/stm32/l1/Makefile
+++ b/lib/stm32/l1/Makefile
@@ -20,7 +20,7 @@
 LIBNAME		= libopencm3_stm32l1
 
 PREFIX		?= arm-none-eabi
-#PREFIX		?= arm-elf
+
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
 CFLAGS		= -Os -g \
@@ -28,7 +28,7 @@ CFLAGS		= -Os -g \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \
 		  -I../../../include -fno-common \
-		  -mcpu=cortex-m3 -mthumb -Wstrict-prototypes \
+		  -mcpu=cortex-m3 $(FP_FLAGS) -mthumb -Wstrict-prototypes \
 		  -ffunction-sections -fdata-sections -MD -DSTM32L1
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs


### PR DESCRIPTION
We currently default to "-mfloat-abi=hard -mfpu=fpv4-sp-d16" for M4F cores.
Keep that default, but allow building with "-mfloat-abi=soft" if desired.
For this, we introduce the NO_HARD_FLOAT flag. See README for details.
