### PR TITLE
Documentation: Strip the BEGIN_DECLS definition from the first function in a module ...

### DIFF
--- a/doc/Doxyfile_common
+++ b/doc/Doxyfile_common
@@ -1525,7 +1525,7 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator
 # instead of the = operator.
 
-PREDEFINED             = __attribute__(x)=
+PREDEFINED             = __attribute__(x)= BEGIN_DECLS END_DECLS
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.


### PR DESCRIPTION
In present doxygen generated documentation, there is present definition BEGIN_DECLS on the beginning of the first documented function in a module. (both html and latex output)

This patch removes this behavior by telling to the doxygen the suggested macro expansion to empty string.

doxygen v 1.8.4 (latest)
