### PR TITLE
Audit RTCPRE Shift and Mask Values

### DIFF
--- a/include/libopencm3/stm32/f2/rcc.h
+++ b/include/libopencm3/stm32/f2/rcc.h
@@ -136,7 +136,8 @@
 #define RCC_CFGR_MCO1_PLL			0x3
 
 /* RTCPRE: HSE division factor for RTC clock */
-#define RCC_CFGR_RTCPRE_SHIFT			21
+#define RCC_CFGR_RTCPRE_SHIFT			16
+#define RCC_CFGR_RTCPRE_MASK			0x1f
 
 /* PPRE1/2: APB high-speed prescalers */
 #define RCC_CFGR_PPRE2_SHIFT			13

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -132,17 +132,21 @@
 
 /* MCO1: Microcontroller clock output 1 */
 #define RCC_CFGR_MCO1_SHIFT			21
+#define RCC_CFGR_MCO1_MASK			0x3
 #define RCC_CFGR_MCO1_HSI			0x0
 #define RCC_CFGR_MCO1_LSE			0x1
 #define RCC_CFGR_MCO1_HSE			0x2
 #define RCC_CFGR_MCO1_PLL			0x3
 
 /* RTCPRE: HSE division factor for RTC clock */
-#define RCC_CFGR_RTCPRE_SHIFT			21
+#define RCC_CFGR_RTCPRE_SHIFT			16
+#define RCC_CFGR_RTCPRE_MASK			0x1f
 
 /* PPRE1/2: APB high-speed prescalers */
 #define RCC_CFGR_PPRE2_SHIFT			13
+#define RCC_CFGR_PPRE2_MASK			0x7
 #define RCC_CFGR_PPRE1_SHIFT			10
+#define RCC_CFGR_PPRE1_MASK			0x7
 #define RCC_CFGR_PPRE_DIV_NONE			0x0
 #define RCC_CFGR_PPRE_DIV_2			0x4
 #define RCC_CFGR_PPRE_DIV_4			0x5
@@ -151,6 +155,7 @@
 
 /* HPRE: AHB high-speed prescaler */
 #define RCC_CFGR_HPRE_SHIFT			4
+#define RCC_CFGR_HPRE_MASK			0xf
 #define RCC_CFGR_HPRE_DIV_NONE			0x0
 #define RCC_CFGR_HPRE_DIV_2			(0x8 + 0)
 #define RCC_CFGR_HPRE_DIV_4			(0x8 + 1)

--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -69,7 +69,12 @@
 
 #define RCC_CR_PLLRDY				(1 << 25)
 #define RCC_CR_PLLON				(1 << 24)
-/* RTCPRE at 12:20 */
+#define RCC_CR_RTCPRE_SHIFT			20
+#define RCC_CR_RTCPRE_MASK			0x3
+#define RCC_CR_RTCPRE_DIV2			0
+#define RCC_CR_RTCPRE_DIV4			1
+#define RCC_CR_RTCPRE_DIV8			2
+#define RCC_CR_RTCPRE_DIV16			3
 #define RCC_CR_CSSHSEON                         (1 << 19)
 #define RCC_CR_HSEBYP				(1 << 18)
 #define RCC_CR_HSERDY				(1 << 17)
@@ -82,12 +87,6 @@
 #define RCC_CR_HSI16KERON			(1 << 1)
 #define RCC_CR_HSI16ON				(1 << 0)
 
-#define RCC_CR_RTCPRE_DIV2	0
-#define RCC_CR_RTCPRE_DIV4	1
-#define RCC_CR_RTCPRE_DIV8	2
-#define RCC_CR_RTCPRE_DIV16	3
-#define RCC_CR_RTCPRE_SHIFT	20
-#define RCC_CR_RTCPRE_MASK	0x3
 
 /* --- RCC_ICSCR values ---------------------------------------------------- */
 

--- a/include/libopencm3/stm32/l1/rcc.h
+++ b/include/libopencm3/stm32/l1/rcc.h
@@ -69,7 +69,8 @@
 
 /* --- RCC_CR values ------------------------------------------------------- */
 
-/* RTCPRE[1:0] at 30:29 */
+#define RCC_CR_RTCPRE_SHIFT			29
+#define RCC_CR_RTCPRE_MASK			0x3
 #define RCC_CR_CSSON				(1 << 28)
 #define RCC_CR_PLLRDY				(1 << 25)
 #define RCC_CR_PLLON				(1 << 24)


### PR DESCRIPTION
L0 - RTC Prescaler appears in RCC_CR, bit 20, 2 bits wide (RM0367 Rev 2)
L1 - RTC Prescaler appears in RCC_CR, bit 29, 2 bits wide (RM0038 Rev 10)
F0 - no prescaler setting (RM0091 Rev 7)
F1 - no prescaler setting (RM0041 Rev 4)
F2 - RTC Prescaler appears at RCC_CFGR, bit 16, 4 bits wide (RM0033 Rev 6)
F3 - no prescaler setting (RM0316 Rev 3)
F4 - RTC Prescaler appears at RCC_CFGR, bit 16, 4 bits wide (RM0090 Rev 8)
