### PR TITLE
[stm32l] memorymap entries for ST calibration data

### DIFF
--- a/include/libopencm3/stm32/l1/memorymap.h
+++ b/include/libopencm3/stm32/l1/memorymap.h
@@ -108,6 +108,11 @@
 #define DESIG_FLASH_SIZE_BASE           (INFO_BASE + 0x8004C)
 #define DESIG_UNIQUE_ID_BASE            (INFO_BASE + 0x80050)
 
+/* ST provided factory calibration values @ 3.0V */
+#define ST_VREFINT_CAL			MMIO16(0x1FF80078)
+#define ST_TSENSE_CAL1_30C		MMIO16(0x1FF8007A)
+#define ST_TSENSE_CAL2_110C		MMIO16(0x1FF8007E)
+
 /* Make the map names match those for other families to allow commonality */
 #define SPI1_I2S_BASE       SPI1_BASE
 #define SPI2_I2S_BASE       SPI2_BASE


### PR DESCRIPTION
Didn't find this with cursory inspection on other chips.
