### PR TITLE
Doxygen: Generic _commmon_ EXCLUDE_PATTERNS for stm32 family

### DIFF
--- a/doc/stm32f0/Doxyfile
+++ b/doc/stm32f0/Doxyfile
@@ -25,9 +25,10 @@ INPUT                  += ../../lib/stm32/f0 \
 EXCLUDE                 = ../../include/libopencm3/stm32/f0/usb.h \
                          ../../include/libopencm3/stm32/f0/usb_desc.h
 
-EXCLUDE_PATTERNS	= *_common_*f24.h *_common_*f24.c \
-                          *_common_*f234.h *_common_*f234.c \
-                          *_common_*f124.h *_common_*f124.c
+EXCLUDE_PATTERNS	= *_common_*f1*.h *_common_*f1*.c \
+                          *_common_*f2*.h *_common_*f2*.c \
+                          *_common_*f3*.h *_common_*f3*.c \
+                          *_common_*f4.h *_common_*f4.c
 
 LAYOUT_FILE 	        = DoxygenLayout_stm32f0.xml
 

--- a/doc/stm32f1/Doxyfile
+++ b/doc/stm32f1/Doxyfile
@@ -25,10 +25,13 @@ INPUT                 += ../../lib/stm32/f1 \
 EXCLUDE                = ../../include/libopencm3/stm32/f1/usb.h \
                          ../../include/libopencm3/stm32/f1/usb_desc.h
 
-EXCLUDE_PATTERNS       = *_common_*f24.h *_common_*f24.c \
-                         *_common_*f234.h *_common_*f234.c \
-                         *_common_*f024.h *_common_*f024.c \
-                         *_common_*f03.h *_common_*f03.c
+EXCLUDE_PATTERNS       = *_common_*f0.h *_common_*f0.c \
+                         *_common_*f02*.h *_common_*f02*.c \
+                         *_common_*f03*.h *_common_*f03*.c \
+                         *_common_*f04*.h *_common_*f04*.c \
+                         *_common_*f2*.h *_common_*f2*.c \
+                         *_common_*f3*.h *_common_*f3*.c \
+                         *_common_*f4.h *_common_*f4.c
 
 LAYOUT_FILE 	       = DoxygenLayout_stm32f1.xml
 

--- a/doc/stm32f2/Doxyfile
+++ b/doc/stm32f2/Doxyfile
@@ -24,10 +24,14 @@ INPUT                 += ../../lib/stm32/f2 \
 
 EXCLUDE                = 
 
-EXCLUDE_PATTERNS       = *_common_f13.h *_common_f13.c \
-                         *_common_*f013.h *_common_*f013.c \
-                         *_common_*f01.h *_common_*f01.c \
-                         *_common_*f03.h *_common_*f03.c
+EXCLUDE_PATTERNS       = *_common_*f0.h *_common_*f0.c \
+                         *_common_*f*1.h *_common_*f*1.c \
+                         *_common_*f03*.h *_common_*f03*.c \
+                         *_common_*f04.h *_common_*f04.c \
+                         *_common_*f*13*.h *_common_*f*13*.c \
+                         *_common_*f*14*.h *_common_*f*14*.c \
+                         *_common_*f3*.h *_common_*f3*.c \
+                         *_common_*f4.h *_common_*f4.c
 
 LAYOUT_FILE 	       = DoxygenLayout_stm32f2.xml
 

--- a/doc/stm32f3/Doxyfile
+++ b/doc/stm32f3/Doxyfile
@@ -22,8 +22,13 @@ INPUT                 += ../../lib/stm32/f3 \
 EXCLUDE                = ../../include/libopencm3/stm32/f3/usb.h \
                          ../../include/libopencm3/stm32/f3/usb_desc.h
 
-EXCLUDE_PATTERNS	= *_common_*f*24.h *_common_*f*24.c \
-                          *_common_*f01.h *_common_*f01.c \
+EXCLUDE_PATTERNS	= *_common_*f0.h *_common_*f0.c \
+                          *_common_*f*1.h *_common_*f*1.c \
+                          *_common_*f*2.h *_common_*f*2.c \
+                          *_common_*f*04.h *_common_*f*04.c \
+                          *_common_*f*14.h *_common_*f*14.c \
+                          *_common_*f*24.h *_common_*f*24.c \
+                          *_common_*f4.h *_common_*f4.c \
                           *_common_bcd.h *_common_bcd.c
 
 LAYOUT_FILE		= DoxygenLayout_stm32f3.xml

--- a/doc/stm32f4/Doxyfile
+++ b/doc/stm32f4/Doxyfile
@@ -24,10 +24,11 @@ INPUT                 += ../../lib/stm32/f4 \
 
 EXCLUDE                = 
 
-EXCLUDE_PATTERNS       = *_common_f*3.h *_common_f*3.c \
-                         *_common_*f013.h *_common_*f013.c \
-                         *_common_*f01.h *_common_*f01.c \ \
-                         *_common_*f03.h *_common_*f03.c
+EXCLUDE_PATTERNS       = *_common_*f0.h *_common_*f0.c \
+                         *_common_*f*1.h *_common_*f*1.c \
+                         *_common_*f*2.h *_common_*f*2.c \
+                         *_common_*f*3.h *_common_*f*3.c
+
 
 LAYOUT_FILE 	       = DoxygenLayout_stm32f4.xml
 

--- a/doc/stm32l1/Doxyfile
+++ b/doc/stm32l1/Doxyfile
@@ -22,17 +22,9 @@ INPUT                  = ../../include/libopencm3/license.dox \
 INPUT                 += ../../lib/stm32/l1 \
 			 ../../lib/stm32/common
 
-EXCLUDE                = ../../include/libopencm3/stm32/common/gpio_common_f24.h \
-                         ../../include/libopencm3/stm32/common/timer_common_f24.h \
-                         ../../include/libopencm3/stm32/common/crypto_common_f24.h \
-                         ../../include/libopencm3/stm32/common/hash_common_f24.h
+EXCLUDE                = 
 
-EXCLUDE               += ../../lib/stm32/common/gpio_common_f24.c \
-                         ../../lib/stm32/common/timer_common_f24.c \
-                         ../../lib/stm32/common/crypto_common_f24.c \
-                         ../../lib/stm32/common/hash_common_f24.c
-
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = *_common_f*.h *_common_f*.c
 
 LAYOUT_FILE 	       = DoxygenLayout_stm32l1.xml
 


### PR DESCRIPTION
When I scrolled through the Doxygen docs, I discovered that some STM32 platforms reference files and functions that do not belong to them.

E.g. STM32F1 GPIO module includes `gpio_common_f0234.c`, STM32L1 DMA module includes `dma_common_f24.c`.

Obvioiusly, this is caused by insufficient exclude patterns in the corresponding `Doxyfile`s. This PR should fix that for now and for the future. :)

---

**Commit message**

Previously, most exclude patterns were written to match exactly one type
of common file, e.g. _common_f02.h files.
The drawback of this method is that newly added files are not covered
by the existing exclude pattern and thus pollute the generated
documentation of controllers they do not belong to.

These more generic exclude patterns instead handle all kind of possible
combinations of existing stm32 platforms (L1,F[0-4]) (that follow the
current naming convention).
