### PR TITLE
fixed DAC buffer OFF bit is inverted

### DIFF
--- a/lib/stm32/common/dac_common_all.c
+++ b/lib/stm32/common/dac_common_all.c
@@ -183,13 +183,13 @@ void dac_buffer_enable(data_channel dac_channel)
 {
 	switch (dac_channel) {
 	case CHANNEL_1:
-		DAC_CR |= DAC_CR_BOFF1;
+		DAC_CR &= ~DAC_CR_BOFF1;
 		break;
 	case CHANNEL_2:
-		DAC_CR |= DAC_CR_BOFF2;
+		DAC_CR &= ~DAC_CR_BOFF2;
 		break;
 	case CHANNEL_D:
-		DAC_CR |= (DAC_CR_BOFF1 | DAC_CR_BOFF2);
+		DAC_CR &= ~(DAC_CR_BOFF1 | DAC_CR_BOFF2);
 		break;
 	}
 }
@@ -207,13 +207,13 @@ void dac_buffer_disable(data_channel dac_channel)
 {
 	switch (dac_channel) {
 	case CHANNEL_1:
-		DAC_CR &= ~DAC_CR_BOFF1;
+		DAC_CR |= DAC_CR_BOFF1;
 		break;
 	case CHANNEL_2:
-		DAC_CR &= ~DAC_CR_BOFF2;
+		DAC_CR |= DAC_CR_BOFF2;
 		break;
 	case CHANNEL_D:
-		DAC_CR &= ~(DAC_CR_BOFF1 | DAC_CR_BOFF2);
+		DAC_CR |= (DAC_CR_BOFF1 | DAC_CR_BOFF2);
 		break;
 	}
 }


### PR DESCRIPTION
The DAC buffer can be turned off by SETTING a bit in the CR register. The bit is called B(uffer)OFF. 
The implementation was wrong, it cleared the bit in the "...._disable" function and it set the bit in the "...._enable" function. 
