### PR TITLE
[stm32] fix i2c_reset

### DIFF
--- a/lib/stm32/common/i2c_common_all.c
+++ b/lib/stm32/common/i2c_common_all.c
@@ -53,16 +53,16 @@ void i2c_reset(uint32_t i2c)
 {
 	switch (i2c) {
 		case I2C1:
-			rcc_periph_reset_pulse(RCC_I2C1);
+			rcc_periph_reset_pulse(RST_I2C1);
 			break;
 #if defined(I2C2_BASE)
 		case I2C2:
-			rcc_periph_reset_pulse(RCC_I2C2);
+			rcc_periph_reset_pulse(RST_I2C2);
 			break;
 #endif
 #if defined(I2C3_BASE)
 		case I2C3:
-			rcc_periph_reset_pulse(RCC_I2C3);
+			rcc_periph_reset_pulse(RST_I2C3);
 			break;
 #endif
 		default:


### PR DESCRIPTION
rcc_periph_reset_pulse needs RST_I2Cx instead of RCC_I2Cx as argument
see also #329
