### PR TITLE
[STM32F2-F4:CRYPTO]Fix hash_set_last_word_valid_bits()

### DIFF
--- a/lib/stm32/common/hash_common_f24.c
+++ b/lib/stm32/common/hash_common_f24.c
@@ -99,7 +99,7 @@ Specifies the number of valid bits in the last word.
 void hash_set_last_word_valid_bits(uint8_t validbits)
 {
 	HASH_STR &= ~(HASH_STR_NBW);
-	HASH_STR |= 32 - validbits;
+	HASH_STR |= validbits;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
/**
- @brief Configure the Number of valid bits in last word of the message
- @param ValidNumber: Number of valid bits in last word of the message.
- This parameter must be a number between 0 and 0x1F.
- \- 0x00: All 32 bits of the last data written are valid
- \- 0x01: Only bit [0] of the last data written is valid
- \- 0x02: Only bits[1:0] of the last data written are valid
- \- 0x03: Only bits[2:0] of the last data written are valid
- \- ...
- \- 0x1F: Only bits[30:0] of the last data written are valid
- @note The Number of valid bits must be set before to start the message
- digest competition (in Hash and HMAC) and key treatment(in HMAC).
- @retval None
  */

void HASH_SetLastWordValidBitsNbr(uint16_t ValidNumber)
{
/\* Check the parameters _/
assert_param(IS_HASH_VALIDBITSNUMBER(ValidNumber));
/_ Configure the Number of valid bits in last word of the message */
HASH->STR &= ~(HASH_STR_NBW);
HASH->STR |= ValidNumber;
}

This from StdPeriph

P.S. No need subtraction.
just hash_set_last_word_valid_bits(8 \* (len % 4))
