### PR TITLE
Rename rcc_ppre1_frequency and rcc_ppre2_frequency

### DIFF
--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -375,8 +375,8 @@ Control</b>
 /*****************************************************************************/
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_core_frequency;
-extern uint32_t rcc_ppre_frequency;
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
 
 enum rcc_osc {
 	HSI14, HSI, HSE, PLL, LSI, LSE, HSI48

--- a/include/libopencm3/stm32/f1/rcc.h
+++ b/include/libopencm3/stm32/f1/rcc.h
@@ -534,8 +534,9 @@
 #define RCC_CFGR2_PREDIV2_DIV16			0xf
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_ppre1_frequency;
-extern uint32_t rcc_ppre2_frequency;
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
+extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/f2/rcc.h
+++ b/include/libopencm3/stm32/f2/rcc.h
@@ -468,8 +468,9 @@
 #define RCC_PLLI2SCFGR_PLLI2SN_SHIFT		6
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_ppre1_frequency;
-extern uint32_t rcc_ppre2_frequency;
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
+extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/f3/rcc.h
+++ b/include/libopencm3/stm32/f3/rcc.h
@@ -402,8 +402,9 @@
 
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_ppre1_frequency;
-extern uint32_t rcc_ppre2_frequency;
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
+extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -477,8 +477,9 @@
 #define RCC_PLLI2SCFGR_PLLI2SN_SHIFT		6
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_ppre1_frequency;
-extern uint32_t rcc_ppre2_frequency;
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
+extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -460,8 +460,9 @@
 
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_ppre1_frequency;
-extern uint32_t rcc_ppre2_frequency;
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
+extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/l1/rcc.h
+++ b/include/libopencm3/stm32/l1/rcc.h
@@ -411,8 +411,9 @@ extern const clock_scale_t clock_config[CLOCK_CONFIG_END];
 
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_ppre1_frequency;
-extern uint32_t rcc_ppre2_frequency;
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
+extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -48,16 +48,16 @@ usart_reg_base
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud)
 {
-	uint32_t clock = rcc_ppre1_frequency;
+	uint32_t clock = rcc_apb1_frequency;
 
 #if defined STM32F2 || defined STM32F4
 	if ((usart == USART1) ||
 	    (usart == USART6)) {
-		clock = rcc_ppre2_frequency;
+		clock = rcc_apb2_frequency;
 	}
 #else
 	if (usart == USART1) {
-		clock = rcc_ppre2_frequency;
+		clock = rcc_apb2_frequency;
 	}
 #endif
 

--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -40,8 +40,9 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/flash.h>
 
-uint32_t rcc_core_frequency = 8000000; /* 8MHz after reset */
-uint32_t rcc_ppre_frequency = 8000000; /* 8MHz after reset */
+/* Set the default clock frequencies */
+uint32_t rcc_ahb_frequency = 8000000; /* 8MHz after reset */
+uint32_t rcc_apb1_frequency = 8000000; /* 8MHz after reset */
 
 /*---------------------------------------------------------------------------*/
 /** @brief RCC Clear the Oscillator Ready Interrupt Flag
@@ -503,8 +504,8 @@ void rcc_clock_setup_in_hsi_out_8mhz(void)
 
 	flash_set_ws(FLASH_ACR_LATENCY_000_024MHZ);
 
-	rcc_ppre_frequency = 8000000;
-	rcc_core_frequency = 8000000;
+	rcc_apb1_frequency = 8000000;
+	rcc_ahb_frequency = 8000000;
 }
 
 void rcc_clock_setup_in_hsi_out_16mhz(void)
@@ -527,8 +528,8 @@ void rcc_clock_setup_in_hsi_out_16mhz(void)
 	rcc_wait_for_osc_ready(PLL);
 	rcc_set_sysclk_source(PLL);
 
-	rcc_ppre_frequency = 16000000;
-	rcc_core_frequency = 16000000;
+	rcc_apb1_frequency = 16000000;
+	rcc_ahb_frequency = 16000000;
 }
 
 
@@ -552,8 +553,8 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 	rcc_wait_for_osc_ready(PLL);
 	rcc_set_sysclk_source(PLL);
 
-	rcc_ppre_frequency = 24000000;
-	rcc_core_frequency = 24000000;
+	rcc_apb1_frequency = 24000000;
+	rcc_ahb_frequency = 24000000;
 }
 
 void rcc_clock_setup_in_hsi_out_32mhz(void)
@@ -576,8 +577,8 @@ void rcc_clock_setup_in_hsi_out_32mhz(void)
 	rcc_wait_for_osc_ready(PLL);
 	rcc_set_sysclk_source(PLL);
 
-	rcc_ppre_frequency = 32000000;
-	rcc_core_frequency = 32000000;
+	rcc_apb1_frequency = 32000000;
+	rcc_ahb_frequency = 32000000;
 }
 
 void rcc_clock_setup_in_hsi_out_40mhz(void)
@@ -600,8 +601,8 @@ void rcc_clock_setup_in_hsi_out_40mhz(void)
 	rcc_wait_for_osc_ready(PLL);
 	rcc_set_sysclk_source(PLL);
 
-	rcc_ppre_frequency = 40000000;
-	rcc_core_frequency = 40000000;
+	rcc_apb1_frequency = 40000000;
+	rcc_ahb_frequency = 40000000;
 }
 
 void rcc_clock_setup_in_hsi_out_48mhz(void)
@@ -624,8 +625,8 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 	rcc_wait_for_osc_ready(PLL);
 	rcc_set_sysclk_source(PLL);
 
-	rcc_ppre_frequency = 48000000;
-	rcc_core_frequency = 48000000;
+	rcc_apb1_frequency = 48000000;
+	rcc_ahb_frequency = 48000000;
 }
 
 /**@}*/

--- a/lib/stm32/f0/usart.c
+++ b/lib/stm32/f0/usart.c
@@ -41,10 +41,10 @@
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud)
 {
-	uint32_t clock = rcc_ppre_frequency;
+	uint32_t clock = rcc_apb1_frequency;
 
 	if (usart == USART1) {
-		clock = rcc_ppre_frequency;
+		clock = rcc_apb1_frequency;
 		/* TODO selective PCLK, SYSCLK, HSI or LSE */
 	}
 

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -53,10 +53,10 @@ LGPL License Terms @ref lgpl_license
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/flash.h>
 
-/** Default ppre1 peripheral clock frequency after reset. */
-uint32_t rcc_ppre1_frequency = 8000000;
-/** Default ppre2 peripheral clock frequency after reset. */
-uint32_t rcc_ppre2_frequency = 8000000;
+/** Set the default clock frequencies */
+uint32_t rcc_apb1_frequency = 8000000;
+uint32_t rcc_apb2_frequency = 8000000;
+uint32_t rcc_ahb_frequency = 8000000;
 
 /*---------------------------------------------------------------------------*/
 /** @brief RCC Clear the Oscillator Ready Interrupt Flag
@@ -669,8 +669,8 @@ void rcc_clock_setup_in_hsi_out_64mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 32000000;
-	rcc_ppre2_frequency = 64000000;
+	rcc_apb1_frequency = 32000000;
+	rcc_apb2_frequency = 64000000;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -722,8 +722,8 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 24000000;
-	rcc_ppre2_frequency = 48000000;
+	rcc_apb1_frequency = 24000000;
+	rcc_apb2_frequency = 48000000;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -774,8 +774,9 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 24000000;
-	rcc_ppre2_frequency = 24000000;
+	rcc_ahb_frequency = 24000000;
+	rcc_apb1_frequency = 24000000;
+	rcc_apb2_frequency = 24000000;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -837,8 +838,9 @@ void rcc_clock_setup_in_hse_8mhz_out_24mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 24000000;
-	rcc_ppre2_frequency = 24000000;
+	rcc_ahb_frequency = 24000000;
+	rcc_apb1_frequency = 24000000;
+	rcc_apb2_frequency = 24000000;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -900,8 +902,9 @@ void rcc_clock_setup_in_hse_8mhz_out_72mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 36000000;
-	rcc_ppre2_frequency = 72000000;
+	rcc_ahb_frequency = 72000000;
+	rcc_apb1_frequency = 36000000;
+	rcc_apb2_frequency = 72000000;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -963,8 +966,9 @@ void rcc_clock_setup_in_hse_12mhz_out_72mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 36000000;
-	rcc_ppre2_frequency = 72000000;
+	rcc_ahb_frequency = 72000000;
+	rcc_apb1_frequency = 36000000;
+	rcc_apb2_frequency = 72000000;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1026,8 +1030,9 @@ void rcc_clock_setup_in_hse_16mhz_out_72mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 36000000;
-	rcc_ppre2_frequency = 72000000;
+	rcc_ahb_frequency = 72000000;
+	rcc_apb1_frequency = 36000000;
+	rcc_apb2_frequency = 72000000;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1083,8 +1088,9 @@ void rcc_clock_setup_in_hse_25mhz_out_72mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used */
-	rcc_ppre1_frequency = 36000000;
-	rcc_ppre2_frequency = 72000000;
+	rcc_ahb_frequency = 72000000;
+	rcc_apb1_frequency = 36000000;
+	rcc_apb2_frequency = 72000000;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/f2/rcc.c
+++ b/lib/stm32/f2/rcc.c
@@ -43,9 +43,10 @@
 
 /**@{*/
 
-/* Set the default ppre1 and ppre2 peripheral clock frequencies after reset. */
-uint32_t rcc_ppre1_frequency = 16000000;
-uint32_t rcc_ppre2_frequency = 16000000;
+/* Set the default clock frequencies after reset. */
+uint32_t rcc_ahb_frequency = 16000000;
+uint32_t rcc_apb1_frequency = 16000000;
+uint32_t rcc_apb2_frequency = 16000000;
 
 const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
 	{ /* 120MHz */
@@ -401,8 +402,8 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 	rcc_wait_for_sysclk_status(PLL);
 
 	/* Set the peripheral clock frequencies used. */
-	rcc_ppre1_frequency = clock->apb1_frequency;
-	rcc_ppre2_frequency = clock->apb2_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
 }
 
 void rcc_backupdomain_reset(void)

--- a/lib/stm32/f3/rcc.c
+++ b/lib/stm32/f3/rcc.c
@@ -39,9 +39,10 @@
 #include <libopencm3/stm32/flash.h>
 #include <libopencm3/stm32/i2c.h>
 
-/* Set the default ppre1 and ppre2 peripheral clock frequencies after reset. */
-uint32_t rcc_ppre1_frequency = 8000000;
-uint32_t rcc_ppre2_frequency = 8000000;
+/* Set the default clock frequencies after reset. */
+uint32_t rcc_ahb_frequency = 8000000;
+uint32_t rcc_apb1_frequency = 8000000;
+uint32_t rcc_apb2_frequency = 8000000;
 
 const clock_scale_t hsi_8mhz[CLOCK_END] = {
 	{ /* 44MHz */
@@ -413,8 +414,8 @@ void rcc_clock_setup_hsi(const clock_scale_t *clock)
 	rcc_wait_for_sysclk_status(PLL);
 
 	/* Set the peripheral clock frequencies used. */
-	rcc_ppre1_frequency = clock->apb1_frequency;
-	rcc_ppre2_frequency = clock->apb2_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
 }
 
 

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -44,9 +44,10 @@
 
 /**@{*/
 
-/* Set the default ppre1 and ppre2 peripheral clock frequencies after reset. */
-uint32_t rcc_ppre1_frequency = 16000000;
-uint32_t rcc_ppre2_frequency = 16000000;
+/* Set the default clock frequencies after reset. */
+uint32_t rcc_ahb_frequency = 16000000;
+uint32_t rcc_apb1_frequency = 16000000;
+uint32_t rcc_apb2_frequency = 16000000;
 
 const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
 	{ /* 48MHz */
@@ -571,8 +572,8 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 	rcc_wait_for_sysclk_status(PLL);
 
 	/* Set the peripheral clock frequencies used. */
-	rcc_ppre1_frequency = clock->apb1_frequency;
-	rcc_ppre2_frequency = clock->apb2_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
 
 	/* Disable internal high-speed oscillator. */
 	rcc_osc_off(HSI);

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -25,9 +25,10 @@
 #include <libopencm3/stm32/flash.h>
 #include <libopencm3/stm32/pwr.h>
 
-/* Set the default ppre1 and ppre2 peripheral clock frequencies after reset. */
-uint32_t rcc_ppre1_frequency = 2097000;
-uint32_t rcc_ppre2_frequency = 2097000;
+/* Set the default clock frequencies after reset. */
+uint32_t rcc_ahb_frequency = 2097000;
+uint32_t rcc_apb1_frequency = 2097000;
+uint32_t rcc_apb2_frequency = 2097000;
 
 const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 	{ /* 24MHz PLL from HSI */
@@ -460,8 +461,8 @@ void rcc_clock_setup_msi(const clock_scale_t *clock)
 	flash_set_ws(clock->flash_config);
 
 	/* Set the peripheral clock frequencies used. */
-	rcc_ppre1_frequency = clock->apb1_frequency;
-	rcc_ppre2_frequency = clock->apb2_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
 }
 
 void rcc_clock_setup_hsi(const clock_scale_t *clock)
@@ -491,8 +492,8 @@ void rcc_clock_setup_hsi(const clock_scale_t *clock)
 	flash_set_ws(clock->flash_config);
 
 	/* Set the peripheral clock frequencies used. */
-	rcc_ppre1_frequency = clock->apb1_frequency;
-	rcc_ppre2_frequency = clock->apb2_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
 }
 
 void rcc_clock_setup_pll(const clock_scale_t *clock)
@@ -529,6 +530,6 @@ void rcc_clock_setup_pll(const clock_scale_t *clock)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
 
 	/* Set the peripheral clock frequencies used. */
-	rcc_ppre1_frequency = clock->apb1_frequency;
-	rcc_ppre2_frequency = clock->apb2_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
 }


### PR DESCRIPTION
The original names of rcc_ppre1_frequency and rcc_ppre2_frequency were confusing to me. This updates these variables (that are used in computing USART baudrates and potentially timer periods) to have names reflecting their basis. In particular apb1 and abp2 clocks. I've also added a new counter rcc_ahb_frequency which is generally going to be the SYSCLK frequency. 
