### PR TITLE
Add timers 9-17.  This should support all F0, F1, and F2 products

### DIFF
--- a/include/libopencm3/stm32/common/timer_common_all.h
+++ b/include/libopencm3/stm32/common/timer_common_all.h
@@ -54,6 +54,33 @@ specific memorymap.h header before including this header file.*/
 #if defined(TIM8_BASE)
 # define TIM8				TIM8_BASE
 #endif
+#if defined(TIM9_BASE)
+# define TIM9				TIM9_BASE
+#endif
+#if defined(TIM10_BASE)
+# define TIM10				TIM10_BASE
+#endif
+#if defined(TIM11_BASE)
+# define TIM11				TIM11_BASE
+#endif
+#if defined(TIM12_BASE)
+# define TIM12				TIM12_BASE
+#endif
+#if defined(TIM13_BASE)
+# define TIM13				TIM13_BASE
+#endif
+#if defined(TIM14_BASE)
+# define TIM14				TIM14_BASE
+#endif
+#if defined(TIM15_BASE)
+# define TIM15				TIM15_BASE
+#endif
+#if defined(TIM16_BASE)
+# define TIM16				TIM16_BASE
+#endif
+#if defined(TIM17_BASE)
+# define TIM17				TIM17_BASE
+#endif
 /**@}*/
 
 /* --- Timer registers ----------------------------------------------------- */
@@ -68,6 +95,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_CR1			TIM_CR1(TIM6)
 #define TIM7_CR1			TIM_CR1(TIM7)
 #define TIM8_CR1			TIM_CR1(TIM8)
+#define TIM9_CR1			TIM_CR1(TIM9)
+#define TIM10_CR1			TIM_CR1(TIM10)
+#define TIM11_CR1			TIM_CR1(TIM11)
+#define TIM12_CR1			TIM_CR1(TIM12)
+#define TIM13_CR1			TIM_CR1(TIM13)
+#define TIM14_CR1			TIM_CR1(TIM14)
+#define TIM15_CR1			TIM_CR1(TIM15)
+#define TIM16_CR1			TIM_CR1(TIM16)
+#define TIM17_CR1			TIM_CR1(TIM17)
 
 /* Control register 2 (TIMx_CR2) */
 #define TIM_CR2(tim_base)		MMIO32(tim_base + 0x04)
@@ -79,6 +115,9 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_CR2			TIM_CR2(TIM6)
 #define TIM7_CR2			TIM_CR2(TIM7)
 #define TIM8_CR2			TIM_CR2(TIM8)
+#define TIM15_CR2			TIM_CR2(TIM15)
+#define TIM16_CR2			TIM_CR2(TIM16)
+#define TIM17_CR2			TIM_CR2(TIM17)
 
 /* Slave mode control register (TIMx_SMCR) */
 #define TIM_SMCR(tim_base)		MMIO32(tim_base + 0x08)
@@ -88,6 +127,9 @@ specific memorymap.h header before including this header file.*/
 #define TIM4_SMCR			TIM_SMCR(TIM4)
 #define TIM5_SMCR			TIM_SMCR(TIM5)
 #define TIM8_SMCR			TIM_SMCR(TIM8)
+#define TIM9_SMCR			TIM_SMCR(TIM9)
+#define TIM12_SMCR			TIM_SMCR(TIM12)
+#define TIM15_SMCR			TIM_SMCR(TIM15)
 
 /* DMA/Interrupt enable register (TIMx_DIER) */
 #define TIM_DIER(tim_base)		MMIO32(tim_base + 0x0C)
@@ -99,6 +141,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_DIER			TIM_DIER(TIM6)
 #define TIM7_DIER			TIM_DIER(TIM7)
 #define TIM8_DIER			TIM_DIER(TIM8)
+#define TIM9_DIER			TIM_DIER(TIM9)
+#define TIM10_DIER			TIM_DIER(TIM10)
+#define TIM11_DIER			TIM_DIER(TIM11)
+#define TIM12_DIER			TIM_DIER(TIM12)
+#define TIM13_DIER			TIM_DIER(TIM13)
+#define TIM14_DIER			TIM_DIER(TIM14)
+#define TIM15_DIER			TIM_DIER(TIM15)
+#define TIM16_DIER			TIM_DIER(TIM16)
+#define TIM17_DIER			TIM_DIER(TIM17)
 
 /* Status register (TIMx_SR) */
 #define TIM_SR(tim_base)		MMIO32(tim_base + 0x10)
@@ -110,6 +161,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_SR				TIM_SR(TIM6)
 #define TIM7_SR				TIM_SR(TIM7)
 #define TIM8_SR				TIM_SR(TIM8)
+#define TIM9_SR				TIM_SR(TIM9)
+#define TIM10_SR			TIM_SR(TIM10)
+#define TIM11_SR			TIM_SR(TIM11)
+#define TIM12_SR			TIM_SR(TIM12)
+#define TIM13_SR			TIM_SR(TIM13)
+#define TIM14_SR			TIM_SR(TIM14)
+#define TIM15_SR			TIM_SR(TIM15)
+#define TIM16_SR			TIM_SR(TIM16)
+#define TIM17_SR			TIM_SR(TIM17)
 
 /* Event generation register (TIMx_EGR) */
 #define TIM_EGR(tim_base)		MMIO32(tim_base + 0x14)
@@ -121,6 +181,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_EGR			TIM_EGR(TIM6)
 #define TIM7_EGR			TIM_EGR(TIM7)
 #define TIM8_EGR			TIM_EGR(TIM8)
+#define TIM9_EGR			TIM_EGR(TIM9)
+#define TIM10_EGR			TIM_EGR(TIM10)
+#define TIM11_EGR			TIM_EGR(TIM11)
+#define TIM12_EGR			TIM_EGR(TIM12)
+#define TIM13_EGR			TIM_EGR(TIM13)
+#define TIM14_EGR			TIM_EGR(TIM14)
+#define TIM15_EGR			TIM_EGR(TIM15)
+#define TIM16_EGR			TIM_EGR(TIM16)
+#define TIM17_EGR			TIM_EGR(TIM17)
 
 /* Capture/compare mode register 1 (TIMx_CCMR1) */
 #define TIM_CCMR1(tim_base)		MMIO32(tim_base + 0x18)
@@ -130,6 +199,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM4_CCMR1			TIM_CCMR1(TIM4)
 #define TIM5_CCMR1			TIM_CCMR1(TIM5)
 #define TIM8_CCMR1			TIM_CCMR1(TIM8)
+#define TIM9_CCMR1			TIM_CCMR1(TIM9)
+#define TIM10_CCMR1			TIM_CCMR1(TIM10)
+#define TIM11_CCMR1			TIM_CCMR1(TIM11)
+#define TIM12_CCMR1			TIM_CCMR1(TIM12)
+#define TIM13_CCMR1			TIM_CCMR1(TIM13)
+#define TIM14_CCMR1			TIM_CCMR1(TIM14)
+#define TIM15_CCMR1			TIM_CCMR1(TIM15)
+#define TIM16_CCMR1			TIM_CCMR1(TIM16)
+#define TIM17_CCMR1			TIM_CCMR1(TIM17)
 
 /* Capture/compare mode register 2 (TIMx_CCMR2) */
 #define TIM_CCMR2(tim_base)		MMIO32(tim_base + 0x1C)
@@ -148,6 +226,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM4_CCER			TIM_CCER(TIM4)
 #define TIM5_CCER			TIM_CCER(TIM5)
 #define TIM8_CCER			TIM_CCER(TIM8)
+#define TIM9_CCER			TIM_CCER(TIM9)
+#define TIM10_CCER			TIM_CCER(TIM10)
+#define TIM11_CCER			TIM_CCER(TIM11)
+#define TIM12_CCER			TIM_CCER(TIM12)
+#define TIM13_CCER			TIM_CCER(TIM13)
+#define TIM14_CCER			TIM_CCER(TIM14)
+#define TIM15_CCER			TIM_CCER(TIM15)
+#define TIM16_CCER			TIM_CCER(TIM16)
+#define TIM17_CCER			TIM_CCER(TIM17)
 
 /* Counter (TIMx_CNT) */
 #define TIM_CNT(tim_base)		MMIO32(tim_base + 0x24)
@@ -159,6 +246,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_CNT			TIM_CNT(TIM6)
 #define TIM7_CNT			TIM_CNT(TIM7)
 #define TIM8_CNT			TIM_CNT(TIM8)
+#define TIM9_CNT			TIM_CNT(TIM9)
+#define TIM10_CNT			TIM_CNT(TIM10)
+#define TIM11_CNT			TIM_CNT(TIM11)
+#define TIM12_CNT			TIM_CNT(TIM12)
+#define TIM13_CNT			TIM_CNT(TIM13)
+#define TIM14_CNT			TIM_CNT(TIM14)
+#define TIM15_CNT			TIM_CNT(TIM15)
+#define TIM16_CNT			TIM_CNT(TIM16)
+#define TIM17_CNT			TIM_CNT(TIM17)
 
 /* Prescaler (TIMx_PSC) */
 #define TIM_PSC(tim_base)		MMIO32(tim_base + 0x28)
@@ -170,6 +266,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_PSC			TIM_PSC(TIM6)
 #define TIM7_PSC			TIM_PSC(TIM7)
 #define TIM8_PSC			TIM_PSC(TIM8)
+#define TIM9_PSC			TIM_PSC(TIM9)
+#define TIM10_PSC			TIM_PSC(TIM10)
+#define TIM11_PSC			TIM_PSC(TIM11)
+#define TIM12_PSC			TIM_PSC(TIM12)
+#define TIM13_PSC			TIM_PSC(TIM13)
+#define TIM14_PSC			TIM_PSC(TIM14)
+#define TIM15_PSC			TIM_PSC(TIM15)
+#define TIM16_PSC			TIM_PSC(TIM16)
+#define TIM17_PSC			TIM_PSC(TIM17)
 
 /* Auto-reload register (TIMx_ARR) */
 #define TIM_ARR(tim_base)		MMIO32(tim_base + 0x2C)
@@ -181,11 +286,23 @@ specific memorymap.h header before including this header file.*/
 #define TIM6_ARR			TIM_ARR(TIM6)
 #define TIM7_ARR			TIM_ARR(TIM7)
 #define TIM8_ARR			TIM_ARR(TIM8)
+#define TIM9_ARR			TIM_ARR(TIM9)
+#define TIM10_ARR			TIM_ARR(TIM10)
+#define TIM11_ARR			TIM_ARR(TIM11)
+#define TIM12_ARR			TIM_ARR(TIM12)
+#define TIM13_ARR			TIM_ARR(TIM13)
+#define TIM14_ARR			TIM_ARR(TIM14)
+#define TIM15_ARR			TIM_ARR(TIM15)
+#define TIM16_ARR			TIM_ARR(TIM16)
+#define TIM17_ARR			TIM_ARR(TIM17)
 
 /* Repetition counter register (TIMx_RCR) */
 #define TIM_RCR(tim_base)		MMIO32(tim_base + 0x30)
 #define TIM1_RCR			TIM_RCR(TIM1)
 #define TIM8_RCR			TIM_RCR(TIM8)
+#define TIM15_RCR			TIM_RCR(TIM15)
+#define TIM16_RCR			TIM_RCR(TIM16)
+#define TIM17_RCR			TIM_RCR(TIM17)
 
 /* Capture/compare register 1 (TIMx_CCR1) */
 #define TIM_CCR1(tim_base)		MMIO32(tim_base + 0x34)
@@ -195,6 +312,15 @@ specific memorymap.h header before including this header file.*/
 #define TIM4_CCR1			TIM_CCR1(TIM4)
 #define TIM5_CCR1			TIM_CCR1(TIM5)
 #define TIM8_CCR1			TIM_CCR1(TIM8)
+#define TIM9_CCR1			TIM_CCR1(TIM9)
+#define TIM10_CCR1			TIM_CCR1(TIM10)
+#define TIM11_CCR1			TIM_CCR1(TIM11)
+#define TIM12_CCR1			TIM_CCR1(TIM12)
+#define TIM13_CCR1			TIM_CCR1(TIM13)
+#define TIM14_CCR1			TIM_CCR1(TIM14)
+#define TIM15_CCR1			TIM_CCR1(TIM15)
+#define TIM16_CCR1			TIM_CCR1(TIM16)
+#define TIM17_CCR1			TIM_CCR1(TIM17)
 
 /* Capture/compare register 2 (TIMx_CCR2) */
 #define TIM_CCR2(tim_base)		MMIO32(tim_base + 0x38)
@@ -204,6 +330,9 @@ specific memorymap.h header before including this header file.*/
 #define TIM4_CCR2			TIM_CCR2(TIM4)
 #define TIM5_CCR2			TIM_CCR2(TIM5)
 #define TIM8_CCR2			TIM_CCR2(TIM8)
+#define TIM9_CCR2			TIM_CCR2(TIM9)
+#define TIM12_CCR2			TIM_CCR2(TIM12)
+#define TIM15_CCR2			TIM_CCR2(TIM15)
 
 /* Capture/compare register 3 (TIMx_CCR3) */
 #define TIM_CCR3(tim_base)		MMIO32(tim_base + 0x3C)
@@ -227,6 +356,9 @@ specific memorymap.h header before including this header file.*/
 #define TIM_BDTR(tim_base)		MMIO32(tim_base + 0x44)
 #define TIM1_BDTR			TIM_BDTR(TIM1)
 #define TIM8_BDTR			TIM_BDTR(TIM8)
+#define TIM15_BDTR			TIM_BDTR(TIM15)
+#define TIM16_BDTR			TIM_BDTR(TIM16)
+#define TIM17_BDTR			TIM_BDTR(TIM17)
 
 /* DMA control register (TIMx_DCR) */
 #define TIM_DCR(tim_base)		MMIO32(tim_base + 0x48)
@@ -236,6 +368,9 @@ specific memorymap.h header before including this header file.*/
 #define TIM4_DCR			TIM_DCR(TIM4)
 #define TIM5_DCR			TIM_DCR(TIM5)
 #define TIM8_DCR			TIM_DCR(TIM8)
+#define TIM15_DCR			TIM_DCR(TIM15)
+#define TIM16_DCR			TIM_DCR(TIM16)
+#define TIM17_DCR			TIM_DCR(TIM17)
 
 /* DMA address for full transfer (TIMx_DMAR) */
 #define TIM_DMAR(tim_base)		MMIO32(tim_base + 0x4C)
@@ -245,6 +380,9 @@ specific memorymap.h header before including this header file.*/
 #define TIM4_DMAR			TIM_DMAR(TIM4)
 #define TIM5_DMAR			TIM_DMAR(TIM5)
 #define TIM8_DMAR			TIM_DMAR(TIM8)
+#define TIM15_DMAR			TIM_DMAR(TIM15)
+#define TIM16_DMAR			TIM_DMAR(TIM16)
+#define TIM17_DMAR			TIM_DMAR(TIM17)
 
 /* --- TIMx_CR1 values ----------------------------------------------------- */
 


### PR DESCRIPTION
This resolves #349 by adding deifies for TIM9 through TIM17
I verified the documentation for the F0, F1, and F2 lines that these will cover all timers available to those processors.
