### PR TITLE
Fix STM32F4 ADC

### DIFF
--- a/include/libopencm3/stm32/f4/adc.h
+++ b/include/libopencm3/stm32/f4/adc.h
@@ -842,7 +842,7 @@ void adc_enable_external_trigger_regular(uint32_t adc, uint32_t trigger,
 					 uint32_t polarity);
 void adc_enable_external_trigger_injected(uint32_t adc, uint32_t trigger,
 					  uint32_t polarity);
-void adc_set_resolution(uint32_t adc, uint16_t resolution);
+void adc_set_resolution(uint32_t adc, uint32_t resolution);
 void adc_enable_overrun_interrupt(uint32_t adc);
 void adc_disable_overrun_interrupt(uint32_t adc);
 bool adc_get_overrun_flag(uint32_t adc);

--- a/lib/stm32/f4/adc.c
+++ b/lib/stm32/f4/adc.c
@@ -871,10 +871,10 @@ ADC Resolution can be reduced from 12 bits to 10, 8 or 6 bits for a
 corresponding reduction in conversion time (resolution + 3 ADC clock cycles).
 
 @param[in] adc Unsigned int32. ADC block register address base @ref adc_reg_base
-@param[in] resolution Unsigned int8. Resolution value @ref adc_cr1_res
+@param[in] resolution Unsigned int32. Resolution value @ref adc_cr1_res
 */
 
-void adc_set_resolution(uint32_t adc, uint16_t resolution)
+void adc_set_resolution(uint32_t adc, uint32_t resolution)
 {
 	uint32_t reg32 = ADC_CR1(adc);
 


### PR DESCRIPTION
I can only imagine the resolution argument was 16 bits due to some cut
and paste error
