### PR TITLE
rcc_clock_setup_pll with HSE: enable HSE.

### DIFF
--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -497,9 +497,16 @@ void rcc_clock_setup_hsi(const clock_scale_t *clock)
 
 void rcc_clock_setup_pll(const clock_scale_t *clock)
 {
-	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	/* if high speed-speed external osc, enable before switching on PLL */
+	if(clock->pll_source == RCC_CFGR_PLLSRC_HSE_CLK){
+		rcc_osc_on(HSE);
+		rcc_wait_for_osc_ready(HSE);
+		rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
+	}else{
+		/* Enable internal high-speed oscillator. */
+		rcc_osc_on(HSI);
+		rcc_wait_for_osc_ready(HSI);
+	}
 
 	/*
 	 * Set prescalers for AHB, ADC, ABP1, ABP2.

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -501,7 +501,6 @@ void rcc_clock_setup_pll(const clock_scale_t *clock)
 	if(clock->pll_source == RCC_CFGR_PLLSRC_HSE_CLK){
 		rcc_osc_on(HSE);
 		rcc_wait_for_osc_ready(HSE);
-		rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 	}else{
 		/* Enable internal high-speed oscillator. */
 		rcc_osc_on(HSI);


### PR DESCRIPTION
BUG fix: rcc_clock_setup_pll with clock source HSE: enable HSE oscillator before switching clock source to PLL.

If not done, calling this function with clock set to HSE => CPU seems to stop running.


E.g., with an 8 MHz external crystal:
	 clock_scale_t config_hse_no_usb_32MHz = {
				.pll_source = RCC_CFGR_PLLSRC_HSE_CLK,
				.pll_mul = RCC_CFGR_PLLMUL_MUL8,
				.pll_div = RCC_CFGR_PLLDIV_DIV2,
				.hpre = RCC_CFGR_HPRE_SYSCLK_NODIV,
				.ppre1 = RCC_CFGR_PPRE1_HCLK_NODIV,
				.ppre2 = RCC_CFGR_PPRE2_HCLK_NODIV,
				.voltage_scale = RANGE1,
				.flash_config = FLASH_ACR_LATENCY_1WS,
				.apb1_frequency = 32000000,
				.apb2_frequency = 32000000,
	 };


	rcc_clock_setup_pll(&config_hse_no_usb_32MHz); 

Remark: USB clock source is not 48 MHz in this configuration but at 64 MHz. USB periph. requires a clock at 48 MHz