### PR TITLE
[sam3a] apply SRCLIBDIR patch

### DIFF
--- a/lib/sam/3a/Makefile
+++ b/lib/sam/3a/Makefile
@@ -18,6 +18,7 @@
 ##
 
 LIBNAME		= libopencm3_sam3a
+SRCLIBDIR	?= ../..
 
 PREFIX		?= arm-none-eabi
 


### PR DESCRIPTION
the SRCLIBDIR patch wasn't applied to the SAM3A makefile
