### PR TITLE
cm3/cortex.h: specify headers for non-standard types explicitly

### DIFF
--- a/include/libopencm3/cm3/cortex.h
+++ b/include/libopencm3/cm3/cortex.h
@@ -31,6 +31,9 @@
 #ifndef LIBOPENCM3_CORTEX_H
 #define LIBOPENCM3_CORTEX_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 /**@{*/
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
If user includes cortex.h header without previously included stdbool.h
and stdint.h a build errors like this occur:

include/libopencm3/cm3/cortex.h:84:1: error: unknown type name 'bool'
 static inline bool cm_is_masked_interrupts(void)
 ^

Signed-off-by: Sam Protsenko <joe.skb7@gmail.com>