### PR TITLE
call pre_main before C++ constructors

### DIFF
--- a/lib/cm3/vector.c
+++ b/lib/cm3/vector.c
@@ -74,6 +74,9 @@ void WEAK __attribute__ ((naked)) reset_handler(void)
 		*dest++ = 0;
 	}
 
+	/* might be provided by platform specific vector.c */
+	pre_main();
+
 	/* Constructors. */
 	for (fp = &__preinit_array_start; fp < &__preinit_array_end; fp++) {
 		(*fp)();
@@ -81,9 +84,6 @@ void WEAK __attribute__ ((naked)) reset_handler(void)
 	for (fp = &__init_array_start; fp < &__init_array_end; fp++) {
 		(*fp)();
 	}
-
-	/* might be provided by platform specific vector.c */
-	pre_main();
 
 	/* Call the application's entry point. */
 	main();


### PR DESCRIPTION
This moves the platform specific initialization function pre_main
in front of C++ constructors. This is especially necessary for
platforms which need to setup the stack pointer (pre_main itself
is inline, hence no stack needed for this function).

This change is especially required for my Vybrid (vf6xx) pull requests, however I checked the other platforms what they are initializing in this function: STM32F4 enables the floating point unit in this function. I think its totally feasible that somebody uses floating point instructions in a C++ constructor, hence I think moving this is correct anyway.
