### PR TITLE
Pulls out duplicate calls from f0/rcc.c

### DIFF
--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -483,6 +483,8 @@ enum rcc_periph_rst {
 /* API Functions                                                             */
 /*****************************************************************************/
 
+#include <libopencm3/stm32/common/rcc_common_all.h>
+
 BEGIN_DECLS
 
 void rcc_osc_ready_int_clear(enum rcc_osc osc);
@@ -511,11 +513,6 @@ void rcc_clock_setup_in_hsi_out_24mhz(void);
 void rcc_clock_setup_in_hsi_out_32mhz(void);
 void rcc_clock_setup_in_hsi_out_40mhz(void);
 void rcc_clock_setup_in_hsi_out_48mhz(void);
-void rcc_periph_clock_enable(enum rcc_periph_clken periph);
-void rcc_periph_clock_disable(enum rcc_periph_clken periph);
-void rcc_periph_reset_pulse(enum rcc_periph_rst periph);
-void rcc_periph_reset_hold(enum rcc_periph_rst periph);
-void rcc_periph_reset_release(enum rcc_periph_rst periph);
 
 END_DECLS
 

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -41,7 +41,7 @@ OBJS            += gpio_common_all.o gpio_common_f0234.o crc_common_all.o \
                    pwr_common_all.o iwdg_common_all.o rtc_common_l1f024.o \
                    dma_common_l1f013.o exti_common_all.o spi_common_all.o \
 		   spi_common_f03.o flash_common_f01.o dac_common_all.o \
-		   timer_common_all.o
+		   timer_common_all.o rcc_common_all.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -628,38 +628,5 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 	rcc_core_frequency = 48000000;
 }
 
-
-#define _RCC_REG(i)		MMIO32(RCC_BASE + ((i) >> 5))
-#define _RCC_BIT(i)		(1 << ((i) & 0x1f))
-
-void rcc_periph_clock_enable(enum rcc_periph_clken periph)
-{
-	_RCC_REG(periph) |= _RCC_BIT(periph);
-}
-
-void rcc_periph_clock_disable(enum rcc_periph_clken periph)
-{
-	_RCC_REG(periph) &= ~_RCC_BIT(periph);
-}
-
-void rcc_periph_reset_pulse(enum rcc_periph_rst periph)
-{
-	_RCC_REG(periph) |= _RCC_BIT(periph);
-	_RCC_REG(periph) &= ~_RCC_BIT(periph);
-}
-
-void rcc_periph_reset_hold(enum rcc_periph_rst periph)
-{
-	_RCC_REG(periph) |= _RCC_BIT(periph);
-}
-
-void rcc_periph_reset_release(enum rcc_periph_rst periph)
-{
-	_RCC_REG(periph) &= ~_RCC_BIT(periph);
-}
-
-#undef _RCC_REG
-#undef _RCC_BIT
-
 /**@}*/
 


### PR DESCRIPTION
This fixes an issue that karlp noted and another which was mentioned on the mailing list. Basically f0 was not using rcc_common_all and so it had duplicate code in its copy of rcc.c, but it also doesn't have the new `rcc_perhipheral_enable_clock` and `rcc_peripheral_disable_clock` calls. 

Note that this is an inspection fix, it compiles cleanly but I don't have an f0 to test it on. I did verify that the code in the f0/rcc.c was identically implemented to the code in common/rcc_common_all.c but only visually.
