### PR TITLE
Fix handling of control transfers where size is a multiple of bMaxPacket...

### DIFF
--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -73,7 +73,7 @@ int usbd_register_control_callback(usbd_device *usbd_dev, uint8_t type,
 
 static void usb_control_send_chunk(usbd_device *usbd_dev)
 {
-	if (usbd_dev->desc->bMaxPacketSize0 <
+	if (usbd_dev->desc->bMaxPacketSize0 <=
 			usbd_dev->control_state.ctrl_len) {
 		/* Data stage, normal transmission */
 		usbd_ep_write_packet(usbd_dev, 0,


### PR DESCRIPTION
...Size0

End of transfer is indicated by a "short" packet where packet size is less than MaxPacketSize. If the transfer has a length that is a multiple of MaxPacketSize, a zero length packet must be sent to indicate the end of the transfer.

By calling the "normal transmission" section rather than the "end of transmission" section for the last packet of data, the state is not prematurely set to LAST_DATA_IN, so usb_control_send_chunk() gets called again and sends a ZLP