### PR TITLE
[stm32][f1|f3] fix adc_set_injected_sequence

### DIFF
--- a/lib/stm32/f1/adc.c
+++ b/lib/stm32/f1/adc.c
@@ -1096,7 +1096,7 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 		return;
 	}
 
-	for (i = 1; i <= length; i++) {
+	for (i = 0; i < length; i++) {
 		reg32 |= ADC_JSQR_JSQ_VAL(4 - i, channel[length - i - 1]);
 	}
 

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -702,7 +702,7 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 		return;
 	}
 
-	for (i = 1; i <= length; i++) {
+	for (i = 0; i < length; i++) {
 		reg32 |= ADC_JSQR_JSQ_VAL(4 - i, channel[length - i - 1]);
 	}
 


### PR DESCRIPTION
Fix adc_set_injected_sequence on F1 and F3 since the "ADC injected channel order fix" in #192.  F4 was already correct.
