### PR TITLE
usb_standard: make possible to add extra descriptors to endpoints

### DIFF
--- a/include/libopencm3/usb/usbstd.h
+++ b/include/libopencm3/usb/usbstd.h
@@ -205,8 +205,14 @@ struct usb_endpoint_descriptor {
 	uint8_t bmAttributes;
 	uint16_t wMaxPacketSize;
 	uint8_t bInterval;
+	uint8_t bRefresh;
+	uint8_t bSynchAddress;
+
+	/* Descriptor ends here.  The following are used internally: */
+	const void *extra;
+	int extralen;
 } __attribute__((packed));
-#define USB_DT_ENDPOINT_SIZE		sizeof(struct usb_endpoint_descriptor)
+#define USB_DT_ENDPOINT_SIZE			9
 
 /* USB Endpoint Descriptor bmAttributes bit definitions */
 #define USB_ENDPOINT_ATTR_CONTROL		0x00

--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -98,6 +98,13 @@ static uint16_t build_config_descriptor(usbd_device *usbd_dev,
 				len -= count;
 				total += count;
 				totallen += ep->bLength;
+				/* Copy extra endpoint descriptors. */
+				memcpy(buf, ep->extra,
+				       count = MIN(len, ep->extralen));
+				buf += count;
+				len -= count;
+				total += count;
+				totallen += ep->extralen;
 			}
 		}
 	}


### PR DESCRIPTION
I'm using this to implement USB MIDI Class device, but can be useful in other cases.
