### PR TITLE
headers: Explicitly error when you include an internal header

### DIFF
--- a/include/libopencm3/dispatch/nvic.h
+++ b/include/libopencm3/dispatch/nvic.h
@@ -1,3 +1,7 @@
+#ifndef LIBOPENCM3_NVIC_H
+#error You should not be including this file directly, but <libopencm3/cm3/nvic.h>
+#endif
+
 #if defined(STM32F0)
 #	include <libopencm3/stm32/f0/nvic.h>
 #elif defined(STM32F1)


### PR DESCRIPTION
People should not be using the dispatch/ headers directly.
Try and make this more explicit.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

This makes a nice error like so:
```
  BUILD   examples/stm32/f1/stm32vl-discovery/adc-dac-printf/
In file included from adc-dac-printf.c:24:0:
/home/karlp/src/libopencm3-examples/libopencm3/include/libopencm3/dispatch/nvic.h:2:2: error: #error You should not be including this file directly, but <libopencm3/cm3/nvic.h>
make[1]: *** [adc-dac-printf.o] Error 1
make: *** [examples/stm32/f1/stm32vl-discovery/adc-dac-printf/] Error 2
karlp@pojak:~/src/libopencm3-examples (master *)$
```

Note: this is _only_ for the dispatch/nvic.h header.  It should arguably be applied in a lot of other places!