### PR TITLE
Fix common case SPI handling

### DIFF
--- a/lib/stm32/common/spi_common_all.c
+++ b/lib/stm32/common/spi_common_all.c
@@ -392,7 +392,7 @@ void spi_set_receive_only_mode(uint32_t spi)
 }
 
 /*---------------------------------------------------------------------------*/
-/** @brief SPI Enable Slave Management by Hardware
+/** @brief SPI Disable Slave Management by Hardware
 
 In slave mode the NSS hardware input is used as a select enable for the slave.
 
@@ -416,6 +416,8 @@ enable/disable of the slave (@ref spi_set_nss_high).
 void spi_enable_software_slave_management(uint32_t spi)
 {
 	SPI_CR1(spi) |= SPI_CR1_SSM;
+	/* allow slave select to be an input */
+	SPI_CR2(spi) &= ~SPI_CR2_SSOE;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/common/spi_common_l1f124.c
+++ b/lib/stm32/common/spi_common_l1f124.c
@@ -77,7 +77,9 @@ baudrate, data format 8/16 bits, frame format lsb/msb first, clock polarity
 and phase. The SPI enable, CRC enable and CRC next controls are not affected.
 These must be controlled separately.
 
-@todo NSS pin handling.
+To support multiple masters (dynamic switching between master and slave)
+you must set SSOE to 0 and select either software or hardware control of
+the NSS pin.
 
 @param[in] spi Unsigned int32. SPI peripheral identifier @ref spi_reg_base.
 @param[in] br Unsigned int32. Baudrate @ref spi_baudrate.
@@ -105,8 +107,7 @@ int spi_init_master(uint32_t spi, uint32_t br, uint32_t cpol, uint32_t cpha,
 	reg32 |= dff;		/* Set data format (8 or 16 bits). */
 	reg32 |= lsbfirst;	/* Set frame format (LSB- or MSB-first). */
 
-	/* TODO: NSS pin handling. */
-
+	SPI_CR2(spi) |= SPI_CR2_SSOE; /* common case */
 	SPI_CR1(spi) = reg32;
 
 	return 0; /* TODO */


### PR DESCRIPTION
The common case for SPI ports in master mode is that they are not
also running as Slaves some times. For these chips the SSOE bit must
be set (or NSS tied high). Since it is common for people to use a separate
GPIO to select remote slaves and they expect the master to always be the master
this sets that up by default.

See issue #391 