### PR TITLE
Update Docs on toolchains (was: fix compilation error on Debian)

### DIFF
--- a/lib/Makefile.include
+++ b/lib/Makefile.include
@@ -23,6 +23,8 @@ ifneq ($(V),1)
 Q := @
 endif
 
+CFLAGS += -I/usr/include
+
 # common objects
 OBJS += vector.o systick.o scb.o nvic.o assert.o sync.o dwt.o
 


### PR DESCRIPTION
When compiling on Debian "jessie" using "gcc-arm-none-eabi" toolchain
there is compilation error: toolchain compiler doesn't see system
include directory and throws next error:

/usr/lib/gcc/arm-none-eabi/4.8.2/include/stdint.h:9:26: fatal error:
stdint.h: No such file or directory
 # include_next <stdint.h>

Maybe this patch is just workaround for buggy Debian toolchain, but it works
for me and doesn't break anything.

Signed-off-by: Sam Protsenko joe.skb7@gmail.com
