### PR TITLE
generic spi_init_master cleanup. 

### DIFF
--- a/include/libopencm3/cm3/common.h
+++ b/include/libopencm3/cm3/common.h
@@ -54,10 +54,10 @@
 
 /* Generic bit-band I/O accessor functions */
 #define BBIO_SRAM(addr, bit) \
-	MMIO8(((addr) & 0x0FFFFF) * 32 + 0x22000000 + (bit) * 4)
+	MMIO32((((uint32_t)addr) & 0x0FFFFF) * 32 + 0x22000000 + (bit) * 4)
 
 #define BBIO_PERIPH(addr, bit) \
-	MMIO8(((addr) & 0x0FFFFF) * 32 + 0x42000000 + (bit) * 4)
+	MMIO32((((uint32_t)addr) & 0x0FFFFF) * 32 + 0x42000000 + (bit) * 4)
 
 /* Generic bit definition */
 #define BIT0  (1<<0)

--- a/include/libopencm3/stm32/common/spi_common_all.h
+++ b/include/libopencm3/stm32/common/spi_common_all.h
@@ -327,6 +327,45 @@ specific memorymap.h header before including this header file.*/
 /* CHLEN: Channel length */
 #define SPI_I2SCFGR_CHLEN			(1 << 0)
 
+/* --- Defines for spi_init_master, the calling code should not need to know
+   --- implementation details about what CR certain bits go into ----------- */
+
+/* Possible baudrate values */
+#define SPI_BAUDRATE_CLK_DIV_2   SPI_CR1_BAUDRATE_FPCLK_DIV_2 
+#define SPI_BAUDRATE_CLK_DIV_4   SPI_CR1_BAUDRATE_FPCLK_DIV_4
+#define SPI_BAUDRATE_CLK_DIV_8   SPI_CR1_BAUDRATE_FPCLK_DIV_8
+#define SPI_BAUDRATE_CLK_DIV_16  SPI_CR1_BAUDRATE_FPCLK_DIV_16
+#define SPI_BAUDRATE_CLK_DIV_32  SPI_CR1_BAUDRATE_FPCLK_DIV_32
+#define SPI_BAUDRATE_CLK_DIV_64  SPI_CR1_BAUDRATE_FPCLK_DIV_64
+#define SPI_BAUDRATE_CLK_DIV_128 SPI_CR1_BAUDRATE_FPCLK_DIV_128
+#define SPI_BAUDRATE_CLK_DIV_256 SPI_CR1_BAUDRATE_FPCLK_DIV_256
+
+/* The SPI mode bits */
+#define SPI_CLK_TO_1_WHEN_IDLE SPI_CR1_CPOL_CLK_TO_1_WHEN_IDLE
+#define SPI_CLK_TO_0_WHEN_IDLE SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE
+
+/* XXX check if these are the rigth way around. */
+#define SPI_LATCH_FALLING SPI_CR1_CPHA_CLK_TRANSITION_1
+#define SPI_LATCH_RISING  SPI_CR1_CPHA_CLK_TRANSITION_2
+
+/* XXX these should be or-ed together and the calling convention 
+   for spi_init_master should be changed. */
+/* XXX check if these are the right way around. */
+#define SPI_MODE0 SPI_CLK_TO_0_WHEN_IDLE,SPI_CR1_CPHA_CLK_TRANSITION_1
+#define SPI_MODE1 SPI_CLK_TO_0_WHEN_IDLE,SPI_CR1_CPHA_CLK_TRANSITION_2
+#define SPI_MODE2 SPI_CLK_TO_1_WHEN_IDLE,SPI_CR1_CPHA_CLK_TRANSITION_1
+#define SPI_MODE3 SPI_CLK_TO_1_WHEN_IDLE,SPI_CR1_CPHA_CLK_TRANSITION_2
+
+/* The data format */ 
+#define SPI_FORMAT_16BIT SPI_CR1_DFF_16BIT
+#define SPI_FORMAT_8BIT SPI_CR1_DFF_8BIT
+
+/* bit order */
+#define SPI_MSBFIRST SPI_CR1_MSBFIRST
+#define SPI_LSBFIRST SPI_CR1_LSBFIRST
+
+
+
 /* --- SPI_I2SPR values ---------------------------------------------------- */
 
 /* Note: None of these bits are used in SPI mode. */

--- a/lib/stm32/common/dac_common_all.c
+++ b/lib/stm32/common/dac_common_all.c
@@ -48,7 +48,7 @@ by specifying the appropriate register to the DMA controller.
 
 @section dac_api_basic_ex Basic DAC handling API.
 
-Set the DAC's GPIO port to any alternate function output mode. Enable the
+Set the DAC's GPIO port to analog in (RM0090 page 311).  Enable the
 DAC clock. Enable the DAC, set a trigger source and load the buffer
 with the first value. After the DAC is triggered, load the buffer with
 the next value. This example uses software triggering and added noise.

--- a/lib/stm32/common/flash_common_f24.c
+++ b/lib/stm32/common/flash_common_f24.c
@@ -229,7 +229,7 @@ void flash_program_double_word(uint32_t address, uint64_t data)
 	/* Enable writes to flash. */
 	FLASH_CR |= FLASH_CR_PG;
 
-	/* Program the first half of the word. */
+	/* Program the double_word. */
 	MMIO64(address) = data;
 
 	/* Wait for the write to complete. */
@@ -259,7 +259,7 @@ void flash_program_word(uint32_t address, uint32_t data)
 	/* Enable writes to flash. */
 	FLASH_CR |= FLASH_CR_PG;
 
-	/* Program the first half of the word. */
+	/* Program the word. */
 	MMIO32(address) = data;
 
 	/* Wait for the write to complete. */


### PR DESCRIPTION
The "spi_init_master" function required me, the user, to know that certain parameters were intended for certain control registers (mostly CR1). It's fine to directly use the function parameter in the implementation, but the coder using the function does not want to know what registers these things go into. So some additional defines were introduced that are control-register agnostic. 

Apparently my previous patch regarding some flash programming comments is also included. And maybe a DAC comment as well. I'm not good enough with GIT yet to separate those. Sorry. Feel free to educate me, especially if you want to keep them as separate commits in the master branch or something like that. 
