### PR TITLE
Arm m0 rcc addition

### DIFF
--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -518,6 +518,8 @@ void rcc_clock_setup_in_hsi_out_48mhz(void);
 void rcc_clock_setup_in_hse_8mhz_out_48mhz(void);
 void rcc_periph_clock_enable(enum rcc_periph_clken periph);
 void rcc_periph_clock_disable(enum rcc_periph_clken periph);
+void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset);
+void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset);
 void rcc_periph_reset_pulse(enum rcc_periph_rst periph);
 void rcc_periph_reset_hold(enum rcc_periph_rst periph);
 void rcc_periph_reset_release(enum rcc_periph_rst periph);

--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -129,6 +129,8 @@ Control</b>
 #define RCC_CFGR_PLLSRC0			(1<<15)
 #define RCC_CFGR_ADCPRE				(1<<14)
 
+#define RCC_CFGR_PLLXTPRE_HSE_CLK		0x0
+#define RCC_CFGR_PLLSRC_HSE_CLK			0x1
 
 #define RCC_CFGR_PPRE_SHIFT			8
 #define RCC_CFGR_PPRE				(7 << RCC_CFGR_PPRE_SHIFT)
@@ -500,6 +502,8 @@ void rcc_css_int_clear(void);
 int rcc_css_int_flag(void);
 void rcc_set_sysclk_source(enum rcc_osc clk);
 void rcc_set_pll_multiplication_factor(uint32_t mul);
+void rcc_set_pll_source(uint32_t pllsrc);
+void rcc_set_pllxtpre(uint32_t pllxtpre);
 void rcc_set_ppre(uint32_t ppre);
 void rcc_set_hpre(uint32_t hpre);
 void rcc_set_prediv(uint32_t prediv);
@@ -511,6 +515,7 @@ void rcc_clock_setup_in_hsi_out_24mhz(void);
 void rcc_clock_setup_in_hsi_out_32mhz(void);
 void rcc_clock_setup_in_hsi_out_40mhz(void);
 void rcc_clock_setup_in_hsi_out_48mhz(void);
+void rcc_clock_setup_in_hse_8mhz_out_48mhz(void);
 void rcc_periph_clock_enable(enum rcc_periph_clken periph);
 void rcc_periph_clock_disable(enum rcc_periph_clken periph);
 void rcc_periph_reset_pulse(enum rcc_periph_rst periph);

--- a/include/libopencm3/stm32/f0/timer.h
+++ b/include/libopencm3/stm32/f0/timer.h
@@ -34,4 +34,18 @@
 
 #include <libopencm3/stm32/common/timer_common_all.h>
 
+/** Input Capture input polarity */
+enum tim_ic_pol {
+	TIM_IC_RISING,
+	TIM_IC_FALLING,
+};
+
+BEGIN_DECLS
+
+void timer_ic_set_polarity(uint32_t timer,
+			   enum tim_ic_id ic,
+			   enum tim_ic_pol pol);
+
+END_DECLS
+
 #endif

--- a/lib/stm32/can.c
+++ b/lib/stm32/can.c
@@ -37,7 +37,9 @@ LGPL License Terms @ref lgpl_license
 
 #include <libopencm3/stm32/can.h>
 
-#if defined(STM32F1)
+#if defined(STM32F0)
+#	include <libopencm3/stm32/f0/rcc.h>
+#elif defined(STM32F1)
 #	include <libopencm3/stm32/f1/rcc.h>
 #elif defined(STM32F2)
 #	include <libopencm3/stm32/f2/rcc.h>
@@ -71,6 +73,10 @@ can_reg_base.
  */
 void can_reset(uint32_t canport)
 {
+#if defined(STM32F0)
+	rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CANRST);
+	rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CANRST);
+#else
 	if (canport == CAN1) {
 		rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN1RST);
 		rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN1RST);
@@ -78,6 +84,7 @@ void can_reset(uint32_t canport)
 		rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN2RST);
 		rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN2RST);
 	}
+#endif
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -35,7 +35,7 @@ CFLAGS		= -Os -g \
 ARFLAGS		= rcs
 
 OBJS		= flash.o rcc.o usart.o dma.o rtc.o comparator.o crc.o \
-                  dac.o i2c.o iwdg.o pwr.o gpio.o timer.o adc.o
+                  dac.o i2c.o iwdg.o pwr.o gpio.o timer.o adc.o can.o
 
 OBJS            += gpio_common_all.o gpio_common_f0234.o crc_common_all.o \
                    pwr_common_all.o iwdg_common_all.o rtc_common_l1f024.o \

--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -686,7 +686,7 @@ void rcc_clock_setup_in_hse_8mhz_out_48mhz(void)
 
 	/*
 	 * Set the PLL multiplication factor to 3.
-	 * 8MHz (external) * 6 (multiplier) = 24MHz
+	 * 8MHz (external) * 6 (multiplier) = 48MHz
 	 */
 	rcc_set_pll_multiplication_factor(RCC_CFGR_PLLMUL_MUL6);
 

--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -723,6 +723,47 @@ void rcc_periph_clock_disable(enum rcc_periph_clken periph)
 	_RCC_REG(periph) &= ~_RCC_BIT(periph);
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief RCC Reset Peripherals.
+ *
+ * Reset particular peripherals. There are three registers involved, each one
+ * controlling reset of peripherals associated with the AHB, APB1 and APB2
+ * respectively. Several peripherals could be reset simultaneously <em>only if
+ * they are controlled by the same register</em>.
+ *
+ * @param[in] *reg Unsigned int32. Pointer to a Reset Register
+ *			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
+ * @param[in] reset Unsigned int32. Logical OR of all resets.
+ * @li If register is RCC_AHBRSTR, from @ref rcc_ahbrstr_rst
+ * @li If register is RCC_APB1RSTR, from @ref rcc_apb1rstr_rst
+ * @li If register is RCC_APB2RSTR, from @ref rcc_apb2rstr_rst
+ */
+void rcc_peripheral_reset(volatile uint32_t *reg, uint32_t reset)
+{
+	*reg |= reset;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief RCC Remove Reset on Peripherals.
+ *
+ * Remove the reset on particular peripherals. There are three registers
+ * involved, each one controlling reset of peripherals associated with the AHB,
+ * APB1 and APB2 respectively. Several peripherals could have the reset removed
+ * simultaneously <em>only if they are controlled by the same register</em>.
+ *
+ * @param[in] *reg Unsigned int32. Pointer to a Reset Register
+ *			 (either RCC_AHBENR, RCC_APB1ENR or RCC_APB2ENR)
+ * @param[in] clear_reset Unsigned int32. Logical OR of all resets to be
+ * removed:
+ * @li If register is RCC_AHBRSTR, from @ref rcc_ahbrstr_rst
+ * @li If register is RCC_APB1RSTR, from @ref rcc_apb1rstr_rst
+ * @li If register is RCC_APB2RSTR, from @ref rcc_apb2rstr_rst
+ */
+void rcc_peripheral_clear_reset(volatile uint32_t *reg, uint32_t clear_reset)
+{
+	*reg &= ~clear_reset;
+}
+
 void rcc_periph_reset_pulse(enum rcc_periph_rst periph)
 {
 	_RCC_REG(periph) |= _RCC_BIT(periph);

--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -661,49 +661,57 @@ void rcc_clock_setup_in_hse_8mhz_out_48mhz(void)
 	rcc_osc_on(HSI);
 	rcc_wait_for_osc_ready(HSI);
 
-	/* Select HSI as SYSCLK source. */
+	// Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(HSI);
-
-	/* Enable external high-speed oscillator 8MHz. */
+/*
 	rcc_osc_on(HSE);
 	rcc_wait_for_osc_ready(HSE);
 	rcc_set_sysclk_source(HSE);
 
-	/*
-	 * Set prescalers for AHB, ABP
-	 * Do this before touching the PLL (TODO: why?).
-	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
 
-	/*
-	 * Sysclk runs with 24MHz -> 0 waitstates.
-	 * 0WS from 0-24MHz
-	 * 1WS from 24-48MHz
-	 * 2WS from 48-72MHz
-	 */
 	flash_set_ws(FLASH_ACR_LATENCY_024_048MHZ);
 
-	/*
-	 * Set the PLL multiplication factor to 3.
-	 * 8MHz (external) * 6 (multiplier) = 48MHz
-	 */
-	rcc_set_pll_multiplication_factor(RCC_CFGR_PLLMUL_MUL6);
+	rcc_set_pll_multiplication_factor(RCC_CFGR_PLLMUL_MUL1);
 
-	/* Select HSE as PLL source. */
 	rcc_set_pll_source(RCC_CFGR_PLLSRC_HSE_CLK);
 
-	/*
-	 * External frequency undivided before entering PLL
-	 * (only valid/needed for HSE).
-	 */
 	rcc_set_pllxtpre(RCC_CFGR_PLLXTPRE_HSE_CLK);
 
-	/* Enable PLL oscillator and wait for it to stabilize. */
 	rcc_osc_on(PLL);
 	rcc_wait_for_osc_ready(PLL);
 
-	/* Select PLL as SYSCLK source. */
+	rcc_set_sysclk_source(PLL);
+*/
+    RCC_CFGR &= (uint32_t)0xF8FFB80C;
+    RCC_CR &= (uint32_t)0xFEF6FFFF;
+    RCC_CR &= (uint32_t)0xFFFBFFFF;
+    RCC_CFGR &= (uint32_t)0xFFC0FFFF;
+    RCC_CFGR2 &= (uint32_t)0xFFFFFFF0;
+    RCC_CFGR3 &= (uint32_t)0xFFFFFEAC;
+    RCC_CR2 &= (uint32_t)0xFFFFFFFE;
+    RCC_CIR &= (uint32_t)0x00000000;
+
+	rcc_osc_on(HSE);
+	rcc_wait_for_osc_ready(HSE);
+	flash_set_ws(FLASH_ACR_LATENCY_024_048MHZ);
+
+	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
+	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
+
+#define RCC_CFGR_PLLSRC_X        ((uint32_t)0x00018000)
+#define RCC_CFGR_PLLXTPRE_X      ((uint32_t)0x00020000)
+#define RCC_CFGR_PLLMULL         ((uint32_t)0x003C0000)
+#define RCC_CFGR_PLLSRC_PREDIV1  ((uint32_t)0x00010000)
+#define RCC_CFG_PLLXTPRE_PREDIV1 ((uint32_t)0x00000000)
+#define RCC_CFGR_PLLMUL6         ((uint32_t)0x00100000)
+
+    RCC_CFGR &= (uint32_t)~(RCC_CFGR_PLLSRC_X|RCC_CFGR_PLLXTPRE_X|RCC_CFGR_PLLMULL);
+    RCC_CFGR |= (uint32_t)(RCC_CFGR_PLLSRC_PREDIV1|RCC_CFG_PLLXTPRE_PREDIV1|RCC_CFGR_PLLMUL6);
+
+	rcc_osc_on(PLL);
+	rcc_wait_for_osc_ready(PLL);
 	rcc_set_sysclk_source(PLL);
 
 	rcc_ppre_frequency = 48000000;

--- a/lib/stm32/f0/timer.c
+++ b/lib/stm32/f0/timer.c
@@ -32,3 +32,21 @@
 
 #include <libopencm3/stm32/timer.h>
 
+/*---------------------------------------------------------------------------*/
+/** @brief Set Input Polarity
+
+@param[in] timer_peripheral Unsigned int32. Timer register address base
+@param[in] ic ::tim_ic_id. Input Capture channel designator.
+@param[in] pol ::tim_ic_pol. Input Capture polarity.
+*/
+
+void timer_ic_set_polarity(uint32_t timer_peripheral, enum tim_ic_id ic,
+			   enum tim_ic_pol pol)
+{
+	if (pol) {
+		TIM_CCER(timer_peripheral) |= (0x2 << (ic * 4));
+	} else {
+		TIM_CCER(timer_peripheral) &= ~(0x2 << (ic * 4));
+	}
+}
+


### PR DESCRIPTION
I'm doing a project with an stm32 M0 chip (STM32F042C6), which runs on 48MHz max. This chip also has a CAN bus. Some defines had to be added to make the build work. I'm not 100% sure about the "rcc_clock_setup_in_hse_8mhz_out_48mhz" function. It was copied and adapted from the F1 series, but the device seems to run ok with it. 

The datasheet for this M0 chip can be found here: http://www.st.com/web/en/catalog/mmc/FM141/SC1169/SS1574/LN1823/PF259561
