### PR TITLE
[stm32f3] Properly turn on the FPU

### DIFF
--- a/lib/dispatch/vector_chipset.c
+++ b/lib/dispatch/vector_chipset.c
@@ -1,6 +1,7 @@
-#if defined(STM32F4)
+#if defined(STM32F3)
+#	include "../stm32/f3/vector_chipset.c"
+#elif defined(STM32F4)
 #	include "../stm32/f4/vector_chipset.c"
-
 #elif defined(LPC43XX_M4)
 #	include "../lpc43xx/m4/vector_chipset.c"
 


### PR DESCRIPTION
The vector chipset file was added, but not included in the dispatcher.
Fixes github issue #201

This is not actually _tested_ as I don't have any F3 boards, but this gets the code ready for someone to do so!
