### PR TITLE
stm32: f2: Add missing desig.o to Makefile

### DIFF
--- a/lib/stm32/f2/Makefile
+++ b/lib/stm32/f2/Makefile
@@ -34,7 +34,7 @@ CFLAGS		= -Os -g \
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
 
-OBJS		= gpio.o rcc.o
+OBJS		= gpio.o rcc.o desig.o
 
 OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    gpio_common_all.o gpio_common_f0234.o i2c_common_all.o \


### PR DESCRIPTION
Basically the same as ad937e00fd04d1a618146b20f04ebc8460bf98b2 but for stm32/f2