### PR TITLE
STM32: ADC peripheral style 1 header unification

### DIFF
--- a/include/libopencm3/stm32/adc.h
+++ b/include/libopencm3/stm32/adc.h
@@ -25,6 +25,8 @@
 #       include <libopencm3/stm32/f3/adc.h>
 #elif defined(STM32F4)
 #       include <libopencm3/stm32/f4/adc.h>
+#elif defined(STM32L1)
+#       include <libopencm3/stm32/l1/adc.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/common/adc_common_v1.h
+++ b/include/libopencm3/stm32/common/adc_common_v1.h
@@ -1,0 +1,352 @@
+/** @addtogroup adc_defines
+
+@author @htmlonly &copy; @endhtmlonly 2014 Karl Palsson <karlp@tweak.net.au>
+
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2014 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA ADC.H
+The order of header inclusion is important. adc.h includes the device
+specific memorymap.h header before including this header file.*/
+
+/** @cond */
+#ifdef LIBOPENCM3_ADC_H
+/** @endcond */
+#ifndef LIBOPENCM3_ADC_COMMON_V1_H
+#define LIBOPENCM3_ADC_COMMON_V1_H
+
+#include <libopencm3/cm3/common.h>
+
+/* --- Convenience macros -------------------------------------------------- */
+
+/* ADC port base addresses (for convenience) */
+/****************************************************************************/
+/** @defgroup adc_reg_base ADC register base addresses
+@ingroup STM32xx_adc_defines
+
+@{*/
+#define ADC1                            ADC1_BASE
+/**@}*/
+
+/* --- ADC registers ------------------------------------------------------- */
+
+/* ADC status register (ADC_SR) */
+#define ADC_SR(block)                   MMIO32(block + 0x00)
+
+/* ADC control register 1 (ADC_CR1) */
+#define ADC_CR1(block)                  MMIO32(block + 0x04)
+
+/* ADC control register 2 (ADC_CR2) */
+#define ADC_CR2(block)                  MMIO32(block + 0x08)
+
+/* ADC sample time register 1 (ADC_SMPR1) */
+#define ADC_SMPR1(block)                MMIO32(block + 0x0c)
+
+/* ADC sample time register 2 (ADC_SMPR2) */
+#define ADC_SMPR2(block)                MMIO32(block + 0x10)
+
+#define ADC1_SR                         ADC_SR(ADC1)
+#define ADC1_CR1                        ADC_CR1(ADC1)
+#define ADC1_CR2                        ADC_CR2(ADC1)
+#define ADC1_SMPR1                      ADC_SMPR1(ADC1)
+#define ADC1_SMPR2                      ADC_SMPR2(ADC1)
+
+#define ADC1_JOFR1                      ADC_JOFR1(ADC1)
+#define ADC1_JOFR2                      ADC_JOFR2(ADC1)
+#define ADC1_JOFR3                      ADC_JOFR3(ADC1)
+#define ADC1_JOFR4                      ADC_JOFR4(ADC1)
+
+#if defined(ADC2_BASE)
+#define ADC2                            ADC2_BASE
+#define ADC2_SR                         ADC_SR(ADC2)
+#define ADC2_CR1                        ADC_CR1(ADC2)
+#define ADC2_CR2                        ADC_CR2(ADC2)
+#define ADC2_SMPR1                      ADC_SMPR1(ADC2)
+#define ADC2_SMPR2                      ADC_SMPR2(ADC2)
+
+#define ADC2_JOFR1                      ADC_JOFR1(ADC2)
+#define ADC2_JOFR2                      ADC_JOFR2(ADC2)
+#define ADC2_JOFR3                      ADC_JOFR3(ADC2)
+#define ADC2_JOFR4                      ADC_JOFR4(ADC2)
+
+/* ADC watchdog high threshold register (ADC_HTR) */
+#define ADC2_HTR                        ADC_HTR(ADC2)
+/* ADC watchdog low threshold register (ADC_LTR) */
+#define ADC2_LTR                        ADC_LTR(ADC2)
+
+/* ADC regular sequence register 1 (ADC_SQR1) */
+#define ADC2_SQR1                       ADC_SQR1(ADC2)
+/* ADC regular sequence register 2 (ADC_SQR2) */
+#define ADC2_SQR2                       ADC_SQR2(ADC2)
+/* ADC regular sequence register 3 (ADC_SQR3) */
+#define ADC2_SQR3                       ADC_SQR3(ADC2)
+/* ADC injected sequence register (ADC_JSQR) */
+#define ADC2_JSQR                       ADC_JSQR(ADC2)
+
+/* ADC injected data register x (ADC_JDRx) (x=1..4) */
+#define ADC2_JDR1                       ADC_JDR1(ADC2)
+#define ADC2_JDR2                       ADC_JDR2(ADC2)
+#define ADC2_JDR3                       ADC_JDR3(ADC2)
+#define ADC2_JDR4                       ADC_JDR4(ADC2)
+/* ADC regular data register (ADC_DR) */
+#define ADC2_DR                         ADC_DR(ADC2)
+#endif
+
+#if defined(ADC3_BASE)
+#define ADC3                            ADC3_BASE
+#define ADC3_SR                         ADC_SR(ADC3)
+#define ADC3_CR1                        ADC_CR1(ADC3)
+#define ADC3_CR2                        ADC_CR2(ADC3)
+#define ADC3_SMPR1                      ADC_SMPR1(ADC3)
+#define ADC3_SMPR2                      ADC_SMPR2(ADC3)
+
+#define ADC3_JOFR1                      ADC_JOFR1(ADC3)
+#define ADC3_JOFR2                      ADC_JOFR2(ADC3)
+#define ADC3_JOFR3                      ADC_JOFR3(ADC3)
+#define ADC3_JOFR4                      ADC_JOFR4(ADC3)
+
+#define ADC3_HTR                        ADC_HTR(ADC3)
+#define ADC3_LTR                        ADC_LTR(ADC3)
+
+#define ADC3_SQR1                       ADC_SQR1(ADC3)
+#define ADC3_SQR2                       ADC_SQR2(ADC3)
+#define ADC3_SQR3                       ADC_SQR3(ADC3)
+#define ADC3_JSQR                       ADC_JSQR(ADC3)
+
+#define ADC3_JDR1                       ADC_JDR1(ADC3)
+#define ADC3_JDR2                       ADC_JDR2(ADC3)
+#define ADC3_JDR3                       ADC_JDR3(ADC3)
+#define ADC3_JDR4                       ADC_JDR4(ADC3)
+#define ADC3_DR                         ADC_DR(ADC3)
+#endif
+
+
+
+/* --- ADC Channels ------------------------------------------------------- */
+
+/****************************************************************************/
+/** @defgroup adc_channel ADC Channel Numbers
+@ingroup STM32xx_adc_defines
+
+@{*/
+#define ADC_CHANNEL0		0x00
+#define ADC_CHANNEL1		0x01
+#define ADC_CHANNEL2		0x02
+#define ADC_CHANNEL3		0x03
+#define ADC_CHANNEL4		0x04
+#define ADC_CHANNEL5		0x05
+#define ADC_CHANNEL6		0x06
+#define ADC_CHANNEL7		0x07
+#define ADC_CHANNEL8		0x08
+#define ADC_CHANNEL9            0x09
+#define ADC_CHANNEL10           0x0A
+#define ADC_CHANNEL11           0x0B
+#define ADC_CHANNEL12           0x0C
+#define ADC_CHANNEL13           0x0D
+#define ADC_CHANNEL14           0x0E
+#define ADC_CHANNEL15           0x0F
+#define ADC_CHANNEL16           0x10
+#define ADC_CHANNEL17           0x11
+#define ADC_CHANNEL18           0x12
+
+#define ADC_CHANNEL_MASK        0x1F
+
+
+/* --- ADC_SR values ------------------------------------------------------- */
+
+#define ADC_SR_STRT                     (1 << 4)
+#define ADC_SR_JSTRT                    (1 << 3)
+#define ADC_SR_JEOC                     (1 << 2)
+#define ADC_SR_EOC                      (1 << 1)
+#define ADC_SR_AWD                      (1 << 0)
+
+/* --- ADC_CR1 values ------------------------------------------------------ */
+
+/* AWDEN: Analog watchdog enable on regular channels */
+#define ADC_CR1_AWDEN                   (1 << 23)
+
+/* JAWDEN: Analog watchdog enable on injected channels */
+#define ADC_CR1_JAWDEN                  (1 << 22)
+
+/* Note: Bits [21:20] are reserved, and must be kept at reset value. */
+
+
+/* DISCNUM[2:0]: Discontinuous mode channel count. */
+/****************************************************************************/
+/** @defgroup adc_cr1_discnum ADC Number of channels in discontinuous mode.
+@ingroup STM32_adc_defines
+
+@{*/
+#define ADC_CR1_DISCNUM_1CHANNELS       (0x0 << 13)
+#define ADC_CR1_DISCNUM_2CHANNELS       (0x1 << 13)
+#define ADC_CR1_DISCNUM_3CHANNELS       (0x2 << 13)
+#define ADC_CR1_DISCNUM_4CHANNELS       (0x3 << 13)
+#define ADC_CR1_DISCNUM_5CHANNELS       (0x4 << 13)
+#define ADC_CR1_DISCNUM_6CHANNELS       (0x5 << 13)
+#define ADC_CR1_DISCNUM_7CHANNELS       (0x6 << 13)
+#define ADC_CR1_DISCNUM_8CHANNELS       (0x7 << 13)
+/**@}*/
+#define ADC_CR1_DISCNUM_MASK            (0x7 << 13)
+#define ADC_CR1_DISCNUM_SHIFT           13
+
+/* JDISCEN: */ /** Discontinuous mode on injected channels. */
+#define ADC_CR1_JDISCEN                 (1 << 12)
+
+/* DISCEN: */ /** Discontinuous mode on regular channels. */
+#define ADC_CR1_DISCEN                  (1 << 11)
+
+/* JAUTO: */ /** Automatic Injection Group conversion. */
+#define ADC_CR1_JAUTO                   (1 << 10)
+
+/* AWDSGL: */ /** Enable the watchdog on a single channel in scan mode. */
+#define ADC_CR1_AWDSGL                  (1 << 9)
+
+/* SCAN: */ /** Scan mode. */
+#define ADC_CR1_SCAN                    (1 << 8)
+
+/* JEOCIE: */ /** Interrupt enable for injected channels. */
+#define ADC_CR1_JEOCIE                  (1 << 7)
+
+/* AWDIE: */ /** Analog watchdog interrupt enable. */
+#define ADC_CR1_AWDIE                   (1 << 6)
+
+/* EOCIE: */ /** Interrupt enable EOC. */
+#define ADC_CR1_EOCIE                   (1 << 5)
+
+/* AWDCH[4:0]: Analog watchdog channel bits. (Up to 17 other values reserved) */
+/* Notes: Depending on part, and ADC peripheral, some channels are connected
+ * to V_SS, or to temperature/reference/battery inputs
+ */
+/****************************************************************************/
+/* ADC_CR1 AWDCH[4:0] ADC watchdog channel */
+/** @defgroup adc_watchdog_channel ADC watchdog channel
+@ingroup STM32xx_adc_defines
+
+@{*/
+#define ADC_CR1_AWDCH_CHANNEL0          (0x00 << 0)
+#define ADC_CR1_AWDCH_CHANNEL1          (0x01 << 0)
+#define ADC_CR1_AWDCH_CHANNEL2          (0x02 << 0)
+#define ADC_CR1_AWDCH_CHANNEL3          (0x03 << 0)
+#define ADC_CR1_AWDCH_CHANNEL4          (0x04 << 0)
+#define ADC_CR1_AWDCH_CHANNEL5          (0x05 << 0)
+#define ADC_CR1_AWDCH_CHANNEL6          (0x06 << 0)
+#define ADC_CR1_AWDCH_CHANNEL7          (0x07 << 0)
+#define ADC_CR1_AWDCH_CHANNEL8          (0x08 << 0)
+#define ADC_CR1_AWDCH_CHANNEL9          (0x09 << 0)
+#define ADC_CR1_AWDCH_CHANNEL10         (0x0A << 0)
+#define ADC_CR1_AWDCH_CHANNEL11         (0x0B << 0)
+#define ADC_CR1_AWDCH_CHANNEL12         (0x0C << 0)
+#define ADC_CR1_AWDCH_CHANNEL13         (0x0D << 0)
+#define ADC_CR1_AWDCH_CHANNEL14         (0x0E << 0)
+#define ADC_CR1_AWDCH_CHANNEL15         (0x0F << 0)
+#define ADC_CR1_AWDCH_CHANNEL16         (0x10 << 0)
+#define ADC_CR1_AWDCH_CHANNEL17         (0x11 << 0)
+/**@}*/
+#define ADC_CR1_AWDCH_MASK              (0x1F << 0)
+#define ADC_CR1_AWDCH_SHIFT             0
+
+/* --- ADC_CR2 values ------------------------------------------------------ */
+
+/* ALIGN: Data alignement. */
+#define ADC_CR2_ALIGN_RIGHT             (0 << 11)
+#define ADC_CR2_ALIGN_LEFT              (1 << 11)
+#define ADC_CR2_ALIGN                   (1 << 11)
+
+/* DMA: Direct memory access mode. (ADC1 and ADC3 only!) */
+#define ADC_CR2_DMA                     (1 << 8)
+
+/* CONT: Continous conversion. */
+#define ADC_CR2_CONT                    (1 << 1)
+
+/* ADON: A/D converter On/Off. */
+/* Note: If any other bit in this register apart from ADON is changed at the
+ * same time, then conversion is not triggered. This is to prevent triggering
+ * an erroneous conversion.
+ * Conclusion: Must be separately written.
+ */
+#define ADC_CR2_ADON                    (1 << 0)
+
+/* --- ADC_JOFRx, ADC_HTR, ADC_LTR values ---------------------------------- */
+
+#define ADC_JOFFSET_LSB                 0
+#define ADC_JOFFSET_MSK                 (0x7ff << 0)
+#define ADC_HT_LSB                      0
+#define ADC_HT_MSK                      (0x7ff << 0)
+#define ADC_LT_LSB                      0
+#define ADC_LT_MSK                      (0x7ff << 0)
+
+/* --- ADC_SQR1 values ----------------------------------------------------- */
+/* The sequence length field is always in the same place, but sized 
+ * differently on various parts */
+#define ADC_SQR1_L_LSB                  20
+
+/* --- ADC_JSQR values ----------------------------------------------------- */
+#define ADC_JSQR_JL_LSB                 20
+#define ADC_JSQR_JSQ4_LSB               15
+#define ADC_JSQR_JSQ3_LSB               10
+#define ADC_JSQR_JSQ2_LSB               5
+#define ADC_JSQR_JSQ1_LSB               0
+
+/* JL[2:0]: Discontinous mode channel count injected channels. */
+/****************************************************************************/
+/** @defgroup adc_jsqr_jl ADC Number of channels in discontinuous injected mode
+@ingroup STM32xx_adc_defines
+
+@{*/
+#define ADC_JSQR_JL_1CHANNELS       (0x0 << ADC_JSQR_JL_LSB)
+#define ADC_JSQR_JL_2CHANNELS       (0x1 << ADC_JSQR_JL_LSB)
+#define ADC_JSQR_JL_3CHANNELS       (0x2 << ADC_JSQR_JL_LSB)
+#define ADC_JSQR_JL_4CHANNELS       (0x3 << ADC_JSQR_JL_LSB)
+/**@}*/
+#define ADC_JSQR_JL_SHIFT               13
+#define ADC_JSQR_JL_MSK                 (0x2 << ADC_JSQR_JL_LSB)
+#define ADC_JSQR_JSQ4_MSK               (0x1f << ADC_JSQR_JSQ4_LSB)
+#define ADC_JSQR_JSQ3_MSK               (0x1f << ADC_JSQR_JSQ3_LSB)
+#define ADC_JSQR_JSQ2_MSK               (0x1f << ADC_JSQR_JSQ2_LSB)
+#define ADC_JSQR_JSQ1_MSK               (0x1f << ADC_JSQR_JSQ1_LSB)
+
+#define ADC_JSQR_JSQ_VAL(n, val)	((val) << (((n) - 1) * 5))
+#define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
+
+#if (defined(THESE_HAVE_BAD_NAMES_PROBABLY) && (THESE_HAVE_BAD_NAMES_PROBABLY))
+/* --- ADC_JDRx, ADC_DR values --------------------------------------------- */
+
+#define ADC_JDATA_LSB                   0
+#define ADC_DATA_LSB                    0
+#define ADC_ADC2DATA_LSB                16 /* ADC1 only (dual mode) */
+#define ADC_JDATA_MSK                   (0xffff << ADC_JDATA_LSB)
+#define ADC_DATA_MSK                    (0xffff << ADC_DA)
+#define ADC_ADC2DATA_MSK                (0xffff << ADC_ADC2DATA_LSB)
+/* ADC1 only (dual mode) */
+#endif
+
+
+/* --- Function prototypes ------------------------------------------------- */
+
+BEGIN_DECLS
+
+END_DECLS
+
+#endif
+#endif	/* ADC_COMMON_V1_H */
+/**@}*/

--- a/include/libopencm3/stm32/f1/adc.h
+++ b/include/libopencm3/stm32/f1/adc.h
@@ -38,176 +38,51 @@ LGPL License Terms @ref lgpl_license
 #ifndef LIBOPENCM3_ADC_H
 #define LIBOPENCM3_ADC_H
 
-#include <libopencm3/stm32/memorymap.h>
 #include <libopencm3/cm3/common.h>
+#include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/common/adc_common_v1.h>
 
 /* --- Convenience macros -------------------------------------------------- */
-
-/* ADC port base addresses (for convenience) */
-/****************************************************************************/
-/** @defgroup adc_reg_base ADC register base addresses
-@ingroup adc_defines
-
-@{*/
-#define ADC1				ADC1_BASE
-#define ADC2				ADC2_BASE
-#define ADC3				ADC3_BASE
-/**@}*/
-
-/* --- ADC registers ------------------------------------------------------- */
-
-/* ADC status register (ADC_SR) */
-#define ADC_SR(block)			MMIO32(block + 0x00)
-#define ADC1_SR				ADC_SR(ADC1)
-#define ADC2_SR				ADC_SR(ADC2)
-#define ADC3_SR				ADC_SR(ADC3)
-
-/* ADC control register 1 (ADC_CR1) */
-#define ADC_CR1(block)			MMIO32(block + 0x04)
-#define ADC1_CR1			ADC_CR1(ADC1)
-#define ADC2_CR1			ADC_CR1(ADC2)
-#define ADC3_CR1			ADC_CR1(ADC3)
-
-/* ADC control register 2 (ADC_CR2) */
-#define ADC_CR2(block)			MMIO32(block + 0x08)
-#define ADC1_CR2			ADC_CR2(ADC1)
-#define ADC2_CR2			ADC_CR2(ADC2)
-#define ADC3_CR2			ADC_CR2(ADC3)
-
-/* ADC sample time register 1 (ADC_SMPR1) */
-#define ADC_SMPR1(block)		MMIO32(block + 0x0c)
-#define ADC1_SMPR1			ADC_SMPR1(ADC1)
-#define ADC2_SMPR1			ADC_SMPR1(ADC2)
-#define ADC3_SMPR1			ADC_SMPR1(ADC3)
-
-/* ADC sample time register 2 (ADC_SMPR2) */
-#define ADC_SMPR2(block)		MMIO32(block + 0x10)
-#define ADC1_SMPR2			ADC_SMPR2(ADC1)
-#define ADC2_SMPR2			ADC_SMPR2(ADC2)
-#define ADC3_SMPR2			ADC_SMPR2(ADC3)
 
 /* ADC injected channel data offset register x (ADC_JOFRx) (x=1..4) */
 #define ADC_JOFR1(block)		MMIO32(block + 0x14)
 #define ADC_JOFR2(block)		MMIO32(block + 0x18)
 #define ADC_JOFR3(block)		MMIO32(block + 0x1c)
 #define ADC_JOFR4(block)		MMIO32(block + 0x20)
-#define ADC1_JOFR1			ADC_JOFR1(ADC1)
-#define ADC2_JOFR1			ADC_JOFR1(ADC2)
-#define ADC3_JOFR1			ADC_JOFR1(ADC3)
-#define ADC1_JOFR2			ADC_JOFR2(ADC1)
-#define ADC2_JOFR2			ADC_JOFR2(ADC2)
-#define ADC3_JOFR2			ADC_JOFR2(ADC3)
-#define ADC1_JOFR3			ADC_JOFR3(ADC1)
-#define ADC2_JOFR3			ADC_JOFR3(ADC2)
-#define ADC3_JOFR3			ADC_JOFR3(ADC3)
-#define ADC1_JOFR4			ADC_JOFR4(ADC1)
-#define ADC2_JOFR4			ADC_JOFR4(ADC2)
-#define ADC3_JOFR4			ADC_JOFR4(ADC3)
 
 /* ADC watchdog high threshold register (ADC_HTR) */
 #define ADC_HTR(block)			MMIO32(block + 0x24)
-#define ADC1_HTR			ADC_HTR(ADC1)
-#define ADC2_HTR			ADC_HTR(ADC2)
-#define ADC3_HTR			ADC_HTR(ADC3)
 
 /* ADC watchdog low threshold register (ADC_LTR) */
 #define ADC_LTR(block)			MMIO32(block + 0x28)
-#define ADC1_LTR			ADC_LTR(ADC1_BASE)
-#define ADC2_LTR			ADC_LTR(ADC2_BASE)
-#define ADC3_LTR			ADC_LTR(ADC3_BASE)
 
 /* ADC regular sequence register 1 (ADC_SQR1) */
 #define ADC_SQR1(block)			MMIO32(block + 0x2c)
-#define ADC1_SQR1			ADC_SQR1(ADC1)
-#define ADC2_SQR1			ADC_SQR1(ADC2)
-#define ADC3_SQR1			ADC_SQR1(ADC3)
 
 /* ADC regular sequence register 2 (ADC_SQR2) */
 #define ADC_SQR2(block)			MMIO32(block + 0x30)
-#define ADC1_SQR2			ADC_SQR2(ADC1)
-#define ADC2_SQR2			ADC_SQR2(ADC2)
-#define ADC3_SQR2			ADC_SQR2(ADC3)
 
 /* ADC regular sequence register 3 (ADC_SQR3) */
 #define ADC_SQR3(block)			MMIO32(block + 0x34)
-#define ADC1_SQR3			ADC_SQR3(ADC1)
-#define ADC2_SQR3			ADC_SQR3(ADC2)
-#define ADC3_SQR3			ADC_SQR3(ADC3)
 
 /* ADC injected sequence register (ADC_JSQR) */
 #define ADC_JSQR(block)			MMIO32(block + 0x38)
-#define ADC1_JSQR			ADC_JSQR(ADC1_BASE)
-#define ADC2_JSQR			ADC_JSQR(ADC2_BASE)
-#define ADC3_JSQR			ADC_JSQR(ADC3_BASE)
 
 /* ADC injected data register x (ADC_JDRx) (x=1..4) */
 #define ADC_JDR1(block)			MMIO32(block + 0x3c)
 #define ADC_JDR2(block)			MMIO32(block + 0x40)
 #define ADC_JDR3(block)			MMIO32(block + 0x44)
 #define ADC_JDR4(block)			MMIO32(block + 0x48)
-#define ADC1_JDR1			ADC_JDR1(ADC1)
-#define ADC2_JDR1			ADC_JDR1(ADC2)
-#define ADC3_JDR1			ADC_JDR1(ADC3)
-#define ADC1_JDR2			ADC_JDR2(ADC1)
-#define ADC2_JDR2			ADC_JDR2(ADC2)
-#define ADC3_JDR2			ADC_JDR2(ADC3)
-#define ADC1_JDR3			ADC_JDR3(ADC1)
-#define ADC2_JDR3			ADC_JDR3(ADC2)
-#define ADC3_JDR3			ADC_JDR3(ADC3)
-#define ADC1_JDR4			ADC_JDR4(ADC1)
-#define ADC2_JDR4			ADC_JDR4(ADC2)
-#define ADC3_JDR4			ADC_JDR4(ADC3)
 
 /* ADC regular data register (ADC_DR) */
 #define ADC_DR(block)			MMIO32(block + 0x4c)
-#define ADC1_DR				ADC_DR(ADC1)
-#define ADC2_DR				ADC_DR(ADC2)
-#define ADC3_DR				ADC_DR(ADC3)
 
 /* --- ADC Channels ------------------------------------------------------- */
+#define ADC_CHANNEL_TEMP        ADC_CHANNEL16
+#define ADC_CHANNEL_VREFINT     ADC_CHANNEL17
 
-/****************************************************************************/
-/** @defgroup adc_channel ADC Channel Numbers
-@ingroup adc_defines
-
-@{*/
-#define ADC_CHANNEL0		0x00
-#define ADC_CHANNEL1		0x01
-#define ADC_CHANNEL2		0x02
-#define ADC_CHANNEL3		0x03
-#define ADC_CHANNEL4		0x04
-#define ADC_CHANNEL5		0x05
-#define ADC_CHANNEL6		0x06
-#define ADC_CHANNEL7		0x07
-#define ADC_CHANNEL8		0x08
-#define ADC_CHANNEL9		0x09
-#define ADC_CHANNEL10		0x0A
-#define ADC_CHANNEL11		0x0B
-#define ADC_CHANNEL12		0x0C
-#define ADC_CHANNEL13		0x0D
-#define ADC_CHANNEL14		0x0E
-#define ADC_CHANNEL15		0x0F
-#define ADC_CHANNEL16		0x10
-#define ADC_CHANNEL17		0x11
-/**@}*/
-#define ADC_MASK		    0x1F
-#define ADC_SHIFT		    0
-
-/* --- ADC_SR values ------------------------------------------------------- */
-
-#define ADC_SR_STRT			(1 << 4)
-#define ADC_SR_JSTRT			(1 << 3)
-#define ADC_SR_JEOC			(1 << 2)
-#define ADC_SR_EOC			(1 << 1)
-#define ADC_SR_AWD			(1 << 0)
 
 /* --- ADC_CR1 values ------------------------------------------------------ */
-
-/* AWDEN: Analog watchdog enable on regular channels */
-#define ADC_CR1_AWDEN			(1 << 23)
-
-/* JAWDEN: Analog watchdog enable on injected channels */
-#define ADC_CR1_JAWDEN			(1 << 22)
 
 /* Note: Bits [21:20] are reserved, and must be kept at reset value. */
 
@@ -254,82 +129,6 @@ LGPL License Terms @ref lgpl_license
 #define ADC_CR1_DUALMOD_MASK		(0xF << 16)
 #define ADC_CR1_DUALMOD_SHIFT		16
 
-/* DISCNUM[2:0]: Discontinuous mode channel count. */
-/****************************************************************************/
-/** @defgroup adc_cr1_discnum ADC Number of channels in discontinuous mode.
-@ingroup adc_defines
-
-@{*/
-#define ADC_CR1_DISCNUM_1CHANNELS       (0x0 << 13)
-#define ADC_CR1_DISCNUM_2CHANNELS       (0x1 << 13)
-#define ADC_CR1_DISCNUM_3CHANNELS       (0x2 << 13)
-#define ADC_CR1_DISCNUM_4CHANNELS       (0x3 << 13)
-#define ADC_CR1_DISCNUM_5CHANNELS       (0x4 << 13)
-#define ADC_CR1_DISCNUM_6CHANNELS       (0x5 << 13)
-#define ADC_CR1_DISCNUM_7CHANNELS       (0x6 << 13)
-#define ADC_CR1_DISCNUM_8CHANNELS       (0x7 << 13)
-/**@}*/
-#define ADC_CR1_DISCNUM_MASK		(0x7 << 13)
-#define ADC_CR1_DISCNUM_SHIFT		13
-
-/* JDISCEN: */ /** Discontinuous mode on injected channels. */
-#define ADC_CR1_JDISCEN			(1 << 12)
-
-/* DISCEN: */ /** Discontinuous mode on regular channels. */
-#define ADC_CR1_DISCEN			(1 << 11)
-
-/* JAUTO: */ /** Automatic Injection Group conversion. */
-#define ADC_CR1_JAUTO			(1 << 10)
-
-/* AWDSGL: */ /** Enable the watchdog on a single channel in scan mode. */
-#define ADC_CR1_AWDSGL			(1 << 9)
-
-/* SCAN: */ /** Scan mode. */
-#define ADC_CR1_SCAN			(1 << 8)
-
-/* JEOCIE: */ /** Interrupt enable for injected channels. */
-#define ADC_CR1_JEOCIE			(1 << 7)
-
-/* AWDIE: */ /** Analog watchdog interrupt enable. */
-#define ADC_CR1_AWDIE			(1 << 6)
-
-/* EOCIE: */ /** Interrupt enable EOC. */
-#define ADC_CR1_EOCIE			(1 << 5)
-
-/* AWDCH[4:0]: Analog watchdog channel bits. (Up to 17 other values reserved) */
-/* Notes:
- * ADC1: Analog channel 16 and 17 are internally connected to the temperature
- * sensor and V_REFINT, respectively.
- * ADC2: Analog channel 16 and 17 are internally connected to V_SS.
- * ADC3: Analog channel 9, 14, 15, 16 and 17 are internally connected to V_SS.
- */
-/****************************************************************************/
-/* ADC_CR1 AWDCH[4:0] ADC watchdog channel */
-/** @defgroup adc_watchdog_channel ADC watchdog channel
-@ingroup adc_defines
-
-@{*/
-#define ADC_CR1_AWDCH_CHANNEL0		(0x00 << 0)
-#define ADC_CR1_AWDCH_CHANNEL1		(0x01 << 0)
-#define ADC_CR1_AWDCH_CHANNEL2		(0x02 << 0)
-#define ADC_CR1_AWDCH_CHANNEL3		(0x03 << 0)
-#define ADC_CR1_AWDCH_CHANNEL4		(0x04 << 0)
-#define ADC_CR1_AWDCH_CHANNEL5		(0x05 << 0)
-#define ADC_CR1_AWDCH_CHANNEL6		(0x06 << 0)
-#define ADC_CR1_AWDCH_CHANNEL7		(0x07 << 0)
-#define ADC_CR1_AWDCH_CHANNEL8		(0x08 << 0)
-#define ADC_CR1_AWDCH_CHANNEL9		(0x09 << 0)
-#define ADC_CR1_AWDCH_CHANNEL10		(0x0A << 0)
-#define ADC_CR1_AWDCH_CHANNEL11		(0x0B << 0)
-#define ADC_CR1_AWDCH_CHANNEL12		(0x0C << 0)
-#define ADC_CR1_AWDCH_CHANNEL13		(0x0D << 0)
-#define ADC_CR1_AWDCH_CHANNEL14		(0x0E << 0)
-#define ADC_CR1_AWDCH_CHANNEL15		(0x0F << 0)
-#define ADC_CR1_AWDCH_CHANNEL16		(0x10 << 0)
-#define ADC_CR1_AWDCH_CHANNEL17		(0x11 << 0)
-/**@}*/
-#define ADC_CR1_AWDCH_MASK		(0x1F << 0)
-#define ADC_CR1_AWDCH_SHIFT		0
 
 /* --- ADC_CR2 values ------------------------------------------------------ */
 
@@ -595,35 +394,6 @@ and ADC2
 #define ADC_SQR3_SQ3_MSK		(0x1f << ADC_SQR3_SQ3_LSB)
 #define ADC_SQR3_SQ2_MSK		(0x1f << ADC_SQR3_SQ2_LSB)
 #define ADC_SQR3_SQ1_MSK		(0x1f << ADC_SQR3_SQ1_LSB)
-/* --- ADC_JSQR values ----------------------------------------------------- */
-
-#define ADC_JSQR_JL_LSB			20
-#define ADC_JSQR_JSQ4_LSB		15
-#define ADC_JSQR_JSQ3_LSB		10
-#define ADC_JSQR_JSQ2_LSB		5
-#define ADC_JSQR_JSQ1_LSB		0
-
-/* JL[2:0]: Discontinuous mode channel count injected channels. */
-/****************************************************************************/
-/** @defgroup adc_jsqr_jl ADC Number of channels in discontinuous mode from
-injected channels.
-@ingroup adc_defines
-
-@{*/
-#define ADC_JSQR_JL_1CHANNELS       (0x0 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JL_2CHANNELS       (0x1 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JL_3CHANNELS       (0x2 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JL_4CHANNELS       (0x3 << ADC_JSQR_JL_LSB)
-/**@}*/
-#define ADC_JSQR_JL_SHIFT		20
-#define ADC_JSQR_JL_MSK			(0x2 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JSQ4_MSK		(0x1f << ADC_JSQR_JSQ4_LSB)
-#define ADC_JSQR_JSQ3_MSK		(0x1f << ADC_JSQR_JSQ3_LSB)
-#define ADC_JSQR_JSQ2_MSK		(0x1f << ADC_JSQR_JSQ2_LSB)
-#define ADC_JSQR_JSQ1_MSK		(0x1f << ADC_JSQR_JSQ1_LSB)
-
-#define ADC_JSQR_JSQ_VAL(n, val)	((val) << (((n) - 1) * 5))
-#define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
 
 /* --- ADC_JDRx, ADC_DR values --------------------------------------------- */
 

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -1,9 +1,9 @@
 /** @defgroup adc_defines ADC Defines
  *
- * @brief <b>Defined Constants and Types for the STM32F3xx Analog to Digital
+ * @brief <b>Defined Constants and Types for the STM32F37x Analog to Digital
  * converter</b>
  *
- * @ingroup STM32F3xx_defines
+ * @ingroup STM32F37x_defines
  *
  * @version 1.0.0
  *

--- a/include/libopencm3/stm32/f4/adc.h
+++ b/include/libopencm3/stm32/f4/adc.h
@@ -39,131 +39,44 @@ LGPL License Terms @ref lgpl_license
 #ifndef LIBOPENCM3_ADC_H
 #define LIBOPENCM3_ADC_H
 
-#include <libopencm3/stm32/memorymap.h>
 #include <libopencm3/cm3/common.h>
+#include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/common/adc_common_v1.h>
 
 /* --- Convenience macros -------------------------------------------------- */
-
-/* ADC port base addresses (for convenience) */
-/****************************************************************************/
-/** @defgroup adc_reg_base ADC register base addresses
-@ingroup STM32F4xx_adc_defines
-
-@{*/
-#define ADC1				ADC1_BASE
-#define ADC2				ADC2_BASE
-#define ADC3				ADC3_BASE
-/**@}*/
-
-/* --- ADC registers ------------------------------------------------------- */
-
-/* ADC status register (ADC_SR) */
-#define ADC_SR(block)			MMIO32(block + 0x00)
-#define ADC1_SR				ADC_SR(ADC1)
-#define ADC2_SR				ADC_SR(ADC2)
-#define ADC3_SR				ADC_SR(ADC3)
-
-/* ADC control register 1 (ADC_CR1) */
-#define ADC_CR1(block)			MMIO32(block + 0x04)
-#define ADC1_CR1			ADC_CR1(ADC1)
-#define ADC2_CR1			ADC_CR1(ADC2)
-#define ADC3_CR1			ADC_CR1(ADC3)
-
-/* ADC control register 2 (ADC_CR2) */
-#define ADC_CR2(block)			MMIO32(block + 0x08)
-#define ADC1_CR2			ADC_CR2(ADC1)
-#define ADC2_CR2			ADC_CR2(ADC2)
-#define ADC3_CR2			ADC_CR2(ADC3)
-
-/* ADC sample time register 1 (ADC_SMPR1) */
-#define ADC_SMPR1(block)		MMIO32(block + 0x0c)
-#define ADC1_SMPR1			ADC_SMPR1(ADC1)
-#define ADC2_SMPR1			ADC_SMPR1(ADC2)
-#define ADC3_SMPR1			ADC_SMPR1(ADC3)
-
-/* ADC sample time register 2 (ADC_SMPR2) */
-#define ADC_SMPR2(block)		MMIO32(block + 0x10)
-#define ADC1_SMPR2			ADC_SMPR2(ADC1)
-#define ADC2_SMPR2			ADC_SMPR2(ADC2)
-#define ADC3_SMPR2			ADC_SMPR2(ADC3)
 
 /* ADC injected channel data offset register x (ADC_JOFRx) (x=1..4) */
 #define ADC_JOFR1(block)		MMIO32(block + 0x14)
 #define ADC_JOFR2(block)		MMIO32(block + 0x18)
 #define ADC_JOFR3(block)		MMIO32(block + 0x1c)
 #define ADC_JOFR4(block)		MMIO32(block + 0x20)
-#define ADC1_JOFR1			ADC_JOFR1(ADC1)
-#define ADC2_JOFR1			ADC_JOFR1(ADC2)
-#define ADC3_JOFR1			ADC_JOFR1(ADC3)
-#define ADC1_JOFR2			ADC_JOFR2(ADC1)
-#define ADC2_JOFR2			ADC_JOFR2(ADC2)
-#define ADC3_JOFR2			ADC_JOFR2(ADC3)
-#define ADC1_JOFR3			ADC_JOFR3(ADC1)
-#define ADC2_JOFR3			ADC_JOFR3(ADC2)
-#define ADC3_JOFR3			ADC_JOFR3(ADC3)
-#define ADC1_JOFR4			ADC_JOFR4(ADC1)
-#define ADC2_JOFR4			ADC_JOFR4(ADC2)
-#define ADC3_JOFR4			ADC_JOFR4(ADC3)
 
 /* ADC watchdog high threshold register (ADC_HTR) */
 #define ADC_HTR(block)			MMIO32(block + 0x24)
-#define ADC1_HTR			ADC_HTR(ADC1)
-#define ADC2_HTR			ADC_HTR(ADC2)
-#define ADC3_HTR			ADC_HTR(ADC3)
 
 /* ADC watchdog low threshold register (ADC_LTR) */
 #define ADC_LTR(block)			MMIO32(block + 0x28)
-#define ADC1_LTR			ADC_LTR(ADC1_BASE)
-#define ADC2_LTR			ADC_LTR(ADC2_BASE)
-#define ADC3_LTR			ADC_LTR(ADC3_BASE)
 
 /* ADC regular sequence register 1 (ADC_SQR1) */
 #define ADC_SQR1(block)			MMIO32(block + 0x2c)
-#define ADC1_SQR1			ADC_SQR1(ADC1)
-#define ADC2_SQR1			ADC_SQR1(ADC2)
-#define ADC3_SQR1			ADC_SQR1(ADC3)
 
 /* ADC regular sequence register 2 (ADC_SQR2) */
 #define ADC_SQR2(block)			MMIO32(block + 0x30)
-#define ADC1_SQR2			ADC_SQR2(ADC1)
-#define ADC2_SQR2			ADC_SQR2(ADC2)
-#define ADC3_SQR2			ADC_SQR2(ADC3)
 
 /* ADC regular sequence register 3 (ADC_SQR3) */
 #define ADC_SQR3(block)			MMIO32(block + 0x34)
-#define ADC1_SQR3			ADC_SQR3(ADC1)
-#define ADC2_SQR3			ADC_SQR3(ADC2)
-#define ADC3_SQR3			ADC_SQR3(ADC3)
 
 /* ADC injected sequence register (ADC_JSQR) */
 #define ADC_JSQR(block)			MMIO32(block + 0x38)
-#define ADC1_JSQR			ADC_JSQR(ADC1_BASE)
-#define ADC2_JSQR			ADC_JSQR(ADC2_BASE)
-#define ADC3_JSQR			ADC_JSQR(ADC3_BASE)
 
 /* ADC injected data register x (ADC_JDRx) (x=1..4) */
 #define ADC_JDR1(block)			MMIO32(block + 0x3c)
 #define ADC_JDR2(block)			MMIO32(block + 0x40)
 #define ADC_JDR3(block)			MMIO32(block + 0x44)
 #define ADC_JDR4(block)			MMIO32(block + 0x48)
-#define ADC1_JDR1			ADC_JDR1(ADC1)
-#define ADC2_JDR1			ADC_JDR1(ADC2)
-#define ADC3_JDR1			ADC_JDR1(ADC3)
-#define ADC1_JDR2			ADC_JDR2(ADC1)
-#define ADC2_JDR2			ADC_JDR2(ADC2)
-#define ADC3_JDR2			ADC_JDR2(ADC3)
-#define ADC1_JDR3			ADC_JDR3(ADC1)
-#define ADC2_JDR3			ADC_JDR3(ADC2)
-#define ADC3_JDR3			ADC_JDR3(ADC3)
-#define ADC1_JDR4			ADC_JDR4(ADC1)
-#define ADC2_JDR4			ADC_JDR4(ADC2)
-#define ADC3_JDR4			ADC_JDR4(ADC3)
 
 /* ADC regular data register (ADC_DR) */
 #define ADC_DR(block)			MMIO32(block + 0x4c)
-#define ADC1_DR				ADC_DR(ADC1)
-#define ADC2_DR				ADC_DR(ADC2)
-#define ADC3_DR				ADC_DR(ADC3)
 
 /* ADC common (shared) registers */
 #define	ADC_COMMON_REGISTERS_BASE	(ADC1_BASE+0x300)
@@ -173,42 +86,15 @@ LGPL License Terms @ref lgpl_license
 
 /* --- ADC Channels ------------------------------------------------------- */
 
-/****************************************************************************/
-/** @defgroup adc_channel ADC Channel Numbers
-@ingroup STM32F4xx_adc_defines
-
-@{*/
-#define ADC_CHANNEL0		0x00
-#define ADC_CHANNEL1		0x01
-#define ADC_CHANNEL2		0x02
-#define ADC_CHANNEL3		0x03
-#define ADC_CHANNEL4		0x04
-#define ADC_CHANNEL5		0x05
-#define ADC_CHANNEL6		0x06
-#define ADC_CHANNEL7		0x07
-#define ADC_CHANNEL8		0x08
-#define ADC_CHANNEL9		0x09
-#define ADC_CHANNEL10		0x0A
-#define ADC_CHANNEL11		0x0B
-#define ADC_CHANNEL12		0x0C
-#define ADC_CHANNEL13		0x0D
-#define ADC_CHANNEL14		0x0E
-#define ADC_CHANNEL15		0x0F
-#define ADC_CHANNEL16		0x10
-#define ADC_CHANNEL17		0x11
-#define ADC_CHANNEL18		0x12
-/**@}*/
-#define ADC_MASK		    0x1F
-#define ADC_SHIFT		    0
+/* Thanks ST! F40x and F41x are on 16, F42x and F43x are on 18! */
+#define ADC_CHANNEL_TEMP_F40	ADC_CHANNEL16
+#define ADC_CHANNEL_TEMP_F42	ADC_CHANNEL18
+#define ADC_CHANNEL_VREFINT	ADC_CHANNEL17
+#define ADC_CHANNEL_VBAT	ADC_CHANNEL18
 
 /* --- ADC_SR values ------------------------------------------------------- */
 
 #define ADC_SR_OVR			(1 << 5)
-#define ADC_SR_STRT			(1 << 4)
-#define ADC_SR_JSTRT			(1 << 3)
-#define ADC_SR_JEOC			(1 << 2)
-#define ADC_SR_EOC			(1 << 1)
-#define ADC_SR_AWD			(1 << 0)
 
 /* --- ADC_CR1 values specific to STM32F2,4--------------------------------- */
 
@@ -233,88 +119,6 @@ LGPL License Terms @ref lgpl_license
 
 /* --- ADC_CR1 values (note some of these are defined elsewhere) ----------- */
 
-/* AWDEN: Analog watchdog enable on regular channels */
-#define ADC_CR1_AWDEN			(1 << 23)
-
-/* JAWDEN: Analog watchdog enable on injected channels */
-#define ADC_CR1_JAWDEN			(1 << 22)
-
-/* DISCNUM[2:0]: Discontinuous mode channel count. */
-/****************************************************************************/
-/** @defgroup adc_cr1_discnum ADC Number of channels in discontinuous mode.
-@ingroup STM32F4xx_adc_defines
-
-@{*/
-#define ADC_CR1_DISCNUM_1CHANNELS       (0x0 << 13)
-#define ADC_CR1_DISCNUM_2CHANNELS       (0x1 << 13)
-#define ADC_CR1_DISCNUM_3CHANNELS       (0x2 << 13)
-#define ADC_CR1_DISCNUM_4CHANNELS       (0x3 << 13)
-#define ADC_CR1_DISCNUM_5CHANNELS       (0x4 << 13)
-#define ADC_CR1_DISCNUM_6CHANNELS       (0x5 << 13)
-#define ADC_CR1_DISCNUM_7CHANNELS       (0x6 << 13)
-#define ADC_CR1_DISCNUM_8CHANNELS       (0x7 << 13)
-/**@}*/
-#define ADC_CR1_DISCNUM_MASK		(0x7 << 13)
-#define ADC_CR1_DISCNUM_SHIFT		13
-
-/* JDISCEN: */ /** Discontinuous mode on injected channels. */
-#define ADC_CR1_JDISCEN			(1 << 12)
-
-/* DISCEN: */ /** Discontinuous mode on regular channels. */
-#define ADC_CR1_DISCEN			(1 << 11)
-
-/* JAUTO: */ /** Automatic Injection Group conversion. */
-#define ADC_CR1_JAUTO			(1 << 10)
-
-/* AWDSGL: */ /** Enable the watchdog on a single channel in scan mode. */
-#define ADC_CR1_AWDSGL			(1 << 9)
-
-/* SCAN: */ /** Scan mode. */
-#define ADC_CR1_SCAN			(1 << 8)
-
-/* JEOCIE: */ /** Interrupt enable for injected channels. */
-#define ADC_CR1_JEOCIE			(1 << 7)
-
-/* AWDIE: */ /** Analog watchdog interrupt enable. */
-#define ADC_CR1_AWDIE			(1 << 6)
-
-/* EOCIE: */ /** Interrupt enable EOC. */
-#define ADC_CR1_EOCIE			(1 << 5)
-
-/* AWDCH[4:0]: Analog watchdog channel bits. (Up to 17 other values reserved) */
-/* Notes:
- * ADC1: Analog channel 16 and 17 are internally connected to the temperature
- *       sensor and V_REFINT, respectively.
- * ADC2: Analog channel 16 and 17 are internally connected to V_SS.
- * ADC3: Analog channel 9, 14, 15, 16 and 17 are internally connected to V_SS.
- */
-/****************************************************************************/
-/* ADC_CR1 AWDCH[4:0] ADC watchdog channel */
-/** @defgroup adc_watchdog_channel ADC watchdog channel
-@ingroup STM32F4xx_adc_defines
-
-@{*/
-#define ADC_CR1_AWDCH_CHANNEL0		(0x00 << 0)
-#define ADC_CR1_AWDCH_CHANNEL1		(0x01 << 0)
-#define ADC_CR1_AWDCH_CHANNEL2		(0x02 << 0)
-#define ADC_CR1_AWDCH_CHANNEL3		(0x03 << 0)
-#define ADC_CR1_AWDCH_CHANNEL4		(0x04 << 0)
-#define ADC_CR1_AWDCH_CHANNEL5		(0x05 << 0)
-#define ADC_CR1_AWDCH_CHANNEL6		(0x06 << 0)
-#define ADC_CR1_AWDCH_CHANNEL7		(0x07 << 0)
-#define ADC_CR1_AWDCH_CHANNEL8		(0x08 << 0)
-#define ADC_CR1_AWDCH_CHANNEL9		(0x09 << 0)
-#define ADC_CR1_AWDCH_CHANNEL10		(0x0A << 0)
-#define ADC_CR1_AWDCH_CHANNEL11		(0x0B << 0)
-#define ADC_CR1_AWDCH_CHANNEL12		(0x0C << 0)
-#define ADC_CR1_AWDCH_CHANNEL13		(0x0D << 0)
-#define ADC_CR1_AWDCH_CHANNEL14		(0x0E << 0)
-#define ADC_CR1_AWDCH_CHANNEL15		(0x0F << 0)
-#define ADC_CR1_AWDCH_CHANNEL16		(0x10 << 0)
-#define ADC_CR1_AWDCH_CHANNEL17		(0x11 << 0)
-/**@}*/
-#define ADC_CR1_AWDCH_MASK		(0x1F << 0)
-#define ADC_CR1_AWDCH_SHIFT		0
 
 /* --- ADC_CR2 values ------------------------------------------------------ */
 
@@ -559,36 +363,6 @@ LGPL License Terms @ref lgpl_license
 #define ADC_SQR3_SQ3_MSK		(0x1f << ADC_SQR3_SQ3_LSB)
 #define ADC_SQR3_SQ2_MSK		(0x1f << ADC_SQR3_SQ2_LSB)
 #define ADC_SQR3_SQ1_MSK		(0x1f << ADC_SQR3_SQ1_LSB)
-
-/* --- ADC_JSQR values ----------------------------------------------------- */
-
-#define ADC_JSQR_JL_LSB			20
-#define ADC_JSQR_JSQ4_LSB		15
-#define ADC_JSQR_JSQ3_LSB		10
-#define ADC_JSQR_JSQ2_LSB		5
-#define ADC_JSQR_JSQ1_LSB		0
-
-/* JL[2:0]: Discontinous mode channel count injected channels. */
-/****************************************************************************/
-/** @defgroup adc_jsqr_jl ADC Number of channels in discontinuous mode fro
-injected channels.
-@ingroup STM32F4xx_adc_defines
-
-@{*/
-#define ADC_JSQR_JL_1CHANNELS       (0x0 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JL_2CHANNELS       (0x1 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JL_3CHANNELS       (0x2 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JL_4CHANNELS       (0x3 << ADC_JSQR_JL_LSB)
-/**@}*/
-#define ADC_JSQR_JL_SHIFT		20
-#define ADC_JSQR_JL_MSK			(0x2 << ADC_JSQR_JL_LSB)
-#define ADC_JSQR_JSQ4_MSK		(0x1f << ADC_JSQR_JSQ4_LSB)
-#define ADC_JSQR_JSQ3_MSK		(0x1f << ADC_JSQR_JSQ3_LSB)
-#define ADC_JSQR_JSQ2_MSK		(0x1f << ADC_JSQR_JSQ2_LSB)
-#define ADC_JSQR_JSQ1_MSK		(0x1f << ADC_JSQR_JSQ1_LSB)
-
-#define ADC_JSQR_JSQ_VAL(n, val)	((val) << (((n) - 1) * 5))
-#define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
 
 /* --- ADC_JDRx, ADC_DR values --------------------------------------------- */
 

--- a/include/libopencm3/stm32/l1/adc.h
+++ b/include/libopencm3/stm32/l1/adc.h
@@ -1,0 +1,219 @@
+/** @defgroup STM32L1xx_adc_defines ADC Defines
+
+@brief <b>Defined Constants and Types for the STM32L1xx Analog to Digital Converters</b>
+
+@ingroup STM32L1xx_defines
+
+@version 1.0.0
+
+@author @htmlonly &copy; @endhtmlonly 2013 Karl Palsson <karlp@remake.is>
+
+LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Karl Palsson <karlp@remake.is>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_ADC_H
+#define LIBOPENCM3_ADC_H
+
+#include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/common/adc_common_v1.h>
+
+#define ADC_MAX_REGULAR_SEQUENCE	28
+/* 26 in L/M, but 32 in two banks for M+/H density */
+#define ADC_MAX_CHANNELS		32
+
+/* ADC sample time register 3 (ADC_SMPR3) */
+#define ADC_SMPR3(block)		MMIO32(block + 0x14)
+#define ADC1_SMPR3			ADC_SMPR3(ADC1)
+
+/* ADC injected channel data offset register x (ADC_JOFRx) (x=1..4) */
+#define ADC_JOFR1(block)		MMIO32(block + 0x18)
+#define ADC_JOFR2(block)		MMIO32(block + 0x1c)
+#define ADC_JOFR3(block)		MMIO32(block + 0x20)
+#define ADC_JOFR4(block)		MMIO32(block + 0x24)
+
+/* ADC watchdog high threshold register (ADC_HTR) */
+#define ADC_HTR(block)			MMIO32(block + 0x28)
+
+/* ADC watchdog low threshold register (ADC_LTR) */
+#define ADC_LTR(block)			MMIO32(block + 0x2c)
+
+/* ADC regular sequence register 1 (ADC_SQR1) */
+#define ADC_SQR1(block)			MMIO32(block + 0x30)
+
+/* ADC regular sequence register 2 (ADC_SQR2) */
+#define ADC_SQR2(block)			MMIO32(block + 0x34)
+
+/* ADC regular sequence register 3 (ADC_SQR3) */
+#define ADC_SQR3(block)			MMIO32(block + 0x38)
+
+/* ADC regular sequence register 4 (ADC_SQR4) */
+#define ADC_SQR4(block)			MMIO32(block + 0x3c)
+#define ADC1_SQR4			ADC_SQR4(ADC1)
+
+/* ADC regular sequence register 5 (ADC_SQR5) */
+#define ADC_SQR5(block)			MMIO32(block + 0x40)
+#define ADC1_SQR5			ADC_SQR5(ADC1)
+
+/* ADC injected sequence register (ADC_JSQR) */
+#define ADC_JSQR(block)			MMIO32(block + 0x44)
+
+/* ADC injected data register x (ADC_JDRx) (x=1..4) */
+#define ADC_JDR1(block)			MMIO32(block + 0x48)
+#define ADC_JDR2(block)			MMIO32(block + 0x4c)
+#define ADC_JDR3(block)			MMIO32(block + 0x50)
+#define ADC_JDR4(block)			MMIO32(block + 0x54)
+
+/* ADC regular data register (ADC_DR) */
+#define ADC_DR(block)			MMIO32(block + 0x58)
+
+/* ADC sample time register 0 (ADC_SMPR0) (high/med+ only) */
+#define ADC_SMPR0(block)		MMIO32(block + 0x5c)
+#define ADC1_SMPR0			ADC_SMPR0(ADC1)
+
+#define ADC_CSR				MMIO32(ADC1 + 0x300)
+#define ADC_CCR				MMIO32(ADC1 + 0x304)
+
+
+/* These are _not_ consistent unfortunately! */
+#define ADC_CHANNEL_TEMP        ADC_CHANNEL16
+#define ADC_CHANNEL_VREFINT     ADC_CHANNEL17
+#define ADC_CHANNEL_VBAT        ADC_CHANNEL18
+
+/* --- ADC_SR values ------------------------------------------------------- */
+#define ADC_SR_JCNR			(1 << 9)
+#define ADC_SR_RCNR			(1 << 8)
+#define ADC_SR_ADONS			(1 << 6)
+#define ADC_SR_OVR			(1 << 5)
+
+/* --- ADC_CR1 values ------------------------------------------------------- */
+#define ADC_CR1_OVRIE			(1 << 28)
+/****************************************************************************/
+/** @defgroup adc_cr1_res ADC Resolution.
+@ingroup STM32L1xx_adc_defines
+@{*/
+#define ADC_CR1_RES_12_BIT		0
+#define ADC_CR1_RES_10_BIT		1
+#define ADC_CR1_RES_8_BIT		2
+#define ADC_CR1_RES_6_BIT		3
+/**@}*/
+#define ADC_CR1_RES_MASK		(0x3)
+#define ADC_CR1_RES_SHIFT		24
+#define ADC_CR1_PDI			(1 << 17)
+#define ADC_CR1_PDD			(1 << 16)
+
+
+/* --- ADC_CR2 values ------------------------------------------------------- */
+/* SWSTART: */ /** Start conversion of regular channels. */
+#define ADC_CR2_SWSTART			(1 << 30)
+
+/* EXTEN[1:0]: External trigger enable for regular channels. */
+/****************************************************************************/
+#define ADC_CR2_EXTEN_SHIFT		28
+#define ADC_CR2_EXTEN_MASK		(0x3 << ADC_CR2_EXTEN_SHIFT)
+/** @defgroup adc_trigger_polarity_regular ADC Trigger Polarity
+@ingroup STM32L1xx_adc_defines
+@{*/
+#define ADC_CR2_EXTEN_DISABLED		(0x0 << ADC_CR2_EXTEN_SHIFT)
+#define ADC_CR2_EXTEN_RISING_EDGE	(0x1 << ADC_CR2_EXTEN_SHIFT)
+#define ADC_CR2_EXTEN_FALLING_EDGE	(0x2 << ADC_CR2_EXTEN_SHIFT)
+#define ADC_CR2_EXTEN_BOTH_EDGES	(0x3 << ADC_CR2_EXTEN_SHIFT)
+/**@}*/
+
+/* EXTSEL[3:0]: External event selection for regular group. */
+/****************************************************************************/
+#define ADC_CR2_EXTSEL_SHIFT		24
+#define ADC_CR2_EXTSEL_MASK		(0xf << ADC_CR2_EXTSEL_SHIFT)
+/** @defgroup adc_trigger_regular ADC Trigger Identifier for Regular group
+@ingroup STM32L1xx_adc_defines
+
+@{*/
+#define ADC_CR2_EXTSEL_TIM9_CC2		(0 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM9_TRGO	(1 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM2_CC3		(2 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM2_CC2		(3 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM3_TRGO	(4 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM4_CC4		(5 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM2_TRGO	(6 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM3_CC1		(7 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM3_CC3		(8 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM4_TRGO	(9 << ADC_CR2_EXTSEL_SHIFT)
+#define ADC_CR2_EXTSEL_TIM6_TRGO	(10 << ADC_CR2_EXTSEL_SHIFT)
+// reserved....
+#define ADC_CR2_EXTSEL_EXTI11		(15 << ADC_CR2_EXTSEL_SHIFT)
+/**@}*/
+
+#define ADC_CR2_JSWSTART		(1 << 22)
+
+/* JEXTEN[1:0]: External trigger enable for injected channels. */
+/****************************************************************************/
+#define ADC_CR2_JEXTEN_SHIFT		20
+#define ADC_CR2_JEXTEN_MASK		(0x3 << ADC_CR2_JEXTEN_SHIFT)
+/** @defgroup adc_trigger_polarity_injected ADC Injected Trigger Polarity
+@ingroup STM32L1xx_adc_defines
+@{*/
+#define ADC_CR2_JEXTEN_DISABLED		(0x0 << ADC_CR2_JEXTEN_SHIFT)
+#define ADC_CR2_JEXTEN_RISING_EDGE	(0x1 << ADC_CR2_JEXTEN_SHIFT)
+#define ADC_CR2_JEXTEN_FALLING_EDGE	(0x2 << ADC_CR2_JEXTEN_SHIFT)
+#define ADC_CR2_JEXTEN_BOTH_EDGES	(0x3 << ADC_CR2_JEXTEN_SHIFT)
+/**@}*/
+
+// FIXME - add the values here
+#define ADC_CR2_JEXTSEL_SHIFT		16
+#define ADC_CR2_JEXTSEL_MASK		(0xf << ADC_CR2_JEXTSEL_SHIFT)
+
+#define ADC_CR2_EOCS			(1 << 10)
+#define ADC_CR2_DDS			(1 << 9)
+// FIXME- add the values here
+#define ADC_CR2_DELS_SHIFT		4
+#define ADC_CR2_DELS_MASK		0x7
+
+#define ADC_CR2_ADC_CFG			(1 << 2)
+
+
+
+
+/* --- ADC_SMPRx generic values -------------------------------------------- */
+/****************************************************************************/
+/* ADC_SMPRG ADC Sample Time Selection for Channels */
+/** @defgroup adc_sample_rg ADC Sample Time Selection for All Channels
+@ingroup STM32L1xx_adc_defines
+
+@{*/
+#define ADC_SMPR_SMP_4CYC		0x0
+#define ADC_SMPR_SMP_9CYC		0x1
+#define ADC_SMPR_SMP_16CYC		0x2
+#define ADC_SMPR_SMP_24CYC		0x3
+#define ADC_SMPR_SMP_48CYC		0x4
+#define ADC_SMPR_SMP_96CYC		0x5
+#define ADC_SMPR_SMP_192CYC		0x6
+#define ADC_SMPR_SMP_384CYC		0x7
+/**@}*/
+
+#define ADC_SQR_MASK			0x1f
+
+#define ADC_CCR_TSVREFE			(1 << 23)
+
+BEGIN_DECLS
+        // We will add these when we are ready...
+
+END_DECLS
+
+#endif

--- a/include/libopencm3/stm32/l1/memorymap.h
+++ b/include/libopencm3/stm32/l1/memorymap.h
@@ -72,6 +72,8 @@
 #define TIM11_BASE			(PERIPH_BASE_APB2 + 0x1000)
 /* gap */
 #define ADC_BASE			(PERIPH_BASE_APB2 + 0x2400)
+/* ADC is the name in the L1 refman, but all other stm32's use ADC1 */
+#define ADC1_BASE			ADC_BASE
 /* gap */
 #define SDIO_BASE			(PERIPH_BASE_APB2 + 0x2c00)
 #define SPI1_BASE			(PERIPH_BASE_APB2 + 0x3000)


### PR DESCRIPTION
This pulls out all the common header definitions for the F1, L1, F4 and F37x
parts.  It's verified against the datasheet for F2 as well, but we don't have
any good F2 test boards or any support for that yet.  (The F2 header would be
_exactly_ the same as the F4 header, so it's a target for a future round of
unification, not this one)

Tested with f1, f4 and l1 examples from the examples repository.

(The f1 and f4 example works before and after this change, the l1 example can't be committed until this is merged)

This provides _headers_ for l1, but no unification of the convenience functions is done at this point.  It's all stashed in various private branches, but adc support for the L1 has been missing far too long!
