### PR TITLE
update of the HACKING document

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -64,16 +64,7 @@ Development guidelines
  - Variables that are used to store register values read from registers or
    to be stored in a register should be named reg8, reg16, reg32 etc.
 
- - In the examples directory, the following structure should be used:
-
-    - One (or more) subdirectories for the type of microcontroller, e.g.
-      lm3s, lpc13xx, stm32/f1, stm32/f2, stm32/f4.
-
-    - One subdirectory in there for each eval board or piece of hardware, e.g.
-      stm32-h103, lisa-m, stm32vl-discovery, stm32f4-discovery, etc.
-
-    - One subdirectory in there for each example, e.g.
-      miniblink, button, usart, usb_dfu, etc.
+ - For examples on using libopencm3 see the libopencm3-examples repository.
 
 Tips and tricks
 ---------------


### PR DESCRIPTION
The HACKING document was inconsistent in regard to the use of the stdint-types.
Also the description of the file structure of the examples does not really belong here, since the examples were split from the library. Maybe we should add a HACKING document to the libopencm3-examples repository and put this description there.
