### PR TITLE
cm0 doesn't support sync operations

### DIFF
--- a/lib/cm3/sync.c
+++ b/lib/cm3/sync.c
@@ -27,7 +27,7 @@ void __dmb()
 
 /* Those are defined only on CM3 or CM4 */
 #if defined(__ARM_ARCH_6M__)
-#warning "sync not supported on ARMv6-M arch"
+/* no work around for cm0 */
 #else
 
 uint32_t __ldrex(volatile uint32_t *addr)


### PR DESCRIPTION
So remove the warning, the sync code is already left out of the cm0
builds.

Fixes #291
