### PR TITLE
stm32: f0: Fixes setting of PLL multiplication factor

### DIFF
--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -453,7 +453,7 @@ void rcc_set_usbclk_source(enum rcc_osc clk)
 
 void rcc_set_pll_multiplication_factor(uint32_t mul)
 {
-	RCC_CFGR = (RCC_CFGR & RCC_CFGR_PLLMUL) | mul;
+	RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_PLLMUL) | mul;
 }
 
 


### PR DESCRIPTION
Really use RCC_CFGR_PLLMUL negated as a mask.

Signed-off-by: Daniel Serpell <daniel.serpell@gmail.com>