### PR TITLE
[BUILD] Fix the correct make behavior if compiling inside tree

### DIFF
--- a/lib/efm32/efm32g/Makefile
+++ b/lib/efm32/efm32g/Makefile
@@ -19,6 +19,7 @@
 ##
 
 LIBNAME		= libopencm3_efm32g
+SRCLIBDIR	?= ../..
 FAMILY		= EFM32G
 
 PREFIX		?= arm-none-eabi

--- a/lib/efm32/efm32gg/Makefile
+++ b/lib/efm32/efm32gg/Makefile
@@ -19,6 +19,7 @@
 ##
 
 LIBNAME		= libopencm3_efm32gg
+SRCLIBDIR	?= ../..
 FAMILY		= EFM32GG
 
 PREFIX		?= arm-none-eabi

--- a/lib/efm32/efm32lg/Makefile
+++ b/lib/efm32/efm32lg/Makefile
@@ -19,6 +19,7 @@
 ##
 
 LIBNAME		= libopencm3_efm32lg
+SRCLIBDIR	?= ../..
 FAMILY		= EFM32LG
 
 PREFIX		?= arm-none-eabi

--- a/lib/efm32/efm32tg/Makefile
+++ b/lib/efm32/efm32tg/Makefile
@@ -19,6 +19,7 @@
 ##
 
 LIBNAME		= libopencm3_efm32tg
+SRCLIBDIR	?= ../..
 FAMILY		= EFM32TG
 
 PREFIX		?= arm-none-eabi

--- a/lib/lm3s/Makefile
+++ b/lib/lm3s/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_lm3s
+SRCLIBDIR	?= ..
 
 PREFIX		?= arm-none-eabi
 

--- a/lib/lm4f/Makefile
+++ b/lib/lm4f/Makefile
@@ -19,6 +19,7 @@
 ##
 
 LIBNAME		= libopencm3_lm4f
+SRCLIBDIR	?= ..
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX		?= arm-none-eabi

--- a/lib/lpc13xx/Makefile
+++ b/lib/lpc13xx/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_lpc13xx
+SRCLIBDIR	?= ..
 
 PREFIX		?= arm-none-eabi
 

--- a/lib/lpc17xx/Makefile
+++ b/lib/lpc17xx/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_lpc17xx
+SRCLIBDIR	?= ..
 
 PREFIX		?= arm-none-eabi
 

--- a/lib/lpc43xx/m0/Makefile
+++ b/lib/lpc43xx/m0/Makefile
@@ -20,6 +20,7 @@
 ##
 
 LIBNAME		= libopencm3_lpc43xx_m0
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 #PREFIX		?= arm-elf

--- a/lib/lpc43xx/m4/Makefile
+++ b/lib/lpc43xx/m4/Makefile
@@ -21,6 +21,7 @@
 ##
 
 LIBNAME		= libopencm3_lpc43xx
+SRCLIBDIR	?= ../..
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX		?= arm-none-eabi

--- a/lib/sam/3n/Makefile
+++ b/lib/sam/3n/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_sam3n
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 

--- a/lib/sam/3x/Makefile
+++ b/lib/sam/3x/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_sam3x
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_stm32f0
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 #PREFIX		?= arm-elf

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_stm32f1
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 

--- a/lib/stm32/f2/Makefile
+++ b/lib/stm32/f2/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_stm32f2
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 

--- a/lib/stm32/f3/Makefile
+++ b/lib/stm32/f3/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_stm32f3
+SRCLIBDIR	?= ../..
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX	        ?= arm-none-eabi

--- a/lib/stm32/f4/Makefile
+++ b/lib/stm32/f4/Makefile
@@ -19,6 +19,7 @@
 ##
 
 LIBNAME		= libopencm3_stm32f4
+SRCLIBDIR	?= ../..
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 PREFIX	        ?= arm-none-eabi

--- a/lib/stm32/l1/Makefile
+++ b/lib/stm32/l1/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_stm32l1
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 


### PR DESCRIPTION
On linux, the output of CP rule was try to write to / which is - of course, forbidden for write.

This solution adds to each part of lib correct pointer to the root of lib where the libs should be written.

Bug found by Kuldeep Singh Dhaka.
