### PR TITLE
Add support of splitting parameter classes to ARCH, DEFS, LIB

### DIFF
--- a/ld/devices.data
+++ b/ld/devices.data
@@ -309,12 +309,12 @@ lpc17[78]x lpc17 RAM1_OFF=0x20000000 RAM2_OFF=0x20040000
 ################################################################################
 # the STM32 families
 
-stm32f0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0 -mthumb
-stm32f1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
-stm32f2 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
-stm32f3 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
-stm32f4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb
-stm32l1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
+stm32f0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0 -mthumb -DSTM32F0 -lopencm3_stm32f0 -msoft-float
+stm32f1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F1 -lopencm3_stm32f1 -msoft-float
+stm32f2 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F2 -lopencm3_stm32f2 -msoft-float
+stm32f3 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F3 -lopencm3_stm32f3 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+stm32f4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F4 -lopencm3_stm32f4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+stm32l1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32L1 -lopencm3_stm32l1 -msoft-float
 stm32w stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
 stm32t stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
 

--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -23,6 +23,8 @@
 
 BEGIN {
 	PAT = tolower(PAT);
+	if (length(MODE) == 0)
+		MODE = ".*";
 }
 !/^#/{
 	#remove cr on windows
@@ -39,10 +41,22 @@ BEGIN {
 			PAT=$2;
 
 		for (i = 3; i <= NF; i = i + 1) {
-			if ($i ~ /^-/)
-				printf "%s ",$i;
-			else
-				printf "-D_%s ",$i;
+			if ($i ~ /^-l/) {
+				if ("LIB" ~ MODE)
+					printf "%s ",$i;
+			}
+			else if ($i ~ /^-m/) {
+				if ("ARCH" ~ MODE)
+					printf "%s ",$i;
+			}
+			else if ($i ~ /^-D/) {
+				if ("DEFS" ~ MODE)
+					printf "%s ",$i;
+			}
+			else {
+				if ("DEFS" ~ MODE)
+					printf "-D_%s ",$i;
+			}
 		}
 
 		if (PAT=="END")


### PR DESCRIPTION
in ARCH, there are all -m flags (will be expanded into ARCH_FLAGS in Makefile)
in DEFS, there are all -D flags (will be expanded into DEFS in Makefile)
in LIB, there are all -l flags (will be expanded into LIBNAME in Makefile)

If no MODE option specified, the generator behaves as in previous version.
