### PR TITLE
[swo] Add/Update definitions necessary for SWO to work

### DIFF
--- a/include/libopencm3/cm3/fpb.h
+++ b/include/libopencm3/cm3/fpb.h
@@ -40,6 +40,12 @@
 /* Flash Patch Comparator (FPB_COMPx) */
 #define FPB_COMP			(&MMIO32(FPB_BASE + 8))
 
+/* CoreSight Lock Status Register for this peripheral */
+#define FPB_LSR				MMIO32(FPB_BASE + 0xFB4)
+/* CoreSight Lock Access Register for this peripheral */
+#define FPB_LAR				MMIO32(FPB_BASE + 0xFB0)
+
+
 /* TODO: PID, CID */
 
 /* --- FPB_CTRL values ----------------------------------------------------- */

--- a/include/libopencm3/cm3/itm.h
+++ b/include/libopencm3/cm3/itm.h
@@ -29,8 +29,10 @@
 
 /* --- ITM registers ------------------------------------------------------- */
 
-/* Stimulus Port x (ITM_STIM[x]) */
-#define ITM_STIM			(&MMIO32(ITM_BASE))
+/* Stimulus Port x (ITM_STIM<sz>(x)) */
+#define ITM_STIM8(n)			(MMIO8(ITM_BASE + (n*4)))
+#define ITM_STIM16(n)			(MMIO16(ITM_BASE + (n*4)))
+#define ITM_STIM32(n)			(MMIO32(ITM_BASE + (n*4)))
 
 /* Trace Enable ports (ITM_TER[x]) */
 #define ITM_TER				(&MMIO32(ITM_BASE + 0xE00))
@@ -40,6 +42,11 @@
 
 /* Trace Control (ITM_TCR) */
 #define ITM_TCR				MMIO32(ITM_BASE + 0xE80)
+
+/* CoreSight Lock Status Register for this peripheral */
+#define ITM_LSR			MMIO32(ITM_BASE + 0xFB4)
+/* CoreSight Lock Access Register for this peripheral */
+#define ITM_LAR			MMIO32(ITM_BASE + 0xFB0)
 
 /* TODO: PID, CID */
 

--- a/include/libopencm3/cm3/memorymap.h
+++ b/include/libopencm3/cm3/memorymap.h
@@ -48,15 +48,6 @@
 #define TPIU_BASE                       (PPBI_BASE + 0x40000)
 #endif
 
-/* --- ITM: Instrumentation Trace Macrocell --- */
-/* TODO */
-
-/* --- DWT: Data Watchpoint and Trace unit --- */
-/* TODO */
-
-/* --- FPB: Flash Patch and Breakpoint unit --- */
-/* TODO */
-
 /* --- SCS: System Control Space --- */
 
 /* Those defined only on ARMv7 and above */

--- a/include/libopencm3/cm3/scs.h
+++ b/include/libopencm3/cm3/scs.h
@@ -308,6 +308,11 @@
 /* DWT_PCSR register */
 #define SCS_DWT_PCSR		MMIO32(DWT_BASE + 0x18)
 
+/* CoreSight Lock Status Register for this peripheral */
+#define SCS_DWT_LSR		MMIO32(SCS_DWT_BASE + 0xFB4)
+/* CoreSight Lock Access Register for this peripheral */
+#define SCS_DWT_LAR		MMIO32(SCS_DWT_BASE + 0xFB0)
+
 /* --- SCS_DWT_CTRL values ------------------------------------------------- */
 /*
  * Enables CYCCNT:
@@ -315,6 +320,13 @@
  * This bit is UNK/SBZP if the NOCYCCNT bit is RAO.
  */
 #define SCS_DWT_CTRL_CYCCNTENA	(BIT0)
+
+/* CoreSight Lock Status Register lock status bit */
+#define SCS_LSR_SLK		(1<<1)
+/* CoreSight Lock Status Register lock availability bit */
+#define SCS_LSR_SLI		(1<<0)
+/* CoreSight Lock Access key, common for all */
+#define SCS_LAR_KEY		0xC5ACCE55
 
 /* TODO bit definition values for other DWT_XXX register */
 

--- a/include/libopencm3/cm3/tpiu.h
+++ b/include/libopencm3/cm3/tpiu.h
@@ -50,24 +50,12 @@
 /* (TPIU_DEVID) */
 #define TPIU_DEVID			MMIO32(TPIU_BASE + 0xFC8)
 
+/* CoreSight Lock Status Register for this peripheral */
+#define TPIU_LSR			MMIO32(TPIU_BASE + 0xFB4)
+/* CoreSight Lock Access Register for this peripheral */
+#define TPIU_LAR			MMIO32(TPIU_BASE + 0xFB0)
+
 /* TODO: PID, CID */
-
-/* --- TPIU_SSPSR values --------------------------------------------------- */
-
-/*
- * bit[N] == 0, trace port width of (N+1) not supported
- * bit[N] == 1, trace port width of (N+1) supported
- */
-#define TPIU_SSPSR_BYTE			(1 << 0)
-#define TPIU_SSPSR_HALFWORD		(1 << 1)
-#define TPIU_SSPSR_WORD			(1 << 3)
-
-/* --- TPIU_SSPSR values --------------------------------------------------- */
-
-/* Same format as TPIU_SSPSR, except only one is set */
-#define TPIU_CSPSR_BYTE			(1 << 0)
-#define TPIU_CSPSR_HALFWORD		(1 << 1)
-#define TPIU_CSPSR_WORD			(1 << 3)
 
 /* --- TPIU_ACPR values ---------------------------------------------------- */
 


### PR DESCRIPTION
ITM Stimulus ports need to be accessible with different sizes

The amount of data written out is determined by the size of the write.
Writing a full 32 bit value when you only need 8 for printf() style
substantially reduces the available bandwidth of the SWO

Note: this is an API change for doing 32bit writes.
Old:
    ITM_STIM[stimulus_port] = value
New:
    ITM_STIM32(stimulus_port) = value

This api is much more in common with some of the other registers that
behave this way.  As there's very little (if any) code already using
this API, it's a good time to fix it permanently.  (I have a corresponding change to the examples repository for this)

Remove misleading ITM register definitions

ITM_SSPSR is the supported parallel trace size, in _bits_
ITM_CSPSR is in _bits_ as well.  There's really no advantage in even
having these sorts of definitions in libopencm3, as these settings are
normally controlled from the debugger side, not the target itself.

Lock and lock status register definitions were added, as per ARM:
  "For ARMv7-M, the component ID registers are required for the ROM table,
   and the CoreSight management lock access mechanism is defined for the
   DWT, ITM, FPB and TPIU blocks."
