### PR TITLE
[STM32F0] added DMA1_BASE because of dma_common_l1f013.h

### DIFF
--- a/include/libopencm3/stm32/f0/memorymap.h
+++ b/include/libopencm3/stm32/f0/memorymap.h
@@ -82,6 +82,7 @@
 
 /* AHB1 */
 #define DMA_BASE			(PERIPH_BASE_AHB1 + 0x0000)
+#define DMA1_BASE			(PERIPH_BASE_AHB1 + 0x0000)
 
 #define RCC_BASE			(PERIPH_BASE_AHB1 + 0x1000)
 


### PR DESCRIPTION
Missing defination
fix https://github.com/libopencm3/libopencm3/issues/299
