### PR TITLE
Fixes spi_common_all warning

### DIFF
--- a/lib/stm32/common/spi_common_all.c
+++ b/lib/stm32/common/spi_common_all.c
@@ -80,28 +80,40 @@ spi_reg_base.
 */
 
 void spi_reset(uint32_t spi_peripheral)
-{
-/* there is another way of resetting mechanism on F0. It will be extended to all
-  families of stm32 and this function will be deprecated and deleted in the
-  future.*/
-#if !defined(STM32F0)
-	switch (spi_peripheral) {
-	case SPI1:
-		rcc_peripheral_reset(&RCC_APB2RSTR, RCC_APB2RSTR_SPI1RST);
-		rcc_peripheral_clear_reset(&RCC_APB2RSTR, RCC_APB2RSTR_SPI1RST);
-		break;
-	case SPI2:
-		rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_SPI2RST);
-		rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_SPI2RST);
-		break;
-#if defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || defined(STM32F4)
-	case SPI3:
-		rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_SPI3RST);
-		rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_SPI3RST);
+{	switch (spi_peripheral) {
+#if defined(SPI1_BASE)
+	case SPI1_BASE:
+		rcc_periph_reset_pulse(RST_SPI1);
 		break;
 #endif
+#if defined(SPI2_I2S_BASE)
+	case SPI2_I2S_BASE:
+		rcc_periph_reset_pulse(RST_SPI2);
+		break;
+#endif
+#if defined(SPI3_I2S_BASE)
+	case SPI3_I2S_BASE:
+		rcc_periph_reset_pulse(RST_SPI3);
+		break;
+#endif
+#if defined(SPI4_BASE)
+	case SPI4_BASE:
+		rcc_periph_reset_pulse(RST_SPI4);
+		break;
+#endif
+#if defined(SPI5_BASE)
+	case SPI5_BASE:
+		rcc_periph_reset_pulse(RST_SPI5);
+		break;
+#endif
+#if defined(SPI6_BASE)
+	case SPI6_BASE:
+		rcc_periph_reset_pulse(RST_SPI6);
+		break;
+#endif
+	default:
+		break;
 	}
-#endif
 }
 
 /* TODO: Error handling? */


### PR DESCRIPTION
Fixes spi_common_all and deprecates the function spi_reset as there is rcc_periph_reset_pulse for this reason. Fixes #226.
