### PR TITLE
Fix the order of ADC injected channel list

### DIFF
--- a/include/libopencm3/stm32/f1/adc.h
+++ b/include/libopencm3/stm32/f1/adc.h
@@ -615,12 +615,15 @@ injected channels.
 #define ADC_JSQR_JL_3CHANNELS       (0x2 << ADC_JSQR_JL_LSB)
 #define ADC_JSQR_JL_4CHANNELS       (0x3 << ADC_JSQR_JL_LSB)
 /**@}*/
-#define ADC_JSQR_JL_SHIFT		13
+#define ADC_JSQR_JL_SHIFT		20
 #define ADC_JSQR_JL_MSK			(0x2 << ADC_JSQR_JL_LSB)
 #define ADC_JSQR_JSQ4_MSK		(0x1f << ADC_JSQR_JSQ4_LSB)
 #define ADC_JSQR_JSQ3_MSK		(0x1f << ADC_JSQR_JSQ3_LSB)
 #define ADC_JSQR_JSQ2_MSK		(0x1f << ADC_JSQR_JSQ2_LSB)
 #define ADC_JSQR_JSQ1_MSK		(0x1f << ADC_JSQR_JSQ1_LSB)
+
+#define ADC_JSQR_JSQ_VAL(n,val)		((val) << (((n) - 1) * 5))
+#define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
 
 /* --- ADC_JDRx, ADC_DR values --------------------------------------------- */
 

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -622,10 +622,14 @@
 /*------- ADC_JSQR values ---------*/
 
 #define ADC_JSQR_JL_LSB			0
+#define ADC_JSQR_JL_SHIFT		0
 #define ADC_JSQR_JSQ4_LSB		26
 #define ADC_JSQR_JSQ3_LSB		20
 #define ADC_JSQR_JSQ2_LSB		14
 #define ADC_JSQR_JSQ1_LSB		8
+
+#define ADC_JSQR_JSQ_VAL(n,val)		((val) << (((n) - 1) * 6 + 8))
+#define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
 
 /* Bits 30:26 JSQ4[4:0]: 4th conversion in the injected sequence */
 

--- a/include/libopencm3/stm32/f4/adc.h
+++ b/include/libopencm3/stm32/f4/adc.h
@@ -580,12 +580,15 @@ injected channels.
 #define ADC_JSQR_JL_3CHANNELS       (0x2 << ADC_JSQR_JL_LSB)
 #define ADC_JSQR_JL_4CHANNELS       (0x3 << ADC_JSQR_JL_LSB)
 /**@}*/
-#define ADC_JSQR_JL_SHIFT		13
+#define ADC_JSQR_JL_SHIFT		20
 #define ADC_JSQR_JL_MSK			(0x2 << ADC_JSQR_JL_LSB)
 #define ADC_JSQR_JSQ4_MSK		(0x1f << ADC_JSQR_JSQ4_LSB)
 #define ADC_JSQR_JSQ3_MSK		(0x1f << ADC_JSQR_JSQ3_LSB)
 #define ADC_JSQR_JSQ2_MSK		(0x1f << ADC_JSQR_JSQ2_LSB)
 #define ADC_JSQR_JSQ1_MSK		(0x1f << ADC_JSQR_JSQ1_LSB)
+
+#define ADC_JSQR_JSQ_VAL(n,val)		((val) << (((n) - 1) * 5))
+#define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
 
 /* --- ADC_JDRx, ADC_DR values --------------------------------------------- */
 

--- a/lib/stm32/f1/adc.c
+++ b/lib/stm32/f1/adc.c
@@ -1091,16 +1091,16 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 	uint32_t reg32 = 0;
 	uint8_t i = 0;
 
-	/* Maximum sequence length is 4 channels. */
-	if (length > 4) {
+	/* Maximum sequence length is 4 channels. Minimum sequence is 1.*/
+	if ((length - 1) > 3) {
 		return;
 	}
 
 	for (i = 1; i <= length; i++) {
-		reg32 |= (channel[4 - i] << ((4 - i) * 5));
+		reg32 |= ADC_JSQR_JSQ_VAL(4 - i, channel[length - i - 1]);
 	}
 
-	reg32 |= ((length - 1) << ADC_JSQR_JL_LSB);
+	reg32 |= ADC_JSQR_JL_VAL(length);
 
 	ADC_JSQR(adc) = reg32;
 }

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -697,16 +697,16 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 	uint32_t reg32 = 0;
 	uint8_t i = 0;
 
-	/* Maximum sequence length is 4 channels. */
-	if ((length-1) > 3) {
+	/* Maximum sequence length is 4 channels. Minimum sequence is 1.*/
+	if ((length - 1) > 3) {
 		return;
 	}
 
 	for (i = 1; i <= length; i++) {
-		reg32 |= (channel[4 - i] << ((4 - i) * 5));
+		reg32 |= ADC_JSQR_JSQ_VAL(4 - i, channel[length - i - 1]);
 	}
 
-	reg32 |= ((length - 1) << ADC_JSQR_JL_LSB);
+	reg32 |= ADC_JSQR_JL_VAL(length);
 
 	ADC_JSQR(adc) = reg32;
 }

--- a/lib/stm32/f4/adc.c
+++ b/lib/stm32/f4/adc.c
@@ -634,16 +634,16 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 	uint32_t reg32 = 0;
 	uint8_t i = 0;
 
-	/* Maximum sequence length is 4 channels. */
-	if ((length-1) > 3) {
+	/* Maximum sequence length is 4 channels. Minimum sequence is 1.*/
+	if ((length - 1) > 3) {
 		return;
 	}
 
-	for (i = 1; i <= length; i++) {
-		reg32 |= (channel[4 - i] << ((4 - i) * 5));
+	for (i = 0; i < length; i++) {
+		reg32 |= ADC_JSQR_JSQ_VAL(4 - i, channel[length - i - 1]);
 	}
 
-	reg32 |= ((length - 1) << ADC_JSQR_JL_LSB);
+	reg32 |= ADC_JSQR_JL_VAL(length);
 
 	ADC_JSQR(adc) = reg32;
 }


### PR DESCRIPTION
According to RM0090, page 301, paragraph 11.13.12 Note.

The JSQR are filled always ending at SQR4 ie for those lists we must set this list:

```
(A)       ->                               JSQ4 = A,
(A,B)     ->                     JSQ3 = A, JSQ4 = B,
(A,B,C)   ->           JSQ2 = A, JSQ3 = B, JSQ4 = C,
(A,B,C,D) -> JSQ1 = A, JSQ2 = B, JSQ3 = C, JSQ4 = D,
```

The readed values are in correct order, starting from JDR1:

```
(A)       -> JDR1 = A,
(A,B)     -> JDR1 = A, JDR2 = B,
(A,B,C)   -> JDR1 = A, JDR2 = B, JDR3 = C,
(A,B,C,D) -> JDR1 = A, JDR2 = B, JDR3 = C, JDR4 = D,
```
