### PR TITLE
[stm32-l1] RFC: Make it possible to use HSE with PLL

### DIFF
--- a/include/libopencm3/stm32/l1/rcc.h
+++ b/include/libopencm3/stm32/l1/rcc.h
@@ -455,6 +455,7 @@ uint32_t rcc_system_clock_source(void);
 void rcc_rtc_select_clock(uint32_t clock);
 void rcc_clock_setup_msi(const clock_scale_t *clock);
 void rcc_clock_setup_hsi(const clock_scale_t *clock);
+void rcc_clock_setup_pll_osc(const osc_t osc, const clock_scale_t *clock);
 void rcc_clock_setup_pll(const clock_scale_t *clock);
 void rcc_backupdomain_reset(void);
 

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -515,12 +515,15 @@ void rcc_clock_setup_hsi(const clock_scale_t *clock)
 	rcc_ppre2_frequency = clock->apb2_frequency;
 }
 
+void rcc_clock_setup_pll_osc(const osc_t osc, const clock_scale_t *clock)
+{
+	rcc_osc_on(osc);
+	rcc_wait_for_osc_ready(osc);
+	rcc_clock_setup_pll(clock);
+}
+
 void rcc_clock_setup_pll(const clock_scale_t *clock)
 {
-	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
-
 	/*
 	 * Set prescalers for AHB, ADC, ABP1, ABP2.
 	 * Do this before touching the PLL (TODO: why?).


### PR DESCRIPTION
The old pll routine was hardcoded to use HSI, that was pretty lame.
This is less lame, but not entirely backwards compatible.  Should
probably look at overhauling the entire clock setup stuff?

Is this less lame enough? Thoughts?
