### PR TITLE
Regexp special characters need to be escaped inside regexp

### DIFF
--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -31,9 +31,9 @@ BEGIN {
 	gsub(/\r$/,"");
 
 	tmp = "^"$1"$";
-	gsub(/?/, ".", tmp);
-	gsub(/*/, ".*", tmp);
-	gsub(/+/, ".+", tmp);
+	gsub(/\?/, ".", tmp);
+	gsub(/\*/, ".*", tmp);
+	gsub(/\+/, ".+", tmp);
 	tolower(tmp);
 
 	if (PAT ~ tmp) {


### PR DESCRIPTION
at least without this fix it was not working with my awk on debian stable