### PR TITLE
Prevent inadvertently clearing USB_EP_RX_CTR and USB_EP_TX_CTR

### DIFF
--- a/include/libopencm3/stm32/tools.h
+++ b/include/libopencm3/stm32/tools.h
@@ -34,8 +34,11 @@
 #define CLR_REG_BIT(REG, BIT)	SET_REG(REG, (~BIT))
 
 /* Clear register bit masking out some bits that must not be touched. */
+#define CLR_REG_BIT_MSK_AND_SET(REG, MSK, BIT, EXTRA_BITS) \
+		SET_REG(REG, (GET_REG(REG) & MSK & (~BIT)) | (EXTRA_BITS))
+
 #define CLR_REG_BIT_MSK(REG, MSK, BIT) \
-		SET_REG(REG, (GET_REG(REG) & MSK & (~BIT)))
+		CLR_REG_BIT_MSK_AND_SET(REG, MSK, BIT, 0)
 
 /* Get masked out bit value. */
 #define GET_REG_BIT(REG, BIT)	(GET_REG(REG) & BIT)
@@ -50,7 +53,7 @@
  *
  * TODO: We may need a faster implementation of that one?
  */
-#define TOG_SET_REG_BIT_MSK(REG, MSK, BIT)				\
+#define TOG_SET_REG_BIT_MSK_AND_SET(REG, MSK, BIT, EXTRA_BITS)		\
 do {									\
 	register uint16_t toggle_mask = GET_REG(REG) & (MSK);		\
 	register uint16_t bit_selector;					\
@@ -59,7 +62,10 @@ do {									\
 			toggle_mask ^= bit_selector;			\
 		}							\
 	}								\
-	SET_REG(REG, toggle_mask);					\
+	SET_REG(REG, toggle_mask | (EXTRA_BITS));			\
 } while (0)
+
+#define TOG_SET_REG_BIT_MSK(REG, MSK, BIT) \
+	TOG_SET_REG_BIT_MSK_AND_SET(REG, MSK, BIT, 0)
 
 #endif

--- a/include/libopencm3/stm32/usb.h
+++ b/include/libopencm3/stm32/usb.h
@@ -206,10 +206,12 @@ LGPL License Terms @ref lgpl_license
  * is why we use some helper macros for that.
  */
 #define USB_SET_EP_RX_STAT(EP, STAT) \
-	TOG_SET_REG_BIT_MSK(USB_EP_REG(EP), USB_EP_RX_STAT_TOG_MSK, STAT)
+	TOG_SET_REG_BIT_MSK_AND_SET(USB_EP_REG(EP), \
+		USB_EP_RX_STAT_TOG_MSK, STAT, USB_EP_RX_CTR | USB_EP_TX_CTR)
 
 #define USB_SET_EP_TX_STAT(EP, STAT) \
-	TOG_SET_REG_BIT_MSK(USB_EP_REG(EP), USB_EP_TX_STAT_TOG_MSK, STAT)
+	TOG_SET_REG_BIT_MSK_AND_SET(USB_EP_REG(EP), \
+		USB_EP_TX_STAT_TOG_MSK, STAT, USB_EP_RX_CTR | USB_EP_TX_CTR)
 
 /*
  * Macros for clearing and setting USB endpoint register bits that do
@@ -218,14 +220,15 @@ LGPL License Terms @ref lgpl_license
  * Because the register contains some bits that use the toggle
  * mechanism we need a helper macro here. Otherwise the code gets really messy.
  */
-#define USB_CLR_EP_NTOGGLE_BIT(EP, BIT) \
-	CLR_REG_BIT_MSK(USB_EP_REG(EP), USB_EP_NTOGGLE_MSK, BIT)
+#define USB_CLR_EP_NTOGGLE_BIT_AND_SET(EP, BIT, EXTRA_BITS) \
+	CLR_REG_BIT_MSK_AND_SET(USB_EP_REG(EP), \
+		USB_EP_NTOGGLE_MSK, BIT, EXTRA_BITS)
 
 #define USB_CLR_EP_RX_CTR(EP) \
-	USB_CLR_EP_NTOGGLE_BIT(EP, USB_EP_RX_CTR)
+	USB_CLR_EP_NTOGGLE_BIT_AND_SET(EP, USB_EP_RX_CTR, USB_EP_TX_CTR)
 
 #define USB_CLR_EP_TX_CTR(EP) \
-	USB_CLR_EP_NTOGGLE_BIT(EP, USB_EP_TX_CTR)
+	USB_CLR_EP_NTOGGLE_BIT_AND_SET(EP, USB_EP_TX_CTR, USB_EP_RX_CTR)
 
 #define USB_SET_EP_TYPE(EP, TYPE) \
 	SET_REG(USB_EP_REG(EP), \


### PR DESCRIPTION
USB_EP_RX_CTR and USB_EP_TX_CTR must be set when USB_EP_REG(n) is modified to prevent inadvertently clearing either bit. Writing a 1 for these bits causes no change to the register.

USB_EP_RX_CTR and USB_EP_TX_CTR should probably be removed from USB_EP_NTOGGLE_MSK but care will need to be taken to also OR in USB_EP_RX_CTR and USB_EP_TX_CTR anywhere the register is written.