### PR TITLE
fix missing USB symbols for STM32F2

### DIFF
--- a/lib/stm32/f2/Makefile
+++ b/lib/stm32/f2/Makefile
@@ -41,6 +41,9 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    timer_common_all.o timer_common_f24.o usart_common_all.o \
 									 flash_common_f24.o hash_common_f24.o
 
+OBJS            += usb.o usb_standard.o usb_control.o usb_fx07_common.o \
+                   usb_f107.o usb_f207.o
+
 VPATH += ../../usb:../:../../cm3:../common
 
 include ../../Makefile.include


### PR DESCRIPTION
When I try to compile code with `libopencm3_stm32f2` that uses USB functions I hit errors:

```
undefined reference to `usbd_ep_setup'
undefined reference to `usbd_ep_read_packet'
undefined reference to `usbd_ep_write_packet'
undefined reference to `usbd_register_control_callback'
undefined reference to `usbd_init'
undefined reference to `usbd_register_set_config_callback'
undefined reference to `usbd_poll'
```

I noticed there are some object files missing from `lib/stm32/f2/Makefile`. Fix is attached.
