### PR TITLE
Commonization of RCC clock enable / reset for entire STM32 family

### DIFF
--- a/include/libopencm3/stm32/common/rcc_common_all.h
+++ b/include/libopencm3/stm32/common/rcc_common_all.h
@@ -1,0 +1,49 @@
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Frantisek Burian <BuFran@seznam.cz>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA RCC.H
+ * The order of header inclusion is important. rcc.h defines the device
+ * specific enumerations before including this header file.
+ */
+
+/** @cond */
+#ifdef LIBOPENCM3_RCC_H
+/** @endcond */
+
+#ifndef LIBOPENCM3_RCC_COMMON_ALL_H
+#define LIBOPENCM3_RCC_COMMON_ALL_H
+ 
+BEGIN_DECLS
+
+void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en);
+void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en);
+void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset);
+void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset);
+
+void rcc_periph_clock_enable(enum rcc_periph_clken clken);
+void rcc_periph_clock_disable(enum rcc_periph_clken clken);
+void rcc_periph_reset_pulse(enum rcc_periph_rst rst);
+void rcc_periph_reset_hold(enum rcc_periph_rst rst);
+void rcc_periph_reset_release(enum rcc_periph_rst rst);
+
+END_DECLS
+
+#endif
+#endif

--- a/include/libopencm3/stm32/f1/rcc.h
+++ b/include/libopencm3/stm32/f1/rcc.h
@@ -495,30 +495,159 @@ extern uint32_t rcc_ppre2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
+enum rcc_osc {
 	PLL, PLL2, PLL3, HSE, HSI, LSE, LSI
-} osc_t;
+};
+
+#define _REG_BIT(base, bit)		(((base) << 5) + (bit))
+
+/* V = value line F100
+ * N = standard line F101, F102, F103
+ * C = communication line F105, F107
+ */
+enum rcc_periph_clken {
+
+	/* AHB peripherals */
+	RCC_DMA1	= _REG_BIT(0x14, 0),/*VNC*/
+	RCC_DMA2	= _REG_BIT(0x14, 1),/*VNC*/
+	RCC_SRAM	= _REG_BIT(0x14, 2),/*VNC*/
+	RCC_FLTF	= _REG_BIT(0x14, 4),/*VNC*/
+	RCC_CRC		= _REG_BIT(0x14, 6),/*VNC*/
+	RCC_FSMC	= _REG_BIT(0x14, 8),/*VN-*/
+	RCC_SDIO	= _REG_BIT(0x14, 10),/*-N-*/
+	RCC_OTGFS	= _REG_BIT(0x14, 12),/*--C*/
+	RCC_ETHMAC	= _REG_BIT(0x14, 14),/*--C*/
+	RCC_ETHMACTX	= _REG_BIT(0x14, 15),/*--C*/
+	RCC_ETHMACRX	= _REG_BIT(0x14, 16),/*--C*/
+	
+	/* APB2 peripherals */
+	RCC_AFIO	= _REG_BIT(0x18, 0),/*VNC*/
+	RCC_GPIOA	= _REG_BIT(0x18, 2),/*VNC*/
+	RCC_GPIOB	= _REG_BIT(0x18, 3),/*VNC*/
+	RCC_GPIOC	= _REG_BIT(0x18, 4),/*VNC*/
+	RCC_GPIOD	= _REG_BIT(0x18, 5),/*VNC*/
+	RCC_GPIOE	= _REG_BIT(0x18, 6),/*VNC*/
+	RCC_GPIOF	= _REG_BIT(0x18, 7),/*VN-*/
+	RCC_GPIOG	= _REG_BIT(0x18, 8),/*VN-*/
+	RCC_ADC1	= _REG_BIT(0x18, 9),/*VNC*/
+	RCC_ADC2	= _REG_BIT(0x18, 10),/*-NC*/
+	RCC_TIM1	= _REG_BIT(0x18, 11),/*VNC*/
+	RCC_SPI1	= _REG_BIT(0x18, 12),/*VNC*/
+	RCC_TIM8	= _REG_BIT(0x18, 13),/*-N-*/
+	RCC_USART1	= _REG_BIT(0x18, 14),/*VNC*/
+	RCC_ADC3	= _REG_BIT(0x18, 15),/*-N-*/
+	RCC_TIM15	= _REG_BIT(0x18, 16),/*V--*/
+	RCC_TIM16	= _REG_BIT(0x18, 17),/*V--*/
+	RCC_TIM17	= _REG_BIT(0x18, 18),/*V--*/
+	RCC_TIM9	= _REG_BIT(0x18, 19),/*-N-*/
+	RCC_TIM10	= _REG_BIT(0x18, 20),/*-N-*/
+	RCC_TIM11	= _REG_BIT(0x18, 21),/*-N-*/
+	
+	/* APB1 peripherals */
+	RCC_TIM2	= _REG_BIT(0x1C, 0),/*VNC*/
+	RCC_TIM3	= _REG_BIT(0x1C, 1),/*VNC*/
+	RCC_TIM4	= _REG_BIT(0x1C, 2),/*VNC*/
+	RCC_TIM5	= _REG_BIT(0x1C, 3),/*VNC*/
+	RCC_TIM6	= _REG_BIT(0x1C, 4),/*VNC*/
+	RCC_TIM7	= _REG_BIT(0x1C, 5),/*VNC*/
+	RCC_TIM12	= _REG_BIT(0x1C, 6),/*VN-*/
+	RCC_TIM13	= _REG_BIT(0x1C, 7),/*VN-*/
+	RCC_TIM14	= _REG_BIT(0x1C, 8),/*VN-*/
+	RCC_WWDG	= _REG_BIT(0x1C, 11),/*VNC*/
+	RCC_SPI2	= _REG_BIT(0x1C, 14),/*VNC*/
+	RCC_SPI3	= _REG_BIT(0x1C, 15),/*VNC*/
+	RCC_USART2	= _REG_BIT(0x1C, 17),/*VNC*/
+	RCC_USART3	= _REG_BIT(0x1C, 18),/*VNC*/
+	RCC_UART4	= _REG_BIT(0x1C, 19),/*VNC*/
+	RCC_UART5	= _REG_BIT(0x1C, 20),/*VNC*/
+	RCC_I2C1	= _REG_BIT(0x1C, 21),/*VNC*/
+	RCC_I2C2	= _REG_BIT(0x1C, 22),/*VNC*/
+	RCC_USB		= _REG_BIT(0x1C, 23),/*-N-*/
+	RCC_CAN		= _REG_BIT(0x1C, 24),/*-N-*/
+	RCC_CAN1	= _REG_BIT(0x1C, 24),/*--C*/
+	RCC_CAN2	= _REG_BIT(0x1C, 25),/*--C*/
+	RCC_BKP		= _REG_BIT(0x1C, 27),/*VNC*/
+	RCC_PWR		= _REG_BIT(0x1C, 28),/*VNC*/
+	RCC_DAC		= _REG_BIT(0x1C, 29),/*VNC*/
+	RCC_CEC		= _REG_BIT(0x1C, 30),/*V--*/
+};
+
+enum rcc_periph_rst {
+
+	/* AHB peripherals */
+	RST_OTGFS	= _REG_BIT(0x28, 12),/*--C*/
+	RST_ETHMAC	= _REG_BIT(0x28, 14),/*--C*/
+
+	/* APB2 peripherals */
+	RST_AFIO	= _REG_BIT(0x0c, 0),/*VNC*/
+	RST_GPIOA	= _REG_BIT(0x0c, 2),/*VNC*/
+	RST_GPIOB	= _REG_BIT(0x0c, 3),/*VNC*/
+	RST_GPIOC	= _REG_BIT(0x0c, 4),/*VNC*/
+	RST_GPIOD	= _REG_BIT(0x0c, 5),/*VNC*/
+	RST_GPIOE	= _REG_BIT(0x0c, 6),/*VNC*/
+	RST_GPIOF	= _REG_BIT(0x0c, 7),/*VN-*/
+	RST_GPIOG	= _REG_BIT(0x0c, 8),/*VN-*/
+	RST_ADC1	= _REG_BIT(0x0c, 9),/*VNC*/
+	RST_ADC2	= _REG_BIT(0x0c, 10),/*-NC*/
+	RST_TIM1	= _REG_BIT(0x0c, 11),/*VNC*/
+	RST_SPI1	= _REG_BIT(0x0c, 12),/*VNC*/
+	RST_TIM8	= _REG_BIT(0x0c, 13),/*-N-*/
+	RST_USART1	= _REG_BIT(0x0c, 14),/*VNC*/
+	RST_ADC3	= _REG_BIT(0x0c, 15),/*-N-*/
+	RST_TIM15	= _REG_BIT(0x0c, 16),/*V--*/
+	RST_TIM16	= _REG_BIT(0x0c, 17),/*V--*/
+	RST_TIM17	= _REG_BIT(0x0c, 18),/*V--*/
+	RST_TIM9	= _REG_BIT(0x0c, 19),/*-N-*/
+	RST_TIM10	= _REG_BIT(0x0c, 20),/*-N-*/
+	RST_TIM11	= _REG_BIT(0x0c, 21),/*-N-*/
+	
+	/* APB1 peripherals */
+	RST_TIM2	= _REG_BIT(0x10, 0),/*VNC*/
+	RST_TIM3	= _REG_BIT(0x10, 1),/*VNC*/
+	RST_TIM4	= _REG_BIT(0x10, 2),/*VNC*/
+	RST_TIM5	= _REG_BIT(0x10, 3),/*VNC*/
+	RST_TIM6	= _REG_BIT(0x10, 4),/*VNC*/
+	RST_TIM7	= _REG_BIT(0x10, 5),/*VNC*/
+	RST_TIM12	= _REG_BIT(0x10, 6),/*VN-*/
+	RST_TIM13	= _REG_BIT(0x10, 7),/*VN-*/
+	RST_TIM14	= _REG_BIT(0x10, 8),/*VN-*/
+	RST_WWDG	= _REG_BIT(0x10, 11),/*VNC*/
+	RST_SPI2	= _REG_BIT(0x10, 14),/*VNC*/
+	RST_SPI3	= _REG_BIT(0x10, 15),/*VNC*/
+	RST_USART2	= _REG_BIT(0x10, 17),/*VNC*/
+	RST_USART3	= _REG_BIT(0x10, 18),/*VNC*/
+	RST_UART4	= _REG_BIT(0x10, 19),/*VNC*/
+	RST_UART5	= _REG_BIT(0x10, 20),/*VNC*/
+	RST_I2C1	= _REG_BIT(0x10, 21),/*VNC*/
+	RST_I2C2	= _REG_BIT(0x10, 22),/*VNC*/
+	RST_USB		= _REG_BIT(0x10, 23),/*-N-*/
+	RST_CAN		= _REG_BIT(0x10, 24),/*-N-*/
+	RST_CAN1	= _REG_BIT(0x10, 24),/*--C*/
+	RST_CAN2	= _REG_BIT(0x10, 25),/*--C*/
+	RST_BKP		= _REG_BIT(0x10, 27),/*VNC*/
+	RST_PWR		= _REG_BIT(0x10, 28),/*VNC*/
+	RST_DAC		= _REG_BIT(0x10, 29),/*VNC*/
+	RST_CEC		= _REG_BIT(0x10, 30),/*V--*/
+};
+
+#include <libopencm3/stm32/common/rcc_common_all.h>
 
 BEGIN_DECLS
 
-void rcc_osc_ready_int_clear(osc_t osc);
-void rcc_osc_ready_int_enable(osc_t osc);
-void rcc_osc_ready_int_disable(osc_t osc);
-int rcc_osc_ready_int_flag(osc_t osc);
+void rcc_osc_ready_int_clear(enum rcc_osc osc);
+void rcc_osc_ready_int_enable(enum rcc_osc osc);
+void rcc_osc_ready_int_disable(enum rcc_osc osc);
+int rcc_osc_ready_int_flag(enum rcc_osc osc);
 void rcc_css_int_clear(void);
 int rcc_css_int_flag(void);
-void rcc_wait_for_osc_ready(osc_t osc);
-void rcc_osc_on(osc_t osc);
-void rcc_osc_off(osc_t osc);
+void rcc_wait_for_osc_ready(enum rcc_osc osc);
+void rcc_osc_on(enum rcc_osc osc);
+void rcc_osc_off(enum rcc_osc osc);
 void rcc_css_enable(void);
 void rcc_css_disable(void);
 void rcc_set_mco(uint32_t mcosrc);
-void rcc_osc_bypass_enable(osc_t osc);
-void rcc_osc_bypass_disable(osc_t osc);
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset);
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset);
+void rcc_osc_bypass_enable(enum rcc_osc osc);
+void rcc_osc_bypass_disable(enum rcc_osc osc);
 void rcc_set_sysclk_source(uint32_t clk);
 void rcc_set_pll_multiplication_factor(uint32_t mul);
 void rcc_set_pll2_multiplication_factor(uint32_t mul);

--- a/include/libopencm3/stm32/f1/rtc.h
+++ b/include/libopencm3/stm32/f1/rtc.h
@@ -147,7 +147,7 @@ typedef enum {
 
 BEGIN_DECLS
 
-void rtc_awake_from_off(osc_t clock_source);
+void rtc_awake_from_off(enum rcc_osc clock_source);
 void rtc_enter_config_mode(void);
 void rtc_exit_config_mode(void);
 void rtc_set_alarm_time(uint32_t alarm_time);
@@ -163,7 +163,7 @@ void rtc_interrupt_disable(rtcflag_t flag_val);
 void rtc_clear_flag(rtcflag_t flag_val);
 uint32_t rtc_check_flag(rtcflag_t flag_val);
 void rtc_awake_from_standby(void);
-void rtc_auto_awake(osc_t clock_source, uint32_t prescale_val);
+void rtc_auto_awake(enum rcc_osc clock_source, uint32_t prescale_val);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f2/rcc.h
+++ b/include/libopencm3/stm32/f2/rcc.h
@@ -479,6 +479,228 @@ typedef enum {
 	PLL, HSE, HSI, LSE, LSI
 } osc_t;
 
+#define _REG_BIT(base, bit)		(((base) << 5) + (bit))
+
+enum rcc_periph_clken {
+	/* AHB1 peripherals  */
+	RCC_GPIOA	= _REG_BIT(0x30, 0),
+	RCC_GPIOB	= _REG_BIT(0x30, 1),
+	RCC_GPIOC	= _REG_BIT(0x30, 2),
+	RCC_GPIOD	= _REG_BIT(0x30, 3),
+	RCC_GPIOE	= _REG_BIT(0x30, 4),
+	RCC_GPIOF	= _REG_BIT(0x30, 5),
+	RCC_GPIOG	= _REG_BIT(0x30, 6),
+	RCC_GPIOH	= _REG_BIT(0x30, 7),
+	RCC_GPIOI	= _REG_BIT(0x30, 8),
+	RCC_CRC		= _REG_BIT(0x30, 12),
+	RCC_BKPSRAM	= _REG_BIT(0x30, 18),
+	RCC_DMA1	= _REG_BIT(0x30, 21),
+	RCC_DMA2	= _REG_BIT(0x30, 22),
+	RCC_ETHMAC	= _REG_BIT(0x30, 25),
+	RCC_ETHMACTX	= _REG_BIT(0x30, 26),
+	RCC_ETHMACRX	= _REG_BIT(0x30, 27),
+	RCC_ETHMACPTP	= _REG_BIT(0x30, 28),
+	RCC_OTGHS	= _REG_BIT(0x30, 29),
+	RCC_OTGHSULPI	= _REG_BIT(0x30, 30),
+
+	/* AHB2 peripherals */
+	RCC_DCMI	= _REG_BIT(0x34, 0),
+	RCC_CRYP	= _REG_BIT(0x34, 4),
+	RCC_HASH	= _REG_BIT(0x34, 5),
+	RCC_RNG		= _REG_BIT(0x34, 6),
+	RCC_OTGFS	= _REG_BIT(0x34, 7),
+
+	/* AHB3 peripherals */
+	RCC_FSMC	= _REG_BIT(0x38, 0),
+
+	/* APB1 peripherals */
+	RCC_TIM2	= _REG_BIT(0x40, 0),
+	RCC_TIM3	= _REG_BIT(0x40, 1),
+	RCC_TIM4	= _REG_BIT(0x40, 2),
+	RCC_TIM5	= _REG_BIT(0x40, 3),
+	RCC_TIM6	= _REG_BIT(0x40, 4),
+	RCC_TIM7	= _REG_BIT(0x40, 5),
+	RCC_TIM12	= _REG_BIT(0x40, 6),
+	RCC_TIM13	= _REG_BIT(0x40, 7),
+	RCC_TIM14	= _REG_BIT(0x40, 8),
+	RCC_WWDG	= _REG_BIT(0x40, 11),
+	RCC_SPI2	= _REG_BIT(0x40, 14),
+	RCC_SPI3	= _REG_BIT(0x40, 15),
+	RCC_USART2	= _REG_BIT(0x40, 17),
+	RCC_USART3	= _REG_BIT(0x40, 18),
+	RCC_UART4	= _REG_BIT(0x40, 19),
+	RCC_UART5	= _REG_BIT(0x40, 20),
+	RCC_I2C1	= _REG_BIT(0x40, 21),
+	RCC_I2C2	= _REG_BIT(0x40, 22),
+	RCC_I2C3	= _REG_BIT(0x40, 23),
+	RCC_CAN1	= _REG_BIT(0x40, 25),
+	RCC_CAN2	= _REG_BIT(0x40, 26),
+	RCC_PWR		= _REG_BIT(0x40, 28),
+	RCC_DAC		= _REG_BIT(0x40, 29),
+
+	/* APB2 peripherals */
+	RCC_TIM1	= _REG_BIT(0x44, 0),
+	RCC_TIM8	= _REG_BIT(0x44, 1),
+	RCC_USART1	= _REG_BIT(0x44, 4),
+	RCC_USART6	= _REG_BIT(0x44, 5),
+	RCC_ADC1	= _REG_BIT(0x44, 8),
+	RCC_ADC2	= _REG_BIT(0x44, 9),
+	RCC_ADC3	= _REG_BIT(0x44, 10),
+	RCC_SDIO	= _REG_BIT(0x44, 11),
+	RCC_SPI1	= _REG_BIT(0x44, 12),
+	RCC_SYSCFG	= _REG_BIT(0x44, 14),
+	RCC_TIM9	= _REG_BIT(0x44, 16),
+	RCC_TIM10	= _REG_BIT(0x44, 17),
+	RCC_TIM11	= _REG_BIT(0x44, 18),
+
+	/* Extended peripherals */
+	RCC_RTC		= _REG_BIT(0x70, 15),/* BDCR[15] */
+
+	/* AHB1 peripherals  */
+	SCC_GPIOA	= _REG_BIT(0x50, 0),
+	SCC_GPIOB	= _REG_BIT(0x50, 1),
+	SCC_GPIOC	= _REG_BIT(0x50, 2),
+	SCC_GPIOD	= _REG_BIT(0x50, 3),
+	SCC_GPIOE	= _REG_BIT(0x50, 4),
+	SCC_GPIOF	= _REG_BIT(0x50, 5),
+	SCC_GPIOG	= _REG_BIT(0x50, 6),
+	SCC_GPIOH	= _REG_BIT(0x50, 7),
+	SCC_GPIOI	= _REG_BIT(0x50, 8),
+	SCC_CRC		= _REG_BIT(0x50, 12),
+	SCC_FLTIF	= _REG_BIT(0x50, 15),
+	SCC_SRAM1	= _REG_BIT(0x50, 16),
+	SCC_SRAM2	= _REG_BIT(0x50, 17),
+	SCC_BKPSRAM	= _REG_BIT(0x50, 18),
+	SCC_DMA1	= _REG_BIT(0x50, 21),
+	SCC_DMA2	= _REG_BIT(0x50, 22),
+	SCC_ETHMAC	= _REG_BIT(0x50, 25),
+	SCC_ETHMACTX	= _REG_BIT(0x50, 26),
+	SCC_ETHMACRX	= _REG_BIT(0x50, 27),
+	SCC_ETHMACPTP	= _REG_BIT(0x50, 28),
+	SCC_OTGHS	= _REG_BIT(0x50, 29),
+	SCC_OTGHSULPI	= _REG_BIT(0x50, 30),
+
+	/* AHB2 peripherals */
+	SCC_DCMI	= _REG_BIT(0x54, 0),
+	SCC_CRYP	= _REG_BIT(0x54, 4),
+	SCC_HASH	= _REG_BIT(0x54, 5),
+	SCC_RNG		= _REG_BIT(0x54, 6),
+	SCC_OTGFS	= _REG_BIT(0x54, 7),
+
+	/* AHB3 peripherals */
+	SCC_FSMC	= _REG_BIT(0x58, 0),
+
+	/* APB1 peripherals */
+	SCC_TIM2	= _REG_BIT(0x60, 0),
+	SCC_TIM3	= _REG_BIT(0x60, 1),
+	SCC_TIM4	= _REG_BIT(0x60, 2),
+	SCC_TIM5	= _REG_BIT(0x60, 3),
+	SCC_TIM6	= _REG_BIT(0x60, 4),
+	SCC_TIM7	= _REG_BIT(0x60, 5),
+	SCC_TIM12	= _REG_BIT(0x60, 6),
+	SCC_TIM13	= _REG_BIT(0x60, 7),
+	SCC_TIM14	= _REG_BIT(0x60, 8),
+	SCC_WWDG	= _REG_BIT(0x60, 11),
+	SCC_SPI2	= _REG_BIT(0x60, 14),
+	SCC_SPI3	= _REG_BIT(0x60, 15),
+	SCC_USART2	= _REG_BIT(0x60, 17),
+	SCC_USART3	= _REG_BIT(0x60, 18),
+	SCC_UART4	= _REG_BIT(0x60, 19),
+	SCC_UART5	= _REG_BIT(0x60, 20),
+	SCC_I2C1	= _REG_BIT(0x60, 21),
+	SCC_I2C2	= _REG_BIT(0x60, 22),
+	SCC_I2C3	= _REG_BIT(0x60, 23),
+	SCC_CAN1	= _REG_BIT(0x60, 25),
+	SCC_CAN2	= _REG_BIT(0x60, 26),
+	SCC_PWR		= _REG_BIT(0x60, 28),
+	SCC_DAC		= _REG_BIT(0x60, 29),
+
+	/* APB2 peripherals */
+	SCC_TIM1	= _REG_BIT(0x64, 0),
+	SCC_TIM8	= _REG_BIT(0x64, 1),
+	SCC_USART1	= _REG_BIT(0x64, 4),
+	SCC_USART6	= _REG_BIT(0x64, 5),
+	SCC_ADC1	= _REG_BIT(0x64, 8),
+	SCC_ADC2	= _REG_BIT(0x64, 9),
+	SCC_ADC3	= _REG_BIT(0x64, 10),
+	SCC_SDIO	= _REG_BIT(0x64, 11),
+	SCC_SPI1	= _REG_BIT(0x64, 12),
+	SCC_SYSCFG	= _REG_BIT(0x64, 14),
+	SCC_TIM9	= _REG_BIT(0x64, 16),
+	SCC_TIM10	= _REG_BIT(0x64, 17),
+	SCC_TIM11	= _REG_BIT(0x64, 18),
+};
+
+enum rcc_periph_rst {
+	/* AHB1 peripherals  */
+	RST_GPIOA	= _REG_BIT(0x10, 0),
+	RST_GPIOB	= _REG_BIT(0x10, 1),
+	RST_GPIOC	= _REG_BIT(0x10, 2),
+	RST_GPIOD	= _REG_BIT(0x10, 3),
+	RST_GPIOE	= _REG_BIT(0x10, 4),
+	RST_GPIOF	= _REG_BIT(0x10, 5),
+	RST_GPIOG	= _REG_BIT(0x10, 6),
+	RST_GPIOH	= _REG_BIT(0x10, 7),
+	RST_GPIOI	= _REG_BIT(0x10, 8),
+	RST_CRC		= _REG_BIT(0x10, 12),
+	RST_DMA1	= _REG_BIT(0x10, 21),
+	RST_DMA2	= _REG_BIT(0x10, 22),
+	RST_ETHMAC	= _REG_BIT(0x10, 25),
+	RST_OTGHS	= _REG_BIT(0x10, 29),
+
+	/* AHB2 peripherals */
+	RST_DCMI	= _REG_BIT(0x14, 0),
+	RST_CRYP	= _REG_BIT(0x14, 4),
+	RST_HASH	= _REG_BIT(0x14, 5),
+	RST_RNG		= _REG_BIT(0x14, 6),
+	RST_OTGFS	= _REG_BIT(0x14, 7),
+
+	/* AHB3 peripherals */
+	RST_FSMC	= _REG_BIT(0x18, 0),
+
+	/* APB1 peripherals */
+	RST_TIM2	= _REG_BIT(0x20, 0),
+	RST_TIM3	= _REG_BIT(0x20, 1),
+	RST_TIM4	= _REG_BIT(0x20, 2),
+	RST_TIM5	= _REG_BIT(0x20, 3),
+	RST_TIM6	= _REG_BIT(0x20, 4),
+	RST_TIM7	= _REG_BIT(0x20, 5),
+	RST_TIM12	= _REG_BIT(0x20, 6),
+	RST_TIM13	= _REG_BIT(0x20, 7),
+	RST_TIM14	= _REG_BIT(0x20, 8),
+	RST_WWDG	= _REG_BIT(0x20, 11),
+	RST_SPI2	= _REG_BIT(0x20, 14),
+	RST_SPI3	= _REG_BIT(0x20, 15),
+	RST_USART2	= _REG_BIT(0x20, 17),
+	RST_USART3	= _REG_BIT(0x20, 18),
+	RST_UART4	= _REG_BIT(0x20, 19),
+	RST_UART5	= _REG_BIT(0x20, 20),
+	RST_I2C1	= _REG_BIT(0x20, 21),
+	RST_I2C2	= _REG_BIT(0x20, 22),
+	RST_I2C3	= _REG_BIT(0x20, 23),
+	RST_CAN1	= _REG_BIT(0x20, 25),
+	RST_CAN2	= _REG_BIT(0x20, 26),
+	RST_PWR		= _REG_BIT(0x20, 28),
+	RST_DAC		= _REG_BIT(0x20, 29),
+
+	/* APB2 peripherals */
+	RST_TIM1	= _REG_BIT(0x24, 0),
+	RST_TIM8	= _REG_BIT(0x24, 1),
+	RST_USART1	= _REG_BIT(0x24, 4),
+	RST_USART6	= _REG_BIT(0x24, 5),
+	RST_ADC		= _REG_BIT(0x24, 8),
+	RST_SDIO	= _REG_BIT(0x24, 11),
+	RST_SPI1	= _REG_BIT(0x24, 12),
+	RST_SYSCFG	= _REG_BIT(0x24, 14),
+	RST_TIM9	= _REG_BIT(0x24, 16),
+	RST_TIM10	= _REG_BIT(0x24, 17),
+	RST_TIM11	= _REG_BIT(0x24, 18),
+};
+
+#undef _REG_BIT
+
+#include <libopencm3/stm32/common/rcc_common_all.h>
+
 BEGIN_DECLS
 
 void rcc_osc_ready_int_clear(osc_t osc);
@@ -495,10 +717,6 @@ void rcc_css_enable(void);
 void rcc_css_disable(void);
 void rcc_osc_bypass_enable(osc_t osc);
 void rcc_osc_bypass_disable(osc_t osc);
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset);
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset);
 void rcc_set_sysclk_source(uint32_t clk);
 void rcc_set_pll_source(uint32_t pllsrc);
 void rcc_set_ppre2(uint32_t ppre2);

--- a/include/libopencm3/stm32/f3/rcc.h
+++ b/include/libopencm3/stm32/f3/rcc.h
@@ -415,6 +415,139 @@ enum osc {
 	PLL, HSE, HSI, LSE, LSI
 };
 
+#define _REG_BIT(base, bit)		(((base) << 5) + (bit))
+
+/* Availability in comment:
+ * 0: F30x
+ * 1: F31x
+ * 7: F37x
+ * 8: F38x
+ */
+enum rcc_periph_clken {
+	/* AHB peripherals*/
+	RCC_DMA1	= _REG_BIT(0x14, 0),/*0178*/
+	RCC_DMA2	= _REG_BIT(0x14, 1),/*0178*/
+	RCC_SRAM	= _REG_BIT(0x14, 2),/*0178*/
+	RCC_FLTIF	= _REG_BIT(0x14, 4),/*0178*/
+	RCC_CRC		= _REG_BIT(0x14, 6),/*0178*/
+	RCC_GPIOA	= _REG_BIT(0x14, 17),/*0178*/
+	RCC_GPIOB	= _REG_BIT(0x14, 18),/*0178*/
+	RCC_GPIOC	= _REG_BIT(0x14, 19),/*0178*/
+	RCC_GPIOD	= _REG_BIT(0x14, 20),/*0178*/
+	RCC_GPIOE	= _REG_BIT(0x14, 21),/*0178*/
+	RCC_GPIOF	= _REG_BIT(0x14, 22),/*0178*/
+	RCC_TSC		= _REG_BIT(0x14, 24),/*0178*/
+	RCC_ADC12	= _REG_BIT(0x14, 28),/*01--*/
+	RCC_ADC34	= _REG_BIT(0x14, 29),/*01--*/
+
+	/* APB2 peripherals */
+	RCC_SYSCFG	= _REG_BIT(0x18, 0),/*0178*/
+	RCC_ADC		= _REG_BIT(0x18, 9),/*--78*/
+	RCC_TIM1	= _REG_BIT(0x18, 11),/*01--*/
+	RCC_SPI1	= _REG_BIT(0x18, 12),/*0178*/
+	RCC_TIM8	= _REG_BIT(0x18, 13),/*01--*/
+	RCC_USART1	= _REG_BIT(0x18, 14),/*0178*/
+	RCC_TIM15	= _REG_BIT(0x18, 16),/*0178*/
+	RCC_TIM16	= _REG_BIT(0x18, 17),/*0178*/
+	RCC_TIM17	= _REG_BIT(0x18, 18),/*0178*/
+	RCC_TIM19	= _REG_BIT(0x18, 19),/*--78*/
+	RCC_DBGMCU	= _REG_BIT(0x18, 22),/*--78*/
+	RCC_SDADC1	= _REG_BIT(0x18, 24),/*--78*/
+	RCC_SDADC2	= _REG_BIT(0x18, 25),/*--78*/
+	RCC_SDADC3	= _REG_BIT(0x18, 26),/*--78*/
+
+	/* APB1 peripherals */
+	RCC_TIM2	= _REG_BIT(0x1C, 0),/*0178*/
+	RCC_TIM3	= _REG_BIT(0x1C, 1),/*0178*/
+	RCC_TIM4	= _REG_BIT(0x1C, 2),/*0178*/
+	RCC_TIM5	= _REG_BIT(0x1C, 3),/*--78*/
+	RCC_TIM6	= _REG_BIT(0x1C, 4),/*0178*/
+	RCC_TIM7	= _REG_BIT(0x1C, 5),/*0178*/
+	RCC_TIM12	= _REG_BIT(0x1C, 6),/*--78*/
+	RCC_TIM13	= _REG_BIT(0x1C, 7),/*--78*/
+	RCC_TIM14	= _REG_BIT(0x1C, 8),/*--78*/
+	RCC_TIM18	= _REG_BIT(0x1C, 9),/*--78*/
+	RCC_WWDG	= _REG_BIT(0x1C, 11),/*0178*/
+	RCC_SPI2	= _REG_BIT(0x1C, 14),/*0178*/
+	RCC_SPI3	= _REG_BIT(0x1C, 15),/*0178*/
+	RCC_USART2	= _REG_BIT(0x1C, 17),/*0178*/
+	RCC_USART3	= _REG_BIT(0x1C, 18),/*0178*/
+	RCC_UART4	= _REG_BIT(0x1C, 19),/*01--*/
+	RCC_UART5	= _REG_BIT(0x1C, 20),/*01--*/
+	RCC_I2C1	= _REG_BIT(0x1C, 21),/*0178*/
+	RCC_I2C2	= _REG_BIT(0x1C, 22),/*0178*/
+	RCC_USB		= _REG_BIT(0x1C, 23),/*0178*/
+	RCC_CAN		= _REG_BIT(0x1C, 25),/*0178*/
+	RCC_DAC2	= _REG_BIT(0x1C, 26),/*--78*/
+	RCC_PWR		= _REG_BIT(0x1C, 28),/*0178*/
+	RCC_DAC		= _REG_BIT(0x1C, 29),/*12--*/
+	RCC_DAC1	= _REG_BIT(0x1C, 29),/*--78*/
+	RCC_CEC		= _REG_BIT(0x1C, 29),/*--78*/
+};
+
+enum rcc_periph_rst {
+	/* APB2 peripherals*/
+	RST_SYSCFG	= _REG_BIT(0x0C, 0),/*0178*/
+	RST_ADC		= _REG_BIT(0x0C, 9),/*--78*/
+	RST_TIM1	= _REG_BIT(0x0C, 11),/*01--*/
+	RST_SPI1	= _REG_BIT(0x0C, 12),/*0178*/
+	RST_TIM8	= _REG_BIT(0x0C, 13),/*01--*/
+	RST_USART1	= _REG_BIT(0x0C, 14),/*0178*/
+	RST_TIM15	= _REG_BIT(0x0C, 16),/*0178*/
+	RST_TIM16	= _REG_BIT(0x0C, 17),/*0178*/
+	RST_TIM17	= _REG_BIT(0x0C, 18),/*0178*/
+	RST_TIM19	= _REG_BIT(0x0C, 19),/*--78*/
+	RST_SDADC1	= _REG_BIT(0x0C, 24),/*--78*/
+	RST_SDADC2	= _REG_BIT(0x0C, 25),/*--78*/
+	RST_SDADC3	= _REG_BIT(0x0C, 26),/*--78*/
+
+	/* APB1 peripherals */
+	RST_TIM2	= _REG_BIT(0x10, 0),/*0178*/
+	RST_TIM3	= _REG_BIT(0x10, 1),/*0178*/
+	RST_TIM4	= _REG_BIT(0x10, 2),/*0178*/
+	RST_TIM5	= _REG_BIT(0x10, 3),/*--78*/
+	RST_TIM6	= _REG_BIT(0x10, 4),/*0178*/
+	RST_TIM7	= _REG_BIT(0x10, 5),/*0178*/
+	RST_TIM12	= _REG_BIT(0x10, 6),/*--78*/
+	RST_TIM13	= _REG_BIT(0x10, 7),/*--78*/
+	RST_TIM14	= _REG_BIT(0x10, 8),/*--78*/
+	RST_TIM18	= _REG_BIT(0x10, 9),/*--78*/
+	RST_WWDG	= _REG_BIT(0x10, 11),/*0178*/
+	RST_SPI2	= _REG_BIT(0x10, 14),/*0178*/
+	RST_SPI3	= _REG_BIT(0x10, 15),/*0178*/
+	RST_USART2	= _REG_BIT(0x10, 17),/*0178*/
+	RST_USART3	= _REG_BIT(0x10, 18),/*0178*/
+	RST_UART4	= _REG_BIT(0x10, 19),/*01--*/
+	RST_UART5	= _REG_BIT(0x10, 20),/*01--*/
+	RST_I2C1	= _REG_BIT(0x10, 21),/*0178*/
+	RST_I2C2	= _REG_BIT(0x10, 22),/*0178*/
+	RST_USB		= _REG_BIT(0x10, 23),/*0178*/
+	RST_CAN		= _REG_BIT(0x10, 25),/*0178*/
+	RST_DAC2	= _REG_BIT(0x10, 26),/*--78*/
+	RST_PWR		= _REG_BIT(0x10, 28),/*0178*/
+	RST_DAC		= _REG_BIT(0x10, 29),/*01--*/
+	RST_DAC1	= _REG_BIT(0x10, 29),/*--78*/
+	RST_CEC		= _REG_BIT(0x10, 30),/*--78*/
+
+	/* AHB peripherals */
+	RST_GPIOA	= _REG_BIT(0x28, 17),/*0178*/
+	RST_GPIOB	= _REG_BIT(0x28, 18),/*0178*/
+	RST_GPIOC	= _REG_BIT(0x28, 19),/*0178*/
+	RST_GPIOD	= _REG_BIT(0x28, 20),/*0178*/
+	RST_GPIOE	= _REG_BIT(0x28, 21),/*0178*/
+	RST_GPIOF	= _REG_BIT(0x28, 22),/*0178*/
+	RST_TSC		= _REG_BIT(0x28, 24),/*0178*/
+	RST_ADC12	= _REG_BIT(0x28, 28),/*01--*/
+	RST_ADC34	= _REG_BIT(0x28, 29),/*01--*/
+
+	/* BDCR[16] */
+	RST_BD		= _REG_BIT(0x20, 16),
+};
+
+#undef _REG_BIT
+
+#include <libopencm3/stm32/common/rcc_common_all.h>
+
 BEGIN_DECLS
 
 void rcc_osc_ready_int_clear(enum osc osc);
@@ -432,10 +565,6 @@ void rcc_css_enable(void);
 void rcc_css_disable(void);
 void rcc_osc_bypass_enable(enum osc osc);
 void rcc_osc_bypass_disable(enum osc osc);
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset);
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset);
 void rcc_set_sysclk_source(uint32_t clk);
 void rcc_set_pll_source(uint32_t pllsrc);
 void rcc_set_ppre2(uint32_t ppre2);

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -481,30 +481,265 @@ extern const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END];
 extern const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END];
 extern const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END];
 
-typedef enum {
+enum rcc_osc {
 	PLL, HSE, HSI, LSE, LSI
-} osc_t;
+};
+
+#define _REG_BIT(base, bit)		(((base) << 5) + (bit))
+
+enum rcc_periph_clken {
+	/* AHB1 peripherals*/
+	RCC_GPIOA	= _REG_BIT(0x30, 0),
+	RCC_GPIOB	= _REG_BIT(0x30, 1),
+	RCC_GPIOC	= _REG_BIT(0x30, 2),
+	RCC_GPIOD	= _REG_BIT(0x30, 3),
+	RCC_GPIOE	= _REG_BIT(0x30, 4),
+	RCC_GPIOF	= _REG_BIT(0x30, 5),
+	RCC_GPIOG	= _REG_BIT(0x30, 6),
+	RCC_GPIOH	= _REG_BIT(0x30, 7),
+	RCC_GPIOI	= _REG_BIT(0x30, 8),
+	RCC_CRC		= _REG_BIT(0x30, 12),
+	RCC_BKPSRAM	= _REG_BIT(0x30, 18),
+	RCC_CCMDATARAM	= _REG_BIT(0x30, 20),
+	RCC_DMA1	= _REG_BIT(0x30, 21),
+	RCC_DMA2	= _REG_BIT(0x30, 22),
+	RCC_ETHMAC	= _REG_BIT(0x30, 25),
+	RCC_ETHMACTX	= _REG_BIT(0x30, 26),
+	RCC_ETHMACRX	= _REG_BIT(0x30, 27),
+	RCC_ETHMACPTP	= _REG_BIT(0x30, 28),
+	RCC_OTGHS	= _REG_BIT(0x30, 29),
+	RCC_OTGHSULPI	= _REG_BIT(0x30, 30),
+
+	/* AHB2 peripherals */
+	RCC_DCMI	= _REG_BIT(0x34, 0),
+	RCC_CRYP	= _REG_BIT(0x34, 4),
+	RCC_HASH	= _REG_BIT(0x34, 5),
+	RCC_RNG		= _REG_BIT(0x34, 6),
+	RCC_OTGFS	= _REG_BIT(0x34, 7),
+
+	/* AHB3 peripherals */
+	RCC_FSMC	= _REG_BIT(0x38, 0),
+
+	/* APB1 peripherals*/
+	RCC_TIM2	= _REG_BIT(0x40, 0),
+	RCC_TIM3	= _REG_BIT(0x40, 1),
+	RCC_TIM4	= _REG_BIT(0x40, 2),
+	RCC_TIM5	= _REG_BIT(0x40, 3),
+	RCC_TIM6	= _REG_BIT(0x40, 4),
+	RCC_TIM7	= _REG_BIT(0x40, 5),
+	RCC_TIM12	= _REG_BIT(0x40, 6),
+	RCC_TIM13	= _REG_BIT(0x40, 7),
+	RCC_TIM14	= _REG_BIT(0x40, 8),
+	RCC_WWDG 	= _REG_BIT(0x40, 11),
+	RCC_SPI2	= _REG_BIT(0x40, 14),
+	RCC_SPI3	= _REG_BIT(0x40, 15),
+	RCC_USART2	= _REG_BIT(0x40, 17),
+	RCC_USART3	= _REG_BIT(0x40, 18),
+	RCC_UART4	= _REG_BIT(0x40, 19),
+	RCC_UART5	= _REG_BIT(0x40, 20),
+	RCC_I2C1	= _REG_BIT(0x40, 21),
+	RCC_I2C2	= _REG_BIT(0x40, 22),
+	RCC_I2C3	= _REG_BIT(0x40, 23),
+	RCC_CAN1	= _REG_BIT(0x40, 25),
+	RCC_CAN2	= _REG_BIT(0x40, 26),
+	RCC_PWR		= _REG_BIT(0x40, 28),
+	RCC_DAC		= _REG_BIT(0x40, 29),
+	RCC_UART7	= _REG_BIT(0x40, 30),/* F2xx, F3xx */
+	RCC_UART8	= _REG_BIT(0x40, 31),/* F2xx, F3xx */
+
+	/* APB2 peripherals */
+	RCC_TIM1	= _REG_BIT(0x44, 0),
+	RCC_TIM8	= _REG_BIT(0x44, 1),
+	RCC_USART1	= _REG_BIT(0x44, 4),
+	RCC_USART6	= _REG_BIT(0x44, 5),
+	RCC_ADC1	= _REG_BIT(0x44, 8),
+	RCC_ADC2	= _REG_BIT(0x44, 9),
+	RCC_ADC3	= _REG_BIT(0x44, 10),
+	RCC_SDIO	= _REG_BIT(0x44, 11),
+	RCC_SPI1	= _REG_BIT(0x44, 12),
+	RCC_SPI4	= _REG_BIT(0x44, 13),/* F2xx, F3xx */
+	RCC_SYSCFG	= _REG_BIT(0x44, 14),
+	RCC_TIM9	= _REG_BIT(0x44, 16),
+	RCC_TIM10	= _REG_BIT(0x44, 17),
+	RCC_TIM11	= _REG_BIT(0x44, 18),
+	RCC_SPI5	= _REG_BIT(0x44, 20),/* F2xx, F3xx */
+	RCC_SPI6	= _REG_BIT(0x44, 21),/* F2xx, F3xx */
+
+	/* BDCR */
+	RCC_RTC		= _REG_BIT(0x70, 15),
+
+	/* AHB1 peripherals*/
+	SCC_GPIOA	= _REG_BIT(0x50, 0),
+	SCC_GPIOB	= _REG_BIT(0x50, 1),
+	SCC_GPIOC	= _REG_BIT(0x50, 2),
+	SCC_GPIOD	= _REG_BIT(0x50, 3),
+	SCC_GPIOE	= _REG_BIT(0x50, 4),
+	SCC_GPIOF	= _REG_BIT(0x50, 5),
+	SCC_GPIOG	= _REG_BIT(0x50, 6),
+	SCC_GPIOH	= _REG_BIT(0x50, 7),
+	SCC_GPIOI	= _REG_BIT(0x50, 8),
+	SCC_CRC		= _REG_BIT(0x50, 12),
+	SCC_FLTIF	= _REG_BIT(0x50, 15),
+	SCC_SRAM1	= _REG_BIT(0x50, 16),
+	SCC_SRAM2	= _REG_BIT(0x50, 17),
+	SCC_BKPSRAM	= _REG_BIT(0x50, 18),
+	SCC_SRAM3	= _REG_BIT(0x50, 19),/* F2xx, F3xx */
+	SCC_DMA1	= _REG_BIT(0x50, 21),
+	SCC_DMA2	= _REG_BIT(0x50, 22),
+	SCC_ETHMAC	= _REG_BIT(0x50, 25),
+	SCC_ETHMACTX	= _REG_BIT(0x50, 26),
+	SCC_ETHMACRX	= _REG_BIT(0x50, 27),
+	SCC_ETHMACPTP	= _REG_BIT(0x50, 28),
+	SCC_OTGHS	= _REG_BIT(0x50, 29),
+	SCC_OTGHSULPI	= _REG_BIT(0x50, 30),
+
+	/* AHB2 peripherals */
+	SCC_DCMI	= _REG_BIT(0x54, 0),
+	SCC_CRYP	= _REG_BIT(0x54, 4),
+	SCC_HASH	= _REG_BIT(0x54, 5),
+	SCC_RNG		= _REG_BIT(0x54, 6),
+	SCC_OTGFS	= _REG_BIT(0x54, 7),
+
+	/* AHB3 peripherals */
+	SCC_FSMC	= _REG_BIT(0x58, 0),
+
+	/* APB1 peripherals*/
+	SCC_TIM2	= _REG_BIT(0x60, 0),
+	SCC_TIM3	= _REG_BIT(0x60, 1),
+	SCC_TIM4	= _REG_BIT(0x60, 2),
+	SCC_TIM5	= _REG_BIT(0x60, 3),
+	SCC_TIM6	= _REG_BIT(0x60, 4),
+	SCC_TIM7	= _REG_BIT(0x60, 5),
+	SCC_TIM12	= _REG_BIT(0x60, 6),
+	SCC_TIM13	= _REG_BIT(0x60, 7),
+	SCC_TIM14	= _REG_BIT(0x60, 8),
+	SCC_WWDG 	= _REG_BIT(0x60, 11),
+	SCC_SPI2	= _REG_BIT(0x60, 14),
+	SCC_SPI3	= _REG_BIT(0x60, 15),
+	SCC_USART2	= _REG_BIT(0x60, 17),
+	SCC_USART3	= _REG_BIT(0x60, 18),
+	SCC_UART4	= _REG_BIT(0x60, 19),
+	SCC_UART5	= _REG_BIT(0x60, 20),
+	SCC_I2C1	= _REG_BIT(0x60, 21),
+	SCC_I2C2	= _REG_BIT(0x60, 22),
+	SCC_I2C3	= _REG_BIT(0x60, 23),
+	SCC_CAN1	= _REG_BIT(0x60, 25),
+	SCC_CAN2	= _REG_BIT(0x60, 26),
+	SCC_PWR		= _REG_BIT(0x60, 28),
+	SCC_DAC		= _REG_BIT(0x60, 29),
+	SCC_UART7	= _REG_BIT(0x60, 30),/* F2xx, F3xx */
+	SCC_UART8	= _REG_BIT(0x60, 31),/* F2xx, F3xx */
+
+	/* APB2 peripherals */
+	SCC_TIM1	= _REG_BIT(0x64, 0),
+	SCC_TIM8	= _REG_BIT(0x64, 1),
+	SCC_USART1	= _REG_BIT(0x64, 4),
+	SCC_USART6	= _REG_BIT(0x64, 5),
+	SCC_ADC1	= _REG_BIT(0x64, 8),
+	SCC_ADC2	= _REG_BIT(0x64, 9),
+	SCC_ADC3	= _REG_BIT(0x64, 10),
+	SCC_SDIO	= _REG_BIT(0x64, 11),
+	SCC_SPI1	= _REG_BIT(0x64, 12),
+	SCC_SPI4	= _REG_BIT(0x64, 13),/* F2xx, F3xx */
+	SCC_SYSCFG	= _REG_BIT(0x64, 14),
+	SCC_TIM9	= _REG_BIT(0x64, 16),
+	SCC_TIM10	= _REG_BIT(0x64, 17),
+	SCC_TIM11	= _REG_BIT(0x64, 18),
+	SCC_SPI5	= _REG_BIT(0x64, 20),/* F2xx, F3xx */
+	SCC_SPI6	= _REG_BIT(0x64, 21),/* F2xx, F3xx */
+};
+
+enum rcc_periph_rst {
+	/* AHB1 peripherals*/
+	RST_GPIOA	= _REG_BIT(0x10, 0),
+	RST_GPIOB	= _REG_BIT(0x10, 1),
+	RST_GPIOC	= _REG_BIT(0x10, 2),
+	RST_GPIOD	= _REG_BIT(0x10, 3),
+	RST_GPIOE	= _REG_BIT(0x10, 4),
+	RST_GPIOF	= _REG_BIT(0x10, 5),
+	RST_GPIOG	= _REG_BIT(0x10, 6),
+	RST_GPIOH	= _REG_BIT(0x10, 7),
+	RST_GPIOI	= _REG_BIT(0x10, 8),
+	RST_CRC		= _REG_BIT(0x10, 12),
+	RST_DMA1	= _REG_BIT(0x10, 21),
+	RST_DMA2	= _REG_BIT(0x10, 22),
+	RST_ETHMAC	= _REG_BIT(0x10, 25),
+	RST_OTGHS	= _REG_BIT(0x10, 29),
+
+	/* AHB2 peripherals */
+	RST_DCMI	= _REG_BIT(0x14, 0),
+	RST_CRYP	= _REG_BIT(0x14, 4),
+	RST_HASH	= _REG_BIT(0x14, 5),
+	RST_RNG		= _REG_BIT(0x14, 6),
+	RST_OTGFS	= _REG_BIT(0x14, 7),
+
+	/* AHB3 peripherals */
+	RST_FSMC	= _REG_BIT(0x18, 0),
+
+	/* APB1 peripherals*/
+	RST_TIM2	= _REG_BIT(0x20, 0),
+	RST_TIM3	= _REG_BIT(0x20, 1),
+	RST_TIM4	= _REG_BIT(0x20, 2),
+	RST_TIM5	= _REG_BIT(0x20, 3),
+	RST_TIM6	= _REG_BIT(0x20, 4),
+	RST_TIM7	= _REG_BIT(0x20, 5),
+	RST_TIM12	= _REG_BIT(0x20, 6),
+	RST_TIM13	= _REG_BIT(0x20, 7),
+	RST_TIM14	= _REG_BIT(0x20, 8),
+	RST_WWDG 	= _REG_BIT(0x20, 11),
+	RST_SPI2	= _REG_BIT(0x20, 14),
+	RST_SPI3	= _REG_BIT(0x20, 15),
+	RST_USART2	= _REG_BIT(0x20, 17),
+	RST_USART3	= _REG_BIT(0x20, 18),
+	RST_UART4	= _REG_BIT(0x20, 19),
+	RST_UART5	= _REG_BIT(0x20, 20),
+	RST_I2C1	= _REG_BIT(0x20, 21),
+	RST_I2C2	= _REG_BIT(0x20, 22),
+	RST_I2C3	= _REG_BIT(0x20, 23),
+	RST_CAN1	= _REG_BIT(0x20, 25),
+	RST_CAN2	= _REG_BIT(0x20, 26),
+	RST_PWR		= _REG_BIT(0x20, 28),
+	RST_DAC		= _REG_BIT(0x20, 29),
+	RST_UART7	= _REG_BIT(0x20, 30),/* F2xx, F3xx */
+	RST_UART8	= _REG_BIT(0x20, 31),/* F2xx, F3xx */
+
+	/* APB2 peripherals */
+	RST_TIM1	= _REG_BIT(0x24, 0),
+	RST_TIM8	= _REG_BIT(0x24, 1),
+	RST_USART1	= _REG_BIT(0x24, 4),
+	RST_USART6	= _REG_BIT(0x24, 5),
+	RST_ADC		= _REG_BIT(0x24, 8),
+	RST_SDIO	= _REG_BIT(0x24, 11),
+	RST_SPI1	= _REG_BIT(0x24, 12),
+	RST_SPI4	= _REG_BIT(0x24, 13),/* F2xx, F3xx */
+	RST_SYSCFG	= _REG_BIT(0x24, 14),
+	RST_TIM9	= _REG_BIT(0x24, 16),
+	RST_TIM10	= _REG_BIT(0x24, 17),
+	RST_TIM11	= _REG_BIT(0x24, 18),
+	RST_SPI5	= _REG_BIT(0x24, 20),/* F2xx, F3xx */
+	RST_SPI6	= _REG_BIT(0x24, 21),/* F2xx, F3xx */
+};
+
+#undef _REG_BIT
+
+#include <libopencm3/stm32/common/rcc_common_all.h>
 
 BEGIN_DECLS
 
-void rcc_osc_ready_int_clear(osc_t osc);
-void rcc_osc_ready_int_enable(osc_t osc);
-void rcc_osc_ready_int_disable(osc_t osc);
-int rcc_osc_ready_int_flag(osc_t osc);
+void rcc_osc_ready_int_clear(enum rcc_osc osc);
+void rcc_osc_ready_int_enable(enum rcc_osc osc);
+void rcc_osc_ready_int_disable(enum rcc_osc osc);
+int rcc_osc_ready_int_flag(enum rcc_osc osc);
 void rcc_css_int_clear(void);
 int rcc_css_int_flag(void);
-void rcc_wait_for_osc_ready(osc_t osc);
-void rcc_wait_for_sysclk_status(osc_t osc);
-void rcc_osc_on(osc_t osc);
-void rcc_osc_off(osc_t osc);
+void rcc_wait_for_osc_ready(enum rcc_osc osc);
+void rcc_wait_for_sysclk_status(enum rcc_osc osc);
+void rcc_osc_on(enum rcc_osc osc);
+void rcc_osc_off(enum rcc_osc osc);
 void rcc_css_enable(void);
 void rcc_css_disable(void);
-void rcc_osc_bypass_enable(osc_t osc);
-void rcc_osc_bypass_disable(osc_t osc);
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset);
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset);
+void rcc_osc_bypass_enable(enum rcc_osc osc);
+void rcc_osc_bypass_disable(enum rcc_osc osc);
 void rcc_set_sysclk_source(uint32_t clk);
 void rcc_set_pll_source(uint32_t pllsrc);
 void rcc_set_ppre2(uint32_t ppre2);
@@ -517,7 +752,6 @@ void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq);
 uint32_t rcc_system_clock_source(void);
 void rcc_clock_setup_hse_3v3(const clock_scale_t *clock);
-void rcc_backupdomain_reset(void);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/l1/rcc.h
+++ b/include/libopencm3/stm32/l1/rcc.h
@@ -421,6 +421,158 @@ typedef enum {
 	PLL, HSE, HSI, MSI, LSE, LSI
 } osc_t;
 
+#define _REG_BIT(base, bit)		(((base) << 5) + (bit))
+
+enum rcc_periph_clken {
+	/* AHB peripherals  */
+	RCC_GPIOA	= _REG_BIT(0x1c, 0),
+	RCC_GPIOB	= _REG_BIT(0x1c, 1),
+	RCC_GPIOC	= _REG_BIT(0x1c, 2),
+	RCC_GPIOD	= _REG_BIT(0x1c, 3),
+	RCC_GPIOE	= _REG_BIT(0x1c, 4),
+	RCC_GPIOH	= _REG_BIT(0x1c, 5),
+	RCC_GPIOF	= _REG_BIT(0x1c, 6),
+	RCC_GPIOG	= _REG_BIT(0x1c, 7),
+	RCC_CRC		= _REG_BIT(0x1c, 12),
+	RCC_FLITF	= _REG_BIT(0x1c, 15),
+	RCC_DMA1	= _REG_BIT(0x1c, 24),
+	RCC_DMA2	= _REG_BIT(0x1c, 25),
+	RCC_AES		= _REG_BIT(0x1c, 27),
+	RCC_FSMC	= _REG_BIT(0x1c, 30),
+	
+	/* APB2 peripherals */
+	RCC_SYSCFG	= _REG_BIT(0x20, 0),
+	RCC_TIM9	= _REG_BIT(0x20, 2),
+	RCC_TIM10	= _REG_BIT(0x20, 3),
+	RCC_TIM11	= _REG_BIT(0x20, 4),
+	RCC_ADC1	= _REG_BIT(0x20, 9),
+	RCC_SDIO	= _REG_BIT(0x20, 11),
+	RCC_SPI1	= _REG_BIT(0x20, 12),
+	RCC_USART1	= _REG_BIT(0x20, 14),
+
+	/* APB1 peripherals*/
+	RCC_TIM2	= _REG_BIT(0x24, 0),
+	RCC_TIM3	= _REG_BIT(0x24, 1),
+	RCC_TIM4	= _REG_BIT(0x24, 2),
+	RCC_TIM5	= _REG_BIT(0x24, 3),
+	RCC_TIM6	= _REG_BIT(0x24, 4),
+	RCC_TIM7	= _REG_BIT(0x24, 5),
+	RCC_LCD		= _REG_BIT(0x24, 9),
+	RCC_WWDG	= _REG_BIT(0x24, 11),
+	RCC_SPI2	= _REG_BIT(0x24, 14),
+	RCC_SPI3	= _REG_BIT(0x24, 15),
+	RCC_USART2	= _REG_BIT(0x24, 17),
+	RCC_USART3	= _REG_BIT(0x24, 18),
+	RCC_UART4	= _REG_BIT(0x24, 19),
+	RCC_UART5	= _REG_BIT(0x24, 20),
+	RCC_I2C1	= _REG_BIT(0x24, 21),
+	RCC_I2C2	= _REG_BIT(0x24, 22),
+	RCC_USB		= _REG_BIT(0x24, 23),
+	RCC_PWR		= _REG_BIT(0x24, 28),
+	RCC_DAC		= _REG_BIT(0x24, 29),
+	RCC_COMP	= _REG_BIT(0x24, 31),
+
+	/* AHB peripherals  */
+	SCC_GPIOA	= _REG_BIT(0x28, 0),
+	SCC_GPIOB	= _REG_BIT(0x28, 1),
+	SCC_GPIOC	= _REG_BIT(0x28, 2),
+	SCC_GPIOD	= _REG_BIT(0x28, 3),
+	SCC_GPIOE	= _REG_BIT(0x28, 4),
+	SCC_GPIOH	= _REG_BIT(0x28, 5),
+	SCC_GPIOF	= _REG_BIT(0x28, 6),
+	SCC_GPIOG	= _REG_BIT(0x28, 7),
+	SCC_CRC		= _REG_BIT(0x28, 12),
+	SCC_FLITF	= _REG_BIT(0x28, 15),
+	SCC_SRAM	= _REG_BIT(0x28, 16),
+	SCC_DMA1	= _REG_BIT(0x28, 24),
+	SCC_DMA2	= _REG_BIT(0x28, 25),
+	SCC_AES		= _REG_BIT(0x28, 27),
+	SCC_FSMC	= _REG_BIT(0x28, 30),
+	
+	/* APB2 peripherals */
+	SCC_SYSCFG	= _REG_BIT(0x2c, 0),
+	SCC_TIM9	= _REG_BIT(0x2c, 2),
+	SCC_TIM10	= _REG_BIT(0x2c, 3),
+	SCC_TIM11	= _REG_BIT(0x2c, 4),
+	SCC_ADC1	= _REG_BIT(0x2c, 9),
+	SCC_SDIO	= _REG_BIT(0x2c, 11),
+	SCC_SPI1	= _REG_BIT(0x2c, 12),
+	SCC_USART1	= _REG_BIT(0x2c, 14),
+
+	/* APB1 peripherals*/
+	SCC_TIM2	= _REG_BIT(0x24, 0),
+	SCC_TIM3	= _REG_BIT(0x24, 1),
+	SCC_TIM4	= _REG_BIT(0x24, 2),
+	SCC_TIM5	= _REG_BIT(0x24, 3),
+	SCC_TIM6	= _REG_BIT(0x24, 4),
+	SCC_TIM7	= _REG_BIT(0x24, 5),
+	SCC_LCD		= _REG_BIT(0x24, 9),
+	SCC_WWDG	= _REG_BIT(0x24, 11),
+	SCC_SPI2	= _REG_BIT(0x24, 14),
+	SCC_SPI3	= _REG_BIT(0x24, 15),
+	SCC_USART2	= _REG_BIT(0x24, 17),
+	SCC_USART3	= _REG_BIT(0x24, 18),
+	SCC_UART4	= _REG_BIT(0x24, 19),
+	SCC_UART5	= _REG_BIT(0x24, 20),
+	SCC_I2C1	= _REG_BIT(0x24, 21),
+	SCC_I2C2	= _REG_BIT(0x24, 22),
+	SCC_USB		= _REG_BIT(0x24, 23),
+	SCC_PWR		= _REG_BIT(0x24, 28),
+	SCC_DAC		= _REG_BIT(0x24, 29),
+	SCC_COMP	= _REG_BIT(0x24, 31),
+};
+
+enum rcc_periph_rst {
+	/* AHB peripherals  */
+	RST_GPIOA	= _REG_BIT(0x10, 0),
+	RST_GPIOB	= _REG_BIT(0x10, 1),
+	RST_GPIOC	= _REG_BIT(0x10, 2),
+	RST_GPIOD	= _REG_BIT(0x10, 3),
+	RST_GPIOE	= _REG_BIT(0x10, 4),
+	RST_GPIOH	= _REG_BIT(0x10, 5),
+	RST_GPIOF	= _REG_BIT(0x10, 6),
+	RST_GPIOG	= _REG_BIT(0x10, 7),
+	RST_CRC		= _REG_BIT(0x10, 12),
+	RST_FLITF	= _REG_BIT(0x10, 15),
+	RST_DMA1	= _REG_BIT(0x10, 24),
+	RST_DMA2	= _REG_BIT(0x10, 25),
+	RST_AES		= _REG_BIT(0x10, 27),
+	RST_FSMC	= _REG_BIT(0x10, 30),
+	
+	/* APB2 peripherals */
+	RST_SYSCFG	= _REG_BIT(0x14, 0),
+	RST_TIM9	= _REG_BIT(0x14, 2),
+	RST_TIM10	= _REG_BIT(0x14, 3),
+	RST_TIM11	= _REG_BIT(0x14, 4),
+	RST_ADC1	= _REG_BIT(0x14, 9),
+	RST_SDIO	= _REG_BIT(0x14, 11),
+	RST_SPI1	= _REG_BIT(0x14, 12),
+	RST_USART1	= _REG_BIT(0x14, 14),
+
+	/* APB1 peripherals*/
+	RST_TIM2	= _REG_BIT(0x18, 0),
+	RST_TIM3	= _REG_BIT(0x18, 1),
+	RST_TIM4	= _REG_BIT(0x18, 2),
+	RST_TIM5	= _REG_BIT(0x18, 3),
+	RST_TIM6	= _REG_BIT(0x18, 4),
+	RST_TIM7	= _REG_BIT(0x18, 5),
+	RST_LCD		= _REG_BIT(0x18, 9),
+	RST_WWDG	= _REG_BIT(0x18, 11),
+	RST_SPI2	= _REG_BIT(0x18, 14),
+	RST_SPI3	= _REG_BIT(0x18, 15),
+	RST_USART2	= _REG_BIT(0x18, 17),
+	RST_USART3	= _REG_BIT(0x18, 18),
+	RST_UART4	= _REG_BIT(0x18, 19),
+	RST_UART5	= _REG_BIT(0x18, 20),
+	RST_I2C1	= _REG_BIT(0x18, 21),
+	RST_I2C2	= _REG_BIT(0x18, 22),
+	RST_USB		= _REG_BIT(0x18, 23),
+	RST_PWR		= _REG_BIT(0x18, 28),
+	RST_DAC		= _REG_BIT(0x18, 29),
+	RST_COMP	= _REG_BIT(0x18, 31),
+};
+#include <libopencm3/stm32/common/rcc_common_all.h>
+
 BEGIN_DECLS
 
 void rcc_osc_ready_int_clear(osc_t osc);
@@ -437,10 +589,6 @@ void rcc_css_enable(void);
 void rcc_css_disable(void);
 void rcc_osc_bypass_enable(osc_t osc);
 void rcc_osc_bypass_disable(osc_t osc);
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en);
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset);
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset);
 void rcc_set_sysclk_source(uint32_t clk);
 void rcc_set_pll_configuration(uint32_t source, uint32_t multiplier,
 			       uint32_t divisor);

--- a/lib/stm32/common/rcc_common_all.c
+++ b/lib/stm32/common/rcc_common_all.c
@@ -1,0 +1,185 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Frantisek Burian <bufran@seznam.cz>
+ * .. file is merged from many other copyrighted files of stm32 family
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include <libopencm3/stm32/rcc.h>
+
+/*---------------------------------------------------------------------------*/
+/** @brief RCC Enable Peripheral Clocks.
+ *
+ * Enable the clock on particular peripherals. There are three registers 
+ * involved, each one controlling the enabling of clocks associated with the 
+ * AHB, APB1 and APB2 respectively. Several peripherals could be enabled 
+ * simultaneously <em>only if they are controlled by the same register</em>.
+ *
+ * @param[in] *reg Unsigned int32. Pointer to a Clock Enable Register
+ *			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
+ *
+ * @param[in] en Unsigned int32. Logical OR of all enables to be set
+ * @li If register is RCC_AHBER, from @ref rcc_ahbenr_en
+ * @li If register is RCC_APB1ENR, from @ref rcc_apb1enr_en
+ * @li If register is RCC_APB2ENR, from @ref rcc_apb2enr_en
+ */
+
+void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en)
+{
+	*reg |= en;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief RCC Disable Peripheral Clocks.
+ *
+ * Enable the clock on particular peripherals. There are three registers 
+ * involved, each one controlling the enabling of clocks associated with 
+ * the AHB, APB1 and APB2 respectively. Several peripherals could be disabled 
+ * simultaneously <em>only if they are controlled by the same register</em>.
+ *
+ * @param[in] *reg Unsigned int32. Pointer to a Clock Enable Register
+ *			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
+ * @param[in] en Unsigned int32. Logical OR of all enables to be used for
+ * disabling.
+ * @li If register is RCC_AHBER, from @ref rcc_ahbenr_en
+ * @li If register is RCC_APB1ENR, from @ref rcc_apb1enr_en
+ * @li If register is RCC_APB2ENR, from @ref rcc_apb2enr_en
+ */
+void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en)
+{
+	*reg &= ~en;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief RCC Reset Peripherals.
+ *
+ * Reset particular peripherals. There are three registers involved, each one
+ * controlling reset of peripherals associated with the AHB, APB1 and APB2
+ * respectively. Several peripherals could be reset simultaneously <em>only if
+ * they are controlled by the same register</em>.
+ * 
+ * @param[in] *reg Unsigned int32. Pointer to a Reset Register
+ *			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
+ * @param[in] reset Unsigned int32. Logical OR of all resets.
+ * @li If register is RCC_AHBRSTR, from @ref rcc_ahbrstr_rst
+ * @li If register is RCC_APB1RSTR, from @ref rcc_apb1rstr_rst
+ * @li If register is RCC_APB2RSTR, from @ref rcc_apb2rstr_rst
+ */
+void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset)
+{
+	*reg |= reset;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief RCC Remove Reset on Peripherals.
+ *
+ * Remove the reset on particular peripherals. There are three registers
+ * involved, each one controlling reset of peripherals associated with the AHB,
+ * APB1 and APB2 respectively. Several peripherals could have the reset removed
+ * simultaneously <em>only if they are controlled by the same register</em>.
+ *
+ * @param[in] *reg Unsigned int32. Pointer to a Reset Register
+ *			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
+ * @param[in] clear_reset Unsigned int32. Logical OR of all resets to be removed:
+ * @li If register is RCC_AHBRSTR, from @ref rcc_ahbrstr_rst
+ * @li If register is RCC_APB1RSTR, from @ref rcc_apb1rstr_rst
+ * @li If register is RCC_APB2RSTR, from @ref rcc_apb2rstr_rst
+ */
+void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset)
+{
+	*reg &= ~clear_reset;
+}
+
+#define _RCC_REG(i)		MMIO32(RCC_BASE + ((i) >> 5))
+#define _RCC_BIT(i)		(1 << ((i) & 0x1f))
+
+/*---------------------------------------------------------------------------*/
+/** @brief Enable Peripheral Clock in running mode.
+ *
+ * Enable the clock on particular peripheral.
+ *
+ * @param[in] periph periph_t Peripheral Name
+ *
+ * For available constants, see #periph_t (RCC_UART1 for example)
+ */
+ 
+void rcc_periph_clock_enable(enum rcc_periph_clken clken)
+{
+	_RCC_REG(clken) |= _RCC_BIT(clken);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Disable Peripheral Clock in running mode.
+ * Disable the clock on particular peripheral.
+ *
+ * @param[in] periph periph_t Peripheral Name
+ *
+ * For available constants, see #periph_t (RCC_UART1 for example)
+ */
+
+void rcc_periph_clock_disable(enum rcc_periph_clken clken)
+{
+	_RCC_REG(clken) &= ~_RCC_BIT(clken);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Reset Peripheral, pulsed
+ *
+ * Reset particular peripheral, and restore to working state.
+ *
+ * @param[in] periph periph_t Peripheral name
+ *
+ * For available constants, see #periph_t (RCC_UART1 for example)
+ */
+
+void rcc_periph_reset_pulse(enum rcc_periph_rst rst)
+{
+	_RCC_REG(rst) |= _RCC_BIT(rst);
+	_RCC_REG(rst) &= ~_RCC_BIT(rst);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Reset Peripheral, hold
+ *
+ * Reset particular peripheral, and hold in reset state.
+ *
+ * @param[in] periph periph_t Peripheral name
+ *
+ * For available constants, see #periph_t  (RCC_UART1 for example)
+ */
+
+void rcc_periph_reset_hold(enum rcc_periph_rst rst)
+{
+	_RCC_REG(rst) |= _RCC_BIT(rst);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Reset Peripheral, release
+ *
+ * Restore peripheral from reset state to working state.
+ *
+ * @param[in] periph periph_t Peripheral name
+ *
+ * For available constants, see #periph_t (RCC_UART1 for example)
+ */
+
+void rcc_periph_reset_release(enum rcc_periph_rst rst)
+{
+	_RCC_REG(rst) &= ~_RCC_BIT(rst);
+}
+
+#undef _RCC_REG
+#undef _RCC_BIT

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -40,7 +40,7 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_l1f013.o \
                    gpio_common_all.o i2c_common_all.o iwdg_common_all.o \
                    pwr_common_all.o spi_common_all.o spi_common_l1f124.o \
                    timer_common_all.o usart_common_all.o usart_common_f124.o \
-                   exti_common_all.o
+                   rcc_common_all.o exti_common_all.o
 
 OBJS            += usb.o usb_control.o usb_standard.o usb_f103.o usb_f107.o \
                    usb_fx07_common.o

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -67,7 +67,7 @@ use.
 @param[in] osc enum ::osc_t. Oscillator ID
 */
 
-void rcc_osc_ready_int_clear(osc_t osc)
+void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -100,7 +100,7 @@ void rcc_osc_ready_int_clear(osc_t osc)
 @param[in] osc enum ::osc_t. Oscillator ID
 */
 
-void rcc_osc_ready_int_enable(osc_t osc)
+void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -133,7 +133,7 @@ void rcc_osc_ready_int_enable(osc_t osc)
 @param[in] osc enum ::osc_t. Oscillator ID
 */
 
-void rcc_osc_ready_int_disable(osc_t osc)
+void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -167,7 +167,7 @@ void rcc_osc_ready_int_disable(osc_t osc)
 @returns int. Boolean value for flag set.
 */
 
-int rcc_osc_ready_int_flag(osc_t osc)
+int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -223,7 +223,7 @@ int rcc_css_int_flag(void)
 @param[in] osc enum ::osc_t. Oscillator ID
 */
 
-void rcc_wait_for_osc_ready(osc_t osc)
+void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -265,7 +265,7 @@ pwr_disable_backup_domain_write_protect).
 @param[in] osc enum ::osc_t. Oscillator ID
 */
 
-void rcc_osc_on(osc_t osc)
+void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -306,7 +306,7 @@ backup domain write protection has been removed (see
 @param[in] osc enum ::osc_t. Oscillator ID
 */
 
-void rcc_osc_off(osc_t osc)
+void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -367,7 +367,7 @@ pwr_disable_backup_domain_write_protect).
 @param[in] osc enum ::osc_t. Oscillator ID. Only HSE and LSE have effect.
 */
 
-void rcc_osc_bypass_enable(osc_t osc)
+void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case HSE:
@@ -400,7 +400,7 @@ pwr_disable_backup_domain_write_protect) or the backup domain has been reset
 @param[in] osc enum ::osc_t. Oscillator ID. Only HSE and LSE have effect.
 */
 
-void rcc_osc_bypass_disable(osc_t osc)
+void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case HSE:
@@ -417,91 +417,6 @@ void rcc_osc_bypass_disable(osc_t osc)
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
-}
-
-/*---------------------------------------------------------------------------*/
-/** @brief RCC Enable Peripheral Clocks.
-
-Enable the clock on particular peripherals. There are three registers involved,
-each one controlling the enabling of clocks associated with the AHB, APB1 and
-APB2 respectively. Several peripherals could be enabled simultaneously <em>only
-if they are controlled by the same register</em>.
-
-@param[in] *reg Unsigned int32. Pointer to a Clock Enable Register
-			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
-@param[in] en Unsigned int32. Logical OR of all enables to be set
-@li If register is RCC_AHBER, from @ref rcc_ahbenr_en
-@li If register is RCC_APB1ENR, from @ref rcc_apb1enr_en
-@li If register is RCC_APB2ENR, from @ref rcc_apb2enr_en
-*/
-
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg |= en;
-}
-
-/*---------------------------------------------------------------------------*/
-/** @brief RCC Disable Peripheral Clocks.
-
-Enable the clock on particular peripherals. There are three registers involved,
-each one controlling the enabling of clocks associated with the AHB, APB1 and
-APB2 respectively. Several peripherals could be disabled simultaneously
-<em>only if they are controlled by the same register</em>.
-
-@param[in] *reg Unsigned int32. Pointer to a Clock Enable Register
-			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
-@param[in] en Unsigned int32. Logical OR of all enables to be used for
-disabling.
-@li If register is RCC_AHBER, from @ref rcc_ahbenr_en
-@li If register is RCC_APB1ENR, from @ref rcc_apb1enr_en
-@li If register is RCC_APB2ENR, from @ref rcc_apb2enr_en
-*/
-
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg &= ~en;
-}
-
-/*---------------------------------------------------------------------------*/
-/** @brief RCC Reset Peripherals.
-
-Reset particular peripherals. There are three registers involved, each one
-controlling reset of peripherals associated with the AHB, APB1 and APB2
-respectively. Several peripherals could be reset simultaneously <em>only if
-they are controlled by the same register</em>.
-
-@param[in] *reg Unsigned int32. Pointer to a Reset Register
-			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
-@param[in] reset Unsigned int32. Logical OR of all resets.
-@li If register is RCC_AHBRSTR, from @ref rcc_ahbrstr_rst
-@li If register is RCC_APB1RSTR, from @ref rcc_apb1rstr_rst
-@li If register is RCC_APB2RSTR, from @ref rcc_apb2rstr_rst
-*/
-
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset)
-{
-	*reg |= reset;
-}
-
-/*---------------------------------------------------------------------------*/
-/** @brief RCC Remove Reset on Peripherals.
-
-Remove the reset on particular peripherals. There are three registers
-involved, each one controlling reset of peripherals associated with the AHB,
-APB1 and APB2 respectively. Several peripherals could have the reset removed
-simultaneously <em>only if they are controlled by the same register</em>.
-
-@param[in] *reg Unsigned int32. Pointer to a Reset Register
-			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
-@param[in] clear_reset Unsigned int32. Logical OR of all resets to be removed:
-@li If register is RCC_AHBRSTR, from @ref rcc_ahbrstr_rst
-@li If register is RCC_APB1RSTR, from @ref rcc_apb1rstr_rst
-@li If register is RCC_APB2RSTR, from @ref rcc_apb2rstr_rst
-*/
-
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset)
-{
-	*reg &= ~clear_reset;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1218,5 +1133,6 @@ void rcc_backupdomain_reset(void)
 	/* Clear the backup domain software reset. */
 	RCC_BDCR &= ~RCC_BDCR_BDRST;
 }
+
 /**@}*/
 

--- a/lib/stm32/f1/rtc.c
+++ b/lib/stm32/f1/rtc.c
@@ -38,7 +38,7 @@ LGPL License Terms @ref lgpl_license
 #include <libopencm3/stm32/rtc.h>
 #include <libopencm3/stm32/pwr.h>
 
-void rtc_awake_from_off(osc_t clock_source)
+void rtc_awake_from_off(enum rcc_osc clock_source)
 {
 	uint32_t reg32;
 
@@ -279,7 +279,7 @@ void rtc_awake_from_standby(void)
 	while ((reg32 = (RTC_CRL & RTC_CRL_RTOFF)) == 0);
 }
 
-void rtc_auto_awake(osc_t clock_source, uint32_t prescale_val)
+void rtc_auto_awake(enum rcc_osc clock_source, uint32_t prescale_val)
 {
 	uint32_t reg32;
 

--- a/lib/stm32/f2/Makefile
+++ b/lib/stm32/f2/Makefile
@@ -41,7 +41,7 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    spi_common_l1f124.o timer_common_all.o timer_common_f234.o \
 		   timer_common_f24.o usart_common_all.o usart_common_f124.o \
 		   flash_common_f234.o flash_common_f24.o hash_common_f24.o \
-		   crypto_common_f24.o exti_common_all.o
+		   crypto_common_f24.o exti_common_all.o rcc_common_all.o
 
 OBJS            += usb.o usb_standard.o usb_control.o usb_fx07_common.o \
                    usb_f107.o usb_f207.o

--- a/lib/stm32/f2/rcc.c
+++ b/lib/stm32/f2/rcc.c
@@ -1,3 +1,21 @@
+/** @defgroup rcc_file RCC
+ *
+ * @ingroup STM32F2xx
+ *
+ * @section rcc_f2_api_ex Reset and Clock Control API.
+ *
+ * @brief <b>libopencm3 STM32F4xx Reset and Clock Control</b>
+ *
+ * @author @htmlonly &copy; @endhtmlonly 2013 Frantisek Burian <BuFran at seznam.cz>
+ *
+ * @date 18 Jun 2013
+ *
+ * This library supports the Reset and Clock Control System in the STM32 series
+ * of ARM Cortex Microcontrollers by ST Microelectronics.
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+
 /*
  * This file is part of the libopencm3 project.
  *
@@ -22,6 +40,8 @@
 #include <libopencm3/cm3/assert.h>
 #include <libopencm3/stm32/f2/rcc.h>
 #include <libopencm3/stm32/f2/flash.h>
+
+/**@{*/
 
 /* Set the default ppre1 and ppre2 peripheral clock frequencies after reset. */
 uint32_t rcc_ppre1_frequency = 16000000;
@@ -264,26 +284,6 @@ void rcc_osc_bypass_disable(osc_t osc)
 	}
 }
 
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg |= en;
-}
-
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg &= ~en;
-}
-
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset)
-{
-	*reg |= reset;
-}
-
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset)
-{
-	*reg &= ~clear_reset;
-}
-
 void rcc_set_sysclk_source(uint32_t clk)
 {
 	uint32_t reg32;
@@ -413,3 +413,5 @@ void rcc_backupdomain_reset(void)
 	/* Clear the backup domain software reset. */
 	RCC_BDCR &= ~RCC_BDCR_BDRST;
 }
+
+/**@}*/

--- a/lib/stm32/f3/Makefile
+++ b/lib/stm32/f3/Makefile
@@ -34,13 +34,13 @@ CFLAGS		= -Os -g \
 
 ARFLAGS		= rcs
 
-OBJS		= rcc.o gpio.o adc.o i2c.o spi.o usart.o dma.o
+OBJS		= rcc.o gpio.o adc.o i2c.o spi.o usart.o dma.o flash.o
 
 OBJS            += gpio_common_all.o gpio_common_f0234.o \
 		   dac_common_all.o usart_common_all.o crc_common_all.o\
 		   iwdg_common_all.o spi_common_all.o dma_common_l1f013.o\
 		   timer_common_all.o timer_common_f234.o flash_common_f234.o \
-		   flash.o exti_common_all.o
+		   flash.o exti_common_all.o rcc_common_all.o
 
 OBJS		+= usb.o usb_control.o usb_standard.o usb_f103.o
 

--- a/lib/stm32/f3/rcc.c
+++ b/lib/stm32/f3/rcc.c
@@ -321,26 +321,6 @@ void rcc_osc_bypass_disable(enum osc osc)
 	}
 }
 
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg |= en;
-}
-
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg &= ~en;
-}
-
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset)
-{
-	*reg |= reset;
-}
-
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset)
-{
-	*reg &= ~clear_reset;
-}
-
 void rcc_set_sysclk_source(uint32_t clk)
 {
 	uint32_t reg32;

--- a/lib/stm32/f4/Makefile
+++ b/lib/stm32/f4/Makefile
@@ -44,7 +44,8 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    spi_common_all.o spi_common_l1f124.o timer_common_all.o \
                    timer_common_f234.o timer_common_f24.o usart_common_all.o \
 		   usart_common_f124.o flash_common_f234.o flash_common_f24.o \
-		   hash_common_f24.o crypto_common_f24.o exti_common_all.o
+		   hash_common_f24.o crypto_common_f24.o exti_common_all.o \
+		   rcc_common_all.o
 
 OBJS            += usb.o usb_standard.o usb_control.o usb_fx07_common.o \
 		   usb_f107.o usb_f207.o

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -1,3 +1,21 @@
+/** @defgroup rcc_file RCC
+ *
+ * @ingroup STM32F4xx
+ *
+ * @section rcc_f4_api_ex Reset and Clock Control API.
+ *
+ * @brief <b>libopencm3 STM32F4xx Reset and Clock Control</b>
+ *
+ * @author @htmlonly &copy; @endhtmlonly 2013 Frantisek Burian <BuFran at seznam.cz>
+ *
+ * @date 18 Jun 2013
+ *
+ * This library supports the Reset and Clock Control System in the STM32 series
+ * of ARM Cortex Microcontrollers by ST Microelectronics.
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+
 /*
  * This file is part of the libopencm3 project.
  *
@@ -23,6 +41,8 @@
 #include <libopencm3/stm32/f4/rcc.h>
 #include <libopencm3/stm32/f4/pwr.h>
 #include <libopencm3/stm32/f4/flash.h>
+
+/**@{*/
 
 /* Set the default ppre1 and ppre2 peripheral clock frequencies after reset. */
 uint32_t rcc_ppre1_frequency = 16000000;
@@ -160,7 +180,7 @@ const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END] = {
 	},
 };
 
-void rcc_osc_ready_int_clear(osc_t osc)
+void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -181,7 +201,7 @@ void rcc_osc_ready_int_clear(osc_t osc)
 	}
 }
 
-void rcc_osc_ready_int_enable(osc_t osc)
+void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -202,7 +222,7 @@ void rcc_osc_ready_int_enable(osc_t osc)
 	}
 }
 
-void rcc_osc_ready_int_disable(osc_t osc)
+void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -223,7 +243,7 @@ void rcc_osc_ready_int_disable(osc_t osc)
 	}
 }
 
-int rcc_osc_ready_int_flag(osc_t osc)
+int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -256,7 +276,7 @@ int rcc_css_int_flag(void)
 	return ((RCC_CIR & RCC_CIR_CSSF) != 0);
 }
 
-void rcc_wait_for_osc_ready(osc_t osc)
+void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -277,7 +297,7 @@ void rcc_wait_for_osc_ready(osc_t osc)
 	}
 }
 
-void rcc_wait_for_sysclk_status(osc_t osc)
+void rcc_wait_for_sysclk_status(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -295,7 +315,7 @@ void rcc_wait_for_sysclk_status(osc_t osc)
 	}
 }
 
-void rcc_osc_on(osc_t osc)
+void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -316,7 +336,7 @@ void rcc_osc_on(osc_t osc)
 	}
 }
 
-void rcc_osc_off(osc_t osc)
+void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
 	case PLL:
@@ -347,7 +367,7 @@ void rcc_css_disable(void)
 	RCC_CR &= ~RCC_CR_CSSON;
 }
 
-void rcc_osc_bypass_enable(osc_t osc)
+void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case HSE:
@@ -364,7 +384,7 @@ void rcc_osc_bypass_enable(osc_t osc)
 	}
 }
 
-void rcc_osc_bypass_disable(osc_t osc)
+void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
 	case HSE:
@@ -381,25 +401,7 @@ void rcc_osc_bypass_disable(osc_t osc)
 	}
 }
 
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg |= en;
-}
 
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg &= ~en;
-}
-
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset)
-{
-	*reg |= reset;
-}
-
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset)
-{
-	*reg &= ~clear_reset;
-}
 
 void rcc_set_sysclk_source(uint32_t clk)
 {
@@ -532,11 +534,6 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 	rcc_osc_off(HSI);
 }
 
-void rcc_backupdomain_reset(void)
-{
-	/* Set the backup domain software reset. */
-	RCC_BDCR |= RCC_BDCR_BDRST;
 
-	/* Clear the backup domain software reset. */
-	RCC_BDCR &= ~RCC_BDCR_BDRST;
-}
+
+/**@}*/

--- a/lib/stm32/l1/Makefile
+++ b/lib/stm32/l1/Makefile
@@ -41,6 +41,7 @@ OBJS		+= pwr_common_all.o pwr.o rtc_common_l1f024.o
 OBJS		+= spi_common_all.o spi_common_l1f124.o timer_common_all.o
 OBJS		+= usart_common_all.o usart_common_f124.o
 OBJS		+= exti_common_all.o
+OBJS		+= rcc_common_all.o
 OBJS		+= usb.o usb_control.o usb_standard.o usb_f103.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -346,26 +346,6 @@ void rcc_osc_bypass_disable(osc_t osc)
 	}
 }
 
-void rcc_peripheral_enable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg |= en;
-}
-
-void rcc_peripheral_disable_clock(volatile uint32_t *reg, uint32_t en)
-{
-	*reg &= ~en;
-}
-
-void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset)
-{
-	*reg |= reset;
-}
-
-void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset)
-{
-	*reg &= ~clear_reset;
-}
-
 void rcc_set_sysclk_source(uint32_t clk)
 {
 	uint32_t reg32;


### PR DESCRIPTION
Commonization commit for L1 F1 F2 F3 and F4 to be compatible with F0

Currently only for F4 target as tested example. I can extend and test it for F1 and L1 target, for F2 i cannot test (having no discovery platform for F2)

Let's see on the current standard, shown in next example. If I would like to create the line of code, I must open the Reference Manual and search for appropriate bit and register.

``` C
rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_USART1EN);
rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPDEN);
....
rcc_peripheral_reset(&RCC_APB2RSTR, RCC_APB2RSTR_USART1RST);
rcc_peripheral_clear_reset(&RCC_APB2RSTR, RCC_APB2RSTR_USART1RST);
```

After my patch, i can write more readable code, because bit and register selection can be done in the background in rcc.c 

``` C
rcc_periph_clock_enable(RCC_USART1);
rcc_periph_clock_enable(RCC_GPIOD);
....
rcc_periph_reset_pulse(RST_USART1)
```

Regards.

   Frantisek Burian

(Compatibility with old method preserved)
