### PR TITLE
stm32/usb: otg_fs and otg_hs register definitions

### DIFF
--- a/include/libopencm3/stm32/otg_common.h
+++ b/include/libopencm3/stm32/otg_common.h
@@ -1,0 +1,489 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Gareth McMullin <gareth@blacksphere.co.nz>
+ * 
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/*
+ * This file is intended to be included by either otg_hs.h or otg_fs.h
+ * Contains common definitions of Command and Status Registers (CSR) and their 
+ * bit definitions. 
+ * 
+ */ 
+
+#ifndef LIBOPENCM3_OTG_COMMON_H
+#define LIBOPENCM3_OTG_COMMON_H
+
+
+ 
+/* Core Global Control and Status Registers */
+#define OTG_GOTGCTL			0x000
+#define OTG_GOTGINT			0x004
+#define OTG_GAHBCFG			0x008
+#define OTG_GUSBCFG			0x00C
+#define OTG_GRSTCTL			0x010
+#define OTG_GINTSTS			0x014
+#define OTG_GINTMSK			0x018
+#define OTG_GRXSTSR			0x01C
+#define OTG_GRXSTSP			0x020
+#define OTG_GRXFSIZ			0x024
+#define OTG_GNPTXFSIZ			0x028
+#define OTG_GNPTXSTS			0x02C
+#define OTG_GCCFG			0x038
+#define OTG_CID				0x03C
+#define OTG_HPTXFSIZ			0x100
+#define OTG_DIEPTXF(x)			(0x104 + 4*(x-1))
+
+/* Host-mode Control and Status Registers */
+#define OTG_HCFG			0x400
+#define OTG_HFIR			0x404
+#define OTG_HFNUM			0x408
+#define OTG_HPTXSTS			0x410
+#define OTG_HAINT			0x414
+#define OTG_HAINTMSK			0x418
+#define OTG_HPRT			0x440
+#define OTG_HCCHAR(x)			(0x500 + 0x20*(x))
+#define OTG_HCINT(x)			(0x508 + 0x20*(x))
+#define OTG_HCINTMSK(x)			(0x50C + 0x20*(x))
+#define OTG_HCTSIZ(x)			(0x510 + 0x20*(x))
+
+
+/* Device-mode Control and Status Registers */
+#define OTG_DCFG			0x800
+#define OTG_DCTL			0x804
+#define OTG_DSTS			0x808
+#define OTG_DIEPMSK			0x810
+#define OTG_DOEPMSK			0x814
+#define OTG_DAINT			0x818
+#define OTG_DAINTMSK			0x81C
+#define OTG_DVBUSDIS			0x828
+#define OTG_DVBUSPULSE			0x82C
+#define OTG_DIEPEMPMSK			0x834
+
+#define OTG_DIEPCTL0			0x900
+#define OTG_DIEPCTL(x)			(0x900 + 0x20*(x))
+#define OTG_DOEPCTL0			0xB00
+#define OTG_DOEPCTL(x)			(0xB00 + 0x20*(x))
+#define OTG_DIEPINT(x)			(0x908 + 0x20*(x))
+#define OTG_DOEPINT(x)			(0xB08 + 0x20*(x))
+#define OTG_DIEPTSIZ0			0x910
+#define OTG_DIEPTSIZ(x)			(0x910 + 0x20*(x))
+#define OTG_DOEPTSIZ0			0xB10
+#define OTG_DOEPTSIZ(x)			(0xB10 + 0x20*(x))
+#define OTG_DTXFSTS(x)			(0x918 + 0x20*(x))
+
+/* Power and clock gating control and status register */
+#define OTG_PCGCCTL			0xE00
+
+/* Data FIFO */
+#define OTG_FIFO(x)			(((x) + 1) << 12)
+
+
+/* Global CSRs */
+/* OTG USB control registers (OTG_GOTGCTL) */
+#define OTG_GOTGCTL_BSVLD		(1 << 19)
+#define OTG_GOTGCTL_ASVLD		(1 << 18)
+#define OTG_GOTGCTL_DBCT		(1 << 17)
+#define OTG_GOTGCTL_CIDSTS		(1 << 16)
+#define OTG_GOTGCTL_DHNPEN		(1 << 11)
+#define OTG_GOTGCTL_HSHNPEN		(1 << 10)
+#define OTG_GOTGCTL_HNPRQ		(1 << 9)
+#define OTG_GOTGCTL_HNGSCS		(1 << 8)
+#define OTG_GOTGCTL_SRQ			(1 << 1)
+#define OTG_GOTGCTL_SRQSCS		(1 << 0)
+
+/* OTG AHB configuration register (OTG_GAHBCFG) */
+#define OTG_GAHBCFG_GINT		0x0001
+#define OTG_GAHBCFG_TXFELVL		0x0080
+#define OTG_GAHBCFG_PTXFELVL		0x0100
+
+/* OTG USB configuration register (OTG_GUSBCFG) */
+#define OTG_GUSBCFG_TOCAL		0x00000003
+#define OTG_GUSBCFG_SRPCAP		0x00000100
+#define OTG_GUSBCFG_HNPCAP		0x00000200
+#define OTG_GUSBCFG_TRDT_MASK		(0xf << 10)
+#define OTG_GUSBCFG_TRDT_16BIT		(0x5 << 10)
+#define OTG_GUSBCFG_TRDT_8BIT		(0x9 << 10)
+#define OTG_GUSBCFG_NPTXRWEN		0x00004000
+#define OTG_GUSBCFG_FHMOD		0x20000000
+#define OTG_GUSBCFG_FDMOD		0x40000000
+#define OTG_GUSBCFG_CTXPKT		0x80000000
+#define OTG_GUSBCFG_PHYSEL		(1 << 6)
+
+/* OTG reset register (OTG_GRSTCTL) */
+#define OTG_GRSTCTL_AHBIDL		(1 << 31)
+/* Bits 30:11 - Reserved */
+#define OTG_GRSTCTL_TXFNUM_MASK		(0x1f << 6)
+#define OTG_GRSTCTL_TXFFLSH		(1 << 5)
+#define OTG_GRSTCTL_RXFFLSH		(1 << 4)
+/* Bit 3 - Reserved */
+#define OTG_GRSTCTL_FCRST		(1 << 2)
+#define OTG_GRSTCTL_HSRST		(1 << 1)
+#define OTG_GRSTCTL_CSRST		(1 << 0)
+
+/* OTG interrupt status register (OTG_GINTSTS) */
+#define OTG_GINTSTS_WKUPINT		(1 << 31)
+#define OTG_GINTSTS_SRQINT		(1 << 30)
+#define OTG_GINTSTS_DISCINT		(1 << 29)
+#define OTG_GINTSTS_CIDSCHG		(1 << 28)
+/* Bit 27 - Reserved */
+#define OTG_GINTSTS_PTXFE		(1 << 26)
+#define OTG_GINTSTS_HCINT		(1 << 25)
+#define OTG_GINTSTS_HPRTINT		(1 << 24)
+/* Bits 23:22 - Reserved */
+#define OTG_GINTSTS_IPXFR		(1 << 21)
+#define OTG_GINTSTS_INCOMPISOOUT	(1 << 21)
+#define OTG_GINTSTS_IISOIXFR		(1 << 20)
+#define OTG_GINTSTS_OEPINT		(1 << 19)
+#define OTG_GINTSTS_IEPINT		(1 << 18)
+/* Bits 17:16 - Reserved */
+#define OTG_GINTSTS_EOPF		(1 << 15)
+#define OTG_GINTSTS_ISOODRP		(1 << 14)
+#define OTG_GINTSTS_ENUMDNE		(1 << 13)
+#define OTG_GINTSTS_USBRST		(1 << 12)
+#define OTG_GINTSTS_USBSUSP		(1 << 11)
+#define OTG_GINTSTS_ESUSP		(1 << 10)
+/* Bits 9:8 - Reserved */
+#define OTG_GINTSTS_GONAKEFF		(1 << 7)
+#define OTG_GINTSTS_GINAKEFF		(1 << 6)
+#define OTG_GINTSTS_NPTXFE		(1 << 5)
+#define OTG_GINTSTS_RXFLVL		(1 << 4)
+#define OTG_GINTSTS_SOF			(1 << 3)
+#define OTG_GINTSTS_OTGINT		(1 << 2)
+#define OTG_GINTSTS_MMIS		(1 << 1)
+#define OTG_GINTSTS_CMOD		(1 << 0)
+
+/* OTG interrupt mask register (OTG_GINTMSK) */
+#define OTG_GINTMSK_MMISM		0x00000002
+#define OTG_GINTMSK_OTGINT		0x00000004
+#define OTG_GINTMSK_SOFM		0x00000008
+#define OTG_GINTMSK_RXFLVLM		0x00000010
+#define OTG_GINTMSK_NPTXFEM		0x00000020
+#define OTG_GINTMSK_GINAKEFFM		0x00000040
+#define OTG_GINTMSK_GONAKEFFM		0x00000080
+#define OTG_GINTMSK_ESUSPM		0x00000400
+#define OTG_GINTMSK_USBSUSPM		0x00000800
+#define OTG_GINTMSK_USBRST		0x00001000
+#define OTG_GINTMSK_ENUMDNEM		0x00002000
+#define OTG_GINTMSK_ISOODRPM		0x00004000
+#define OTG_GINTMSK_EOPFM		0x00008000
+#define OTG_GINTMSK_EPMISM		0x00020000
+#define OTG_GINTMSK_IEPINT		0x00040000
+#define OTG_GINTMSK_OEPINT		0x00080000
+#define OTG_GINTMSK_IISOIXFRM		0x00100000
+#define OTG_GINTMSK_IISOOXFRM		0x00200000
+#define OTG_GINTMSK_IPXFRM		0x00200000
+#define OTG_GINTMSK_PRTIM		0x01000000
+#define OTG_GINTMSK_HCIM		0x02000000
+#define OTG_GINTMSK_PTXFEM		0x04000000
+#define OTG_GINTMSK_CIDSCHGM		0x10000000
+#define OTG_GINTMSK_DISCINT		0x20000000
+#define OTG_GINTMSK_SRQIM		0x40000000
+#define OTG_GINTMSK_WUIM		0x80000000
+
+/* OTG Receive Status Pop Register (OTG_GRXSTSP) */
+/* Bits 31:25 - Reserved */
+#define OTG_GRXSTSP_FRMNUM_MASK		(0xf << 21)
+#define OTG_GRXSTSP_PKTSTS_MASK		(0xf << 17)
+#define OTG_GRXSTSP_PKTSTS_GOUTNAK	(0x1 << 17)
+#define OTG_GRXSTSP_PKTSTS_OUT		(0x2 << 17)
+#define OTG_GRXSTSP_PKTSTS_IN		(0x2 << 17)
+#define OTG_GRXSTSP_PKTSTS_OUT_COMP	(0x3 << 17)
+#define OTG_GRXSTSP_PKTSTS_IN_COMP	(0x3 << 17)
+#define OTG_GRXSTSP_PKTSTS_SETUP_COMP	(0x4 << 17)
+#define OTG_GRXSTSP_PKTSTS_DTERR	(0x5 << 17)
+#define OTG_GRXSTSP_PKTSTS_SETUP	(0x6 << 17)
+#define OTG_GRXSTSP_PKTSTS_CHH		(0x7 << 17)
+#define OTG_GRXSTSP_DPID_MASK		(0x3 << 15)
+#define OTG_GRXSTSP_DPID_DATA0		(0x0 << 15)
+#define OTG_GRXSTSP_DPID_DATA1		(0x2 << 15)
+#define OTG_GRXSTSP_DPID_DATA2		(0x1 << 15)
+#define OTG_GRXSTSP_DPID_MDATA		(0x3 << 15)
+#define OTG_GRXSTSP_BCNT_MASK		(0x7ff << 4)
+#define OTG_GRXSTSP_EPNUM_MASK		(0xf << 0)
+
+/* OTG general core configuration register (OTG_GCCFG) */
+/* Bits 31:22 - Reserved */
+#define OTG_GCCFG_NOVBUSSENS		(1 << 21)
+#define OTG_GCCFG_SOFOUTEN		(1 << 20)
+#define OTG_GCCFG_VBUSBSEN		(1 << 19)
+#define OTG_GCCFG_VBUSASEN		(1 << 18)
+/* Bit 17 - Reserved */
+#define OTG_GCCFG_PWRDWN		(1 << 16)
+/* Bits 15:0 - Reserved */
+
+
+/* Device-mode CSRs */
+/* OTG device control register (OTG_DCTL) */
+/* Bits 31:12 - Reserved */
+#define OTG_DCTL_POPRGDNE	(1 << 11)
+#define OTG_DCTL_CGONAK		(1 << 10)
+#define OTG_DCTL_SGONAK		(1 << 9)
+#define OTG_DCTL_SGINAK		(1 << 8)
+#define OTG_DCTL_TCTL_MASK	(7 << 4)
+#define OTG_DCTL_GONSTS		(1 << 3)
+#define OTG_DCTL_GINSTS		(1 << 2)
+#define OTG_DCTL_SDIS		(1 << 1)
+#define OTG_DCTL_RWUSIG		(1 << 0)
+
+/* OTG device configuration register (OTG_DCFG) */
+#define OTG_DCFG_DSPD		0x0003
+#define OTG_DCFG_NZLSOHSK	0x0004
+#define OTG_DCFG_DAD		0x07F0
+#define OTG_DCFG_PFIVL		0x1800
+
+/* OTG Device IN Endpoint Common Interrupt Mask Register (OTG_DIEPMSK) */
+/* Bits 31:10 - Reserved */
+#define OTG_DIEPMSK_BIM		(1 << 9)
+#define OTG_DIEPMSK_TXFURM	(1 << 8)
+/* Bit 7 - Reserved */
+#define OTG_DIEPMSK_INEPNEM	(1 << 6)
+#define OTG_DIEPMSK_INEPNMM	(1 << 5)
+#define OTG_DIEPMSK_ITTXFEMSK	(1 << 4)
+#define OTG_DIEPMSK_TOM		(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DIEPMSK_EPDM	(1 << 1)
+#define OTG_DIEPMSK_XFRCM	(1 << 0)
+
+/* OTG Device OUT Endpoint Common Interrupt Mask Register (OTG_DOEPMSK) */
+/* Bits 31:10 - Reserved */
+#define OTG_DOEPMSK_BOIM	(1 << 9)
+#define OTG_DOEPMSK_OPEM	(1 << 8)
+/* Bit 7 - Reserved */
+#define OTG_DOEPMSK_B2BSTUP	(1 << 6)
+/* Bit 5 - Reserved */
+#define OTG_DOEPMSK_OTEPDM	(1 << 4)
+#define OTG_DOEPMSK_STUPM	(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DOEPMSK_EPDM	(1 << 1)
+#define OTG_DOEPMSK_XFRCM	(1 << 0)
+
+/* OTG Device Control IN Endpoint 0 Control Register (OTG_DIEPCTL0) */
+#define OTG_DIEPCTL0_EPENA		(1 << 31)
+#define OTG_DIEPCTL0_EPDIS		(1 << 30)
+/* Bits 29:28 - Reserved */
+#define OTG_DIEPCTLX_SD0PID		(1 << 28)
+#define OTG_DIEPCTL0_SNAK		(1 << 27)
+#define OTG_DIEPCTL0_CNAK		(1 << 26)
+#define OTG_DIEPCTL0_TXFNUM_MASK	(0xf << 22)
+#define OTG_DIEPCTL0_STALL		(1 << 21)
+/* Bit 20 - Reserved */
+#define OTG_DIEPCTL0_EPTYP_MASK		(0x3 << 18)
+#define OTG_DIEPCTL0_NAKSTS		(1 << 17)
+/* Bit 16 - Reserved */
+#define OTG_DIEPCTL0_USBAEP		(1 << 15)
+/* Bits 14:2 - Reserved */
+#define OTG_DIEPCTL0_MPSIZ_MASK		(0x3 << 0)
+#define OTG_DIEPCTL0_MPSIZ_64		(0x0 << 0)
+#define OTG_DIEPCTL0_MPSIZ_32		(0x1 << 0)
+#define OTG_DIEPCTL0_MPSIZ_16		(0x2 << 0)
+#define OTG_DIEPCTL0_MPSIZ_8		(0x3 << 0)
+
+/* OTG Device Control OUT Endpoint 0 Control Register (OTG_DOEPCTL0) */
+#define OTG_DOEPCTL0_EPENA		(1 << 31)
+#define OTG_DOEPCTL0_EPDIS		(1 << 30)
+/* Bits 29:28 - Reserved */
+#define OTG_DOEPCTLX_SD0PID		(1 << 28)
+#define OTG_DOEPCTL0_SNAK		(1 << 27)
+#define OTG_DOEPCTL0_CNAK		(1 << 26)
+/* Bits 25:22 - Reserved */
+#define OTG_DOEPCTL0_STALL		(1 << 21)
+#define OTG_DOEPCTL0_SNPM		(1 << 20)
+#define OTG_DOEPCTL0_EPTYP_MASK		(0x3 << 18)
+#define OTG_DOEPCTL0_NAKSTS		(1 << 17)
+/* Bit 16 - Reserved */
+#define OTG_DOEPCTL0_USBAEP		(1 << 15)
+/* Bits 14:2 - Reserved */
+#define OTG_DOEPCTL0_MPSIZ_MASK		(0x3 << 0)
+#define OTG_DOEPCTL0_MPSIZ_64		(0x0 << 0)
+#define OTG_DOEPCTL0_MPSIZ_32		(0x1 << 0)
+#define OTG_DOEPCTL0_MPSIZ_16		(0x2 << 0)
+#define OTG_DOEPCTL0_MPSIZ_8		(0x3 << 0)
+
+/* OTG Device IN Endpoint Interrupt Register (OTG_DIEPINTx) */
+/* Bits 31:8 - Reserved */
+#define OTG_DIEPINTX_TXFE		(1 << 7)
+#define OTG_DIEPINTX_INEPNE		(1 << 6)
+/* Bit 5 - Reserved */
+#define OTG_DIEPINTX_ITTXFE		(1 << 4)
+#define OTG_DIEPINTX_TOC		(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DIEPINTX_EPDISD		(1 << 1)
+#define OTG_DIEPINTX_XFRC		(1 << 0)
+
+/* OTG Device IN Endpoint Interrupt Register (OTG_DOEPINTx) */
+/* Bits 31:7 - Reserved */
+#define OTG_DOEPINTX_B2BSTUP		(1 << 6)
+/* Bit 5 - Reserved */
+#define OTG_DOEPINTX_OTEPDIS		(1 << 4)
+#define OTG_DOEPINTX_STUP		(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DOEPINTX_EPDISD		(1 << 1)
+#define OTG_DOEPINTX_XFRC		(1 << 0)
+
+/* OTG Device OUT Endpoint 0 Transfer Size Register (OTG_DOEPTSIZ0) */
+/* Bit 31 - Reserved */
+#define OTG_DIEPSIZ0_STUPCNT_1		(0x1 << 29)
+#define OTG_DIEPSIZ0_STUPCNT_2		(0x2 << 29)
+#define OTG_DIEPSIZ0_STUPCNT_3		(0x3 << 29)
+#define OTG_DIEPSIZ0_STUPCNT_MASK	(0x3 << 29)
+/* Bits 28:20 - Reserved */
+#define OTG_DIEPSIZ0_PKTCNT		(1 << 19)
+/* Bits 18:7 - Reserved */
+#define OTG_DIEPSIZ0_XFRSIZ_MASK	(0x7f << 0)
+
+
+
+/* Host-mode CSRs */
+/* OTG Host non-periodic transmit FIFO size register
+(OTG_HNPTXFSIZ)/Endpoint 0 Transmit FIFO size (OTG_DIEPTXF0) */
+#define OTG_HNPTXFSIZ_PTXFD_MASK	(0xffff0000)
+#define OTG_HNPTXFSIZ_PTXSA_MASK	(0x0000ffff)
+
+/* OTG Host periodic transmit FIFO size register (OTG_HPTXFSIZ) */
+#define OTG_HPTXFSIZ_PTXFD_MASK		(0xffff0000)
+#define OTG_HPTXFSIZ_PTXSA_MASK		(0x0000ffff)
+
+/* OTG Host Configuration Register (OTG_HCFG) */
+/* Bits 31:3 - Reserved */
+#define OTG_HCFG_FSLSS		(1 << 2)
+#define OTG_HCFG_FSLSPCS_48MHz	(0x1 << 0)
+#define OTG_HCFG_FSLSPCS_6MHz	(0x2 << 0)
+#define OTG_HCFG_FSLSPCS_MASK	(0x3 << 0)
+
+/* OTG Host Frame Interval Register (OTG_HFIR) */
+/* Bits 31:16 - Reserved */
+#define OTG_HFIR_FRIVL_MASK		(0x0000ffff)
+
+/* OTG Host frame number/frame time remaining register (OTG_HFNUM) */
+#define OTG_HFNUM_FTREM_MASK		(0xffff0000)
+#define OTG_HFNUM_FRNUM_MASK		(0x0000ffff)
+
+/* OTG Host periodic transmit FIFO/queue status register (OTG_HPTXSTS) */
+#define OTG_HPTXSTS_PTXQTOP_MASK			(0xff000000)
+#define OTG_HPTXSTS_PTXQTOP_ODDFRM			(1<<31)
+#define OTG_HPTXSTS_PTXQTOP_EVENFRM			(0<<31)
+#define OTG_HPTXSTS_PTXQTOP_CHANNEL_NUMBER_MASK		(0xf<<27)
+#define OTG_HPTXSTS_PTXQTOP_ENDPOINT_NUMBER_MASK	(0xf<<27)
+#define OTG_HPTXSTS_PTXQTOP_TYPE_INOUT			(0x00<<25)
+#define OTG_HPTXSTS_PTXQTOP_TYPE_ZEROLENGTH		(0x01<<25)
+#define OTG_HPTXSTS_PTXQTOP_TYPE_DISABLECMD		(0x11<<25)
+#define OTG_HPTXSTS_PTXQTOP_TERMINATE			(1<<24)
+#define OTG_HPTXSTS_PTXQSAV_MASK			(0x00ff0000)
+#define OTG_HPTXSTS_PTXFSAVL_MASK			(0x0000ffff)
+
+/* OTG Host all channels interrupt mask register (OTG_HAINT) */
+/* Bits 31:16 - Reserved */
+#define OTG_HAINTMSK_HAINT_MASK		(0x0000ffff)
+
+/* OTG Host all channels interrupt mask register (OTG_HAINTMSK) */
+/* Bits 31:16 - Reserved */
+#define OTG_HAINTMSK_HAINTM_MASK	(0x0000ffff)
+
+/* OTG Host port control and status register (OTG_HPRT) */
+/* Bits 31:19 - Reserved */
+#define OTG_HPRT_PSPD_HIGH		(0x0 << 17)
+#define OTG_HPRT_PSPD_FULL		(0x1 << 17)
+#define OTG_HPRT_PSPD_LOW		(0x2 << 17)
+#define OTG_HPRT_PSPD_MASK		(0x3 << 17)
+#define OTG_HPRT_PTCTL_DISABLED		(0x0 << 13)
+#define OTG_HPRT_PTCTL_J		(0x1 << 13)
+#define OTG_HPRT_PTCTL_K		(0x2 << 13)
+#define OTG_HPRT_PTCTL_SE0_NAK		(0x3 << 13)
+#define OTG_HPRT_PTCTL_PACKET		(0x4 << 13)
+#define OTG_HPRT_PTCTL_FORCE_ENABLE	(0x5 << 13)
+#define OTG_HPRT_PPWR			(1 << 12)
+#define OTG_HPRT_PLSTS_DM		(1 << 11)
+#define OTG_HPRT_PLSTS_DP		(1 << 10)
+/* Bit 9 - Reserved */
+#define OTG_HPRT_PRST		(1 << 8)
+#define OTG_HPRT_PSUSP		(1 << 7)
+#define OTG_HPRT_PRES		(1 << 6)
+#define OTG_HPRT_POCCHNG	(1 << 5)
+#define OTG_HPRT_POCA		(1 << 4)
+#define OTG_HPRT_PENCHNG	(1 << 3)
+#define OTG_HPRT_PENA		(1 << 2)
+#define OTG_HPRT_PCDET		(1 << 1)
+#define OTG_HPRT_PCSTS		(1 << 0)
+
+/* OTG Host channel-x characteristics register (OTG_HCCHARx) */
+#define OTG_HCCHAR_CHENA		(1 << 31)
+#define OTG_HCCHAR_CHDIS		(1 << 30)
+#define OTG_HCCHAR_ODDFRM		(1 << 29)
+#define OTG_HCCHAR_DAD_MASK		(0x7f << 22)
+#define OTG_HCCHAR_MCNT_1		(0x1 << 20)
+#define OTG_HCCHAR_MCNT_2		(0x2 << 20)
+#define OTG_HCCHAR_MCNT_3		(0x3 << 20)
+#define OTG_HCCHAR_MCNT_MASK		(0x3 << 20)
+#define OTG_HCCHAR_EPTYP_CONTROL	(0 << 18)
+#define OTG_HCCHAR_EPTYP_ISOCHRONOUS	(1 << 18)
+#define OTG_HCCHAR_EPTYP_BULK		(2 << 18)
+#define OTG_HCCHAR_EPTYP_INTERRUPT	(3 << 18)
+#define OTG_HCCHAR_EPTYP_MASK		(3 << 18)
+#define OTG_HCCHAR_LSDEV		(1 << 17)
+/* Bit 16 - Reserved */
+#define OTG_HCCHAR_EPDIR_OUT		(0 << 15)
+#define OTG_HCCHAR_EPDIR_IN		(1 << 15)
+#define OTG_HCCHAR_EPDIR_MASK		(1 << 15)
+#define OTG_HCCHAR_EPNUM_MASK		(0xf << 11)
+#define OTG_HCCHAR_MPSIZ_MASK		(0x7ff << 0)
+
+/* OTG Host channel-x interrupt register (OTG_HCINTx) */
+/* Bits 31:11 - Reserved */
+#define OTG_HCINT_DTERR		(1 << 10)
+#define OTG_HCINT_FRMOR		(1 << 9)
+#define OTG_HCINT_BBERR		(1 << 8)
+#define OTG_HCINT_TXERR		(1 << 7)
+// Note: OTG_HCINT_NYET: Only in OTG_HS
+#define OTG_HCINT_NYET		(1 << 6)
+#define OTG_HCINT_ACK		(1 << 5)
+#define OTG_HCINT_NAK		(1 << 4)
+#define OTG_HCINT_STALL		(1 << 3)
+// Note: OTG_HCINT_AHBERR: Only in OTG_HS
+#define OTG_HCINT_AHBERR	(1 << 2)
+#define OTG_HCINT_CHH		(1 << 1)
+#define OTG_HCINT_XFRC		(1 << 0)
+
+/* OTG Host channel-x interrupt mask register (OTG_HCINTMSKx) */
+/* Bits 31:11 - Reserved */
+#define OTG_HCINTMSK_DTERRM		(1 << 10)
+#define OTG_HCINTMSK_FRMORM		(1 << 9)
+#define OTG_HCINTMSK_BBERRM		(1 << 8)
+#define OTG_HCINTMSK_TXERRM		(1 << 7)
+// Note: OTG_HCINTMSK_NYET: Only in OTG_HS
+#define OTG_HCINTMSK_NYET		(1 << 6)
+#define OTG_HCINTMSK_ACKM		(1 << 5)
+#define OTG_HCINTMSK_NAKM		(1 << 4)
+#define OTG_HCINTMSK_STALLM		(1 << 3)
+// Note: OTG_HCINTMSK_AHBERR: Only in OTG_HS
+#define OTG_HCINTMSK_AHBERR		(1 << 2)
+#define OTG_HCINTMSK_CHHM		(1 << 1)
+#define OTG_HCINTMSK_XFRCM		(1 << 0)
+
+/* OTG Host channel-x transfer size register (OTG_HCTSIZx) */
+// Note: OTG_HCTSIZ_DOPING: Only in OTG_HS
+#define OTG_HCTSIZ_DOPING	(1 << 31)
+#define OTG_HCTSIZ_DPID_DATA0	(0x0 << 29)
+#define OTG_HCTSIZ_DPID_DATA1	(0x2 << 29)
+#define OTG_HCTSIZ_DPID_DATA2	(0x1 << 29)
+#define OTG_HCTSIZ_DPID_MDATA	(0x3 << 29)
+#define OTG_HCTSIZ_DPID_MASK	(0x3 << 29)
+#define OTG_HCTSIZ_PKTCNT_MASK	(0x3ff << 19)
+#define OTG_HCTSIZ_XFRSIZ_MASK	(0x7ffff << 0)
+
+
+
+#endif

--- a/include/libopencm3/stm32/otg_fs.h
+++ b/include/libopencm3/stm32/otg_fs.h
@@ -27,324 +27,72 @@
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/otg_common.h>
+
+/***********************************************************************/
 
 /* Core Global Control and Status Registers */
-#define OTG_FS_GOTGCTL			MMIO32(USB_OTG_FS_BASE + 0x000)
-#define OTG_FS_GOTGINT			MMIO32(USB_OTG_FS_BASE + 0x004)
-#define OTG_FS_GAHBCFG			MMIO32(USB_OTG_FS_BASE + 0x008)
-#define OTG_FS_GUSBCFG			MMIO32(USB_OTG_FS_BASE + 0x00C)
-#define OTG_FS_GRSTCTL			MMIO32(USB_OTG_FS_BASE + 0x010)
-#define OTG_FS_GINTSTS			MMIO32(USB_OTG_FS_BASE + 0x014)
-#define OTG_FS_GINTMSK			MMIO32(USB_OTG_FS_BASE + 0x018)
-#define OTG_FS_GRXSTSR			MMIO32(USB_OTG_FS_BASE + 0x01C)
-#define OTG_FS_GRXSTSP			MMIO32(USB_OTG_FS_BASE + 0x020)
-#define OTG_FS_GRXFSIZ			MMIO32(USB_OTG_FS_BASE + 0x024)
-#define OTG_FS_GNPTXFSIZ		MMIO32(USB_OTG_FS_BASE + 0x028)
-#define OTG_FS_GNPTXSTS			MMIO32(USB_OTG_FS_BASE + 0x02C)
-#define OTG_FS_GCCFG			MMIO32(USB_OTG_FS_BASE + 0x038)
-#define OTG_FS_CID			MMIO32(USB_OTG_FS_BASE + 0x03C)
-#define OTG_FS_HPTXFSIZ			MMIO32(USB_OTG_FS_BASE + 0x100)
-#define OTG_FS_DIEPTXF(x)		MMIO32(USB_OTG_FS_BASE + 0x104 \
-					       + 4*(x-1))
+#define OTG_FS_GOTGCTL			MMIO32(USB_OTG_FS_BASE + OTG_GOTGCTL)
+#define OTG_FS_GOTGINT			MMIO32(USB_OTG_FS_BASE + OTG_GOTGINT)
+#define OTG_FS_GAHBCFG			MMIO32(USB_OTG_FS_BASE + OTG_GAHBCFG)
+#define OTG_FS_GUSBCFG			MMIO32(USB_OTG_FS_BASE + OTG_GUSBCFG)
+#define OTG_FS_GRSTCTL			MMIO32(USB_OTG_FS_BASE + OTG_GRSTCTL)
+#define OTG_FS_GINTSTS			MMIO32(USB_OTG_FS_BASE + OTG_GINTSTS)
+#define OTG_FS_GINTMSK			MMIO32(USB_OTG_FS_BASE + OTG_GINTMSK)
+#define OTG_FS_GRXSTSR			MMIO32(USB_OTG_FS_BASE + OTG_GRXSTSR)
+#define OTG_FS_GRXSTSP			MMIO32(USB_OTG_FS_BASE + OTG_GRXSTSP)
+#define OTG_FS_GRXFSIZ			MMIO32(USB_OTG_FS_BASE + OTG_GRXFSIZ)
+#define OTG_FS_GNPTXFSIZ		MMIO32(USB_OTG_FS_BASE + OTG_GNPTXFSIZ)
+#define OTG_FS_GNPTXSTS			MMIO32(USB_OTG_FS_BASE + OTG_GNPTXSTS)
+#define OTG_FS_GCCFG			MMIO32(USB_OTG_FS_BASE + OTG_GCCFG)
+#define OTG_FS_CID			MMIO32(USB_OTG_FS_BASE + OTG_CID)
+#define OTG_FS_HPTXFSIZ			MMIO32(USB_OTG_FS_BASE + OTG_HPTXFSIZ)
+#define OTG_FS_DIEPTXF(x)		MMIO32(USB_OTG_FS_BASE + OTG_DIEPTXF(x))
+
 
 /* Host-mode Control and Status Registers */
-#define OTG_FS_HCFG			MMIO32(USB_OTG_FS_BASE + 0x400)
-#define OTG_FS_HFIR			MMIO32(USB_OTG_FS_BASE + 0x404)
-#define OTG_FS_HFNUM			MMIO32(USB_OTG_FS_BASE + 0x408)
-#define OTG_FS_HPTXSTS			MMIO32(USB_OTG_FS_BASE + 0x410)
-#define OTG_FS_HAINT			MMIO32(USB_OTG_FS_BASE + 0x414)
-#define OTG_FS_HAINTMSK			MMIO32(USB_OTG_FS_BASE + 0x418)
-#define OTG_FS_HPRT			MMIO32(USB_OTG_FS_BASE + 0x440)
-#define OTG_FS_HCCHARx			MMIO32(USB_OTG_FS_BASE + 0x500)
-#define OTG_FS_HCINTx			MMIO32(USB_OTG_FS_BASE + 0x508)
-#define OTG_FS_HCINTMSKx		MMIO32(USB_OTG_FS_BASE + 0x50C)
-#define OTG_FS_HCTSIZx			MMIO32(USB_OTG_FS_BASE + 0x510)
+#define OTG_FS_HCFG			MMIO32(USB_OTG_FS_BASE + OTG_HCFG)
+#define OTG_FS_HFIR			MMIO32(USB_OTG_FS_BASE + OTG_HFIR)
+#define OTG_FS_HFNUM			MMIO32(USB_OTG_FS_BASE + OTG_HFNUM)
+#define OTG_FS_HPTXSTS			MMIO32(USB_OTG_FS_BASE + OTG_HPTXSTS)
+#define OTG_FS_HAINT			MMIO32(USB_OTG_FS_BASE + OTG_HAINT)
+#define OTG_FS_HAINTMSK			MMIO32(USB_OTG_FS_BASE + OTG_HAINTMSK)
+#define OTG_FS_HPRT			MMIO32(USB_OTG_FS_BASE + OTG_HPRT)
+#define OTG_FS_HCCHAR(x)		MMIO32(USB_OTG_FS_BASE + OTG_HCCHAR(x))
+#define OTG_FS_HCINT(x)			MMIO32(USB_OTG_FS_BASE + OTG_HCINT(x))
+#define OTG_FS_HCINTMSK(x)		MMIO32(USB_OTG_FS_BASE + OTG_HCINTMSK(x))
+#define OTG_FS_HCTSIZ(x)		MMIO32(USB_OTG_FS_BASE + OTG_HCTSIZ(x))
 
 /* Device-mode Control and Status Registers */
-#define OTG_FS_DCFG			MMIO32(USB_OTG_FS_BASE + 0x800)
-#define OTG_FS_DCTL			MMIO32(USB_OTG_FS_BASE + 0x804)
-#define OTG_FS_DSTS			MMIO32(USB_OTG_FS_BASE + 0x808)
-#define OTG_FS_DIEPMSK			MMIO32(USB_OTG_FS_BASE + 0x810)
-#define OTG_FS_DOEPMSK			MMIO32(USB_OTG_FS_BASE + 0x814)
-#define OTG_FS_DAINT			MMIO32(USB_OTG_FS_BASE + 0x818)
-#define OTG_FS_DAINTMSK			MMIO32(USB_OTG_FS_BASE + 0x81C)
-#define OTG_FS_DVBUSDIS			MMIO32(USB_OTG_FS_BASE + 0x828)
-#define OTG_FS_DVBUSPULSE		MMIO32(USB_OTG_FS_BASE + 0x82C)
-#define OTG_FS_DIEPEMPMSK		MMIO32(USB_OTG_FS_BASE + 0x834)
-#define OTG_FS_DIEPCTL0			MMIO32(USB_OTG_FS_BASE + 0x900)
-#define OTG_FS_DIEPCTL(x)		MMIO32(USB_OTG_FS_BASE + 0x900 + \
-						0x20*(x))
-#define OTG_FS_DOEPCTL0			MMIO32(USB_OTG_FS_BASE + 0xB00)
-#define OTG_FS_DOEPCTL(x)		MMIO32(USB_OTG_FS_BASE + 0xB00 + \
-						0x20*(x))
-#define OTG_FS_DIEPINT(x)		MMIO32(USB_OTG_FS_BASE + 0x908 + \
-						0x20*(x))
-#define OTG_FS_DOEPINT(x)		MMIO32(USB_OTG_FS_BASE + 0xB08 + \
-						0x20*(x))
-#define OTG_FS_DIEPTSIZ0		MMIO32(USB_OTG_FS_BASE + 0x910)
-#define OTG_FS_DOEPTSIZ0		MMIO32(USB_OTG_FS_BASE + 0xB10)
-#define OTG_FS_DIEPTSIZ(x)		MMIO32(USB_OTG_FS_BASE + 0x910 + \
-						0x20*(x))
-#define OTG_FS_DTXFSTS(x)		MMIO32(USB_OTG_FS_BASE + 0x918 + \
-						0x20*(x))
-#define OTG_FS_DOEPTSIZ(x)		MMIO32(USB_OTG_FS_BASE + 0xB10 + \
-						0x20*(x))
+#define OTG_FS_DCFG			MMIO32(USB_OTG_FS_BASE + OTG_DCFG)
+#define OTG_FS_DCTL			MMIO32(USB_OTG_FS_BASE + OTG_DCTL)
+#define OTG_FS_DSTS			MMIO32(USB_OTG_FS_BASE + OTG_DSTS)
+#define OTG_FS_DIEPMSK			MMIO32(USB_OTG_FS_BASE + OTG_DIEPMSK)
+#define OTG_FS_DOEPMSK			MMIO32(USB_OTG_FS_BASE + OTG_DOEPMSK)
+#define OTG_FS_DAINT			MMIO32(USB_OTG_FS_BASE + OTG_DAINT)
+#define OTG_FS_DAINTMSK			MMIO32(USB_OTG_FS_BASE + OTG_DAINTMSK)
+#define OTG_FS_DVBUSDIS			MMIO32(USB_OTG_FS_BASE + OTG_DVBUSDIS)
+#define OTG_FS_DVBUSPULSE		MMIO32(USB_OTG_FS_BASE + OTG_DVBUSPULSE)
+#define OTG_FS_DIEPEMPMSK		MMIO32(USB_OTG_FS_BASE + OTG_DIEPEMPMSK)
+#define OTG_FS_DIEPCTL0			MMIO32(USB_OTG_FS_BASE + OTG_DIEPCTL0)
+#define OTG_FS_DIEPCTL(x)		MMIO32(USB_OTG_FS_BASE + OTG_DIEPCTL(x))
+#define OTG_FS_DOEPCTL0			MMIO32(USB_OTG_FS_BASE + OTG_DOEPCTL0)
+#define OTG_FS_DOEPCTL(x)		MMIO32(USB_OTG_FS_BASE + OTG_DOEPCTL(x))
+#define OTG_FS_DIEPINT(x)		MMIO32(USB_OTG_FS_BASE + OTG_DIEPINT(x))
+#define OTG_FS_DOEPINT(x)		MMIO32(USB_OTG_FS_BASE + OTG_DOEPINT(x))
+#define OTG_FS_DIEPTSIZ0		MMIO32(USB_OTG_FS_BASE + OTG_DIEPTSIZ0)
+#define OTG_FS_DOEPTSIZ0		MMIO32(USB_OTG_FS_BASE + OTG_DOEPTSIZ0)
+#define OTG_FS_DIEPTSIZ(x)		MMIO32(USB_OTG_FS_BASE + OTG_DIEPTSIZ(x))
+#define OTG_FS_DTXFSTS(x)		MMIO32(USB_OTG_FS_BASE + OTG_DTXFSTS(x))
+#define OTG_FS_DOEPTSIZ(x)		MMIO32(USB_OTG_FS_BASE + OTG_DOEPTSIZ(x))
 
 /* Power and clock gating control and status register */
-#define OTG_FS_PCGCCTL			MMIO32(USB_OTG_FS_BASE + 0xE00)
+#define OTG_FS_PCGCCTL			MMIO32(USB_OTG_FS_BASE + OTG_PCGCCTL)
 
 /* Data FIFO */
 #define OTG_FS_FIFO(x)			(&MMIO32(USB_OTG_FS_BASE \
 							      + (((x) + 1) \
 								 << 12)))
 
-/* Global CSRs */
-/* OTG_FS USB control registers (OTG_HS_GOTGCTL) */
-#define OTG_FS_GOTGCTL_BSVLD		(1 << 19)
-#define OTG_FS_GOTGCTL_ASVLD		(1 << 18)
-#define OTG_FS_GOTGCTL_DBCT		(1 << 17)
-#define OTG_FS_GOTGCTL_CIDSTS		(1 << 16)
-#define OTG_FS_GOTGCTL_DHNPEN		(1 << 11)
-#define OTG_FS_GOTGCTL_HSHNPEN		(1 << 10)
-#define OTG_FS_GOTGCTL_HNPRQ		(1 << 9)
-#define OTG_FS_GOTGCTL_HNGSCS		(1 << 8)
-#define OTG_FS_GOTGCTL_SRQ		(1 << 1)
-#define OTG_FS_GOTGCTL_SRQSCS		(1 << 0)
-
-/* OTG_FS AHB configuration register (OTG_FS_GAHBCFG) */
-#define OTG_FS_GAHBCFG_GINT		0x0001
-#define OTG_FS_GAHBCFG_TXFELVL		0x0080
-#define OTG_FS_GAHBCFG_PTXFELVL		0x0100
-
-/* OTG_FS USB configuration register (OTG_FS_GUSBCFG) */
-#define OTG_FS_GUSBCFG_TOCAL		0x00000003
-#define OTG_FS_GUSBCFG_SRPCAP		0x00000100
-#define OTG_FS_GUSBCFG_HNPCAP		0x00000200
-#define OTG_FS_GUSBCFG_TRDT_MASK	(0xf << 10)
-#define OTG_FS_GUSBCFG_TRDT_16BIT	(0x5 << 10)
-#define OTG_FS_GUSBCFG_TRDT_8BIT	(0x9 << 10)
-#define OTG_FS_GUSBCFG_NPTXRWEN		0x00004000
-#define OTG_FS_GUSBCFG_FHMOD		0x20000000
-#define OTG_FS_GUSBCFG_FDMOD		0x40000000
-#define OTG_FS_GUSBCFG_CTXPKT		0x80000000
-#define OTG_FS_GUSBCFG_PHYSEL		(1 << 7)
-
-/* OTG_FS reset register (OTG_FS_GRSTCTL) */
-#define OTG_FS_GRSTCTL_AHBIDL		(1 << 31)
-/* Bits 30:11 - Reserved */
-#define OTG_FS_GRSTCTL_TXFNUM_MASK	(0x1f << 6)
-#define OTG_FS_GRSTCTL_TXFFLSH		(1 << 5)
-#define OTG_FS_GRSTCTL_RXFFLSH		(1 << 4)
-/* Bit 3 - Reserved */
-#define OTG_FS_GRSTCTL_FCRST		(1 << 2)
-#define OTG_FS_GRSTCTL_HSRST		(1 << 1)
-#define OTG_FS_GRSTCTL_CSRST		(1 << 0)
-
-/* OTG_FS interrupt status register (OTG_FS_GINTSTS) */
-#define OTG_FS_GINTSTS_WKUPINT		(1 << 31)
-#define OTG_FS_GINTSTS_SRQINT		(1 << 30)
-#define OTG_FS_GINTSTS_DISCINT		(1 << 29)
-#define OTG_FS_GINTSTS_CIDSCHG		(1 << 28)
-/* Bit 27 - Reserved */
-#define OTG_FS_GINTSTS_PTXFE		(1 << 26)
-#define OTG_FS_GINTSTS_HCINT		(1 << 25)
-#define OTG_FS_GINTSTS_HPRTINT		(1 << 24)
-/* Bits 23:22 - Reserved */
-#define OTG_FS_GINTSTS_IPXFR		(1 << 21)
-#define OTG_FS_GINTSTS_INCOMPISOOUT	(1 << 21)
-#define OTG_FS_GINTSTS_IISOIXFR		(1 << 20)
-#define OTG_FS_GINTSTS_OEPINT		(1 << 19)
-#define OTG_FS_GINTSTS_IEPINT		(1 << 18)
-/* Bits 17:16 - Reserved */
-#define OTG_FS_GINTSTS_EOPF		(1 << 15)
-#define OTG_FS_GINTSTS_ISOODRP		(1 << 14)
-#define OTG_FS_GINTSTS_ENUMDNE		(1 << 13)
-#define OTG_FS_GINTSTS_USBRST		(1 << 12)
-#define OTG_FS_GINTSTS_USBSUSP		(1 << 11)
-#define OTG_FS_GINTSTS_ESUSP		(1 << 10)
-/* Bits 9:8 - Reserved */
-#define OTG_FS_GINTSTS_GONAKEFF		(1 << 7)
-#define OTG_FS_GINTSTS_GINAKEFF		(1 << 6)
-#define OTG_FS_GINTSTS_NPTXFE		(1 << 5)
-#define OTG_FS_GINTSTS_RXFLVL		(1 << 4)
-#define OTG_FS_GINTSTS_SOF		(1 << 3)
-#define OTG_FS_GINTSTS_OTGINT		(1 << 2)
-#define OTG_FS_GINTSTS_MMIS		(1 << 1)
-#define OTG_FS_GINTSTS_CMOD		(1 << 0)
-
-/* OTG_FS interrupt mask register (OTG_FS_GINTMSK) */
-#define OTG_FS_GINTMSK_MMISM		0x00000002
-#define OTG_FS_GINTMSK_OTGINT		0x00000004
-#define OTG_FS_GINTMSK_SOFM		0x00000008
-#define OTG_FS_GINTMSK_RXFLVLM		0x00000010
-#define OTG_FS_GINTMSK_NPTXFEM		0x00000020
-#define OTG_FS_GINTMSK_GINAKEFFM	0x00000040
-#define OTG_FS_GINTMSK_GONAKEFFM	0x00000080
-#define OTG_FS_GINTMSK_ESUSPM		0x00000400
-#define OTG_FS_GINTMSK_USBSUSPM		0x00000800
-#define OTG_FS_GINTMSK_USBRST		0x00001000
-#define OTG_FS_GINTMSK_ENUMDNEM		0x00002000
-#define OTG_FS_GINTMSK_ISOODRPM		0x00004000
-#define OTG_FS_GINTMSK_EOPFM		0x00008000
-#define OTG_FS_GINTMSK_EPMISM		0x00020000
-#define OTG_FS_GINTMSK_IEPINT		0x00040000
-#define OTG_FS_GINTMSK_OEPINT		0x00080000
-#define OTG_FS_GINTMSK_IISOIXFRM	0x00100000
-#define OTG_FS_GINTMSK_IISOOXFRM	0x00200000
-#define OTG_FS_GINTMSK_IPXFRM		0x00200000
-#define OTG_FS_GINTMSK_PRTIM		0x01000000
-#define OTG_FS_GINTMSK_HCIM		0x02000000
-#define OTG_FS_GINTMSK_PTXFEM		0x04000000
-#define OTG_FS_GINTMSK_CIDSCHGM		0x10000000
-#define OTG_FS_GINTMSK_DISCINT		0x20000000
-#define OTG_FS_GINTMSK_SRQIM		0x40000000
-#define OTG_FS_GINTMSK_WUIM		0x80000000
-
-/* OTG_FS Receive Status Pop Register (OTG_FS_GRXSTSP) */
-/* Bits 31:25 - Reserved */
-#define OTG_FS_GRXSTSP_FRMNUM_MASK		(0xf << 21)
-#define OTG_FS_GRXSTSP_PKTSTS_MASK		(0xf << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_GOUTNAK		(0x1 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_OUT		(0x2 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_OUT_COMP		(0x3 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_SETUP_COMP	(0x4 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_SETUP		(0x6 << 17)
-#define OTG_FS_GRXSTSP_DPID_MASK		(0x3 << 15)
-#define OTG_FS_GRXSTSP_DPID_DATA0		(0x0 << 15)
-#define OTG_FS_GRXSTSP_DPID_DATA1		(0x2 << 15)
-#define OTG_FS_GRXSTSP_DPID_DATA2		(0x1 << 15)
-#define OTG_FS_GRXSTSP_DPID_MDATA		(0x3 << 15)
-#define OTG_FS_GRXSTSP_BCNT_MASK		(0x7ff << 4)
-#define OTG_FS_GRXSTSP_EPNUM_MASK		(0xf << 0)
-
-/* OTG_FS general core configuration register (OTG_FS_GCCFG) */
-/* Bits 31:22 - Reserved */
-#define OTG_FS_GCCFG_NOVBUSSENS		(1 << 21)
-#define OTG_FS_GCCFG_SOFOUTEN		(1 << 20)
-#define OTG_FS_GCCFG_VBUSBSEN		(1 << 19)
-#define OTG_FS_GCCFG_VBUSASEN		(1 << 18)
-/* Bit 17 - Reserved */
-#define OTG_FS_GCCFG_PWRDWN		(1 << 16)
-/* Bits 15:0 - Reserved */
-
-
-/* Device-mode CSRs */
-/* OTG_FS device control register (OTG_FS_DCTL) */
-/* Bits 31:12 - Reserved */
-#define OTG_FS_DCTL_POPRGDNE		(1 << 11)
-#define OTG_FS_DCTL_CGONAK		(1 << 10)
-#define OTG_FS_DCTL_SGONAK		(1 << 9)
-#define OTG_FS_DCTL_SGINAK		(1 << 8)
-#define OTG_FS_DCTL_TCTL_MASK		(7 << 4)
-#define OTG_FS_DCTL_GONSTS		(1 << 3)
-#define OTG_FS_DCTL_GINSTS		(1 << 2)
-#define OTG_FS_DCTL_SDIS		(1 << 1)
-#define OTG_FS_DCTL_RWUSIG		(1 << 0)
-
-/* OTG_FS device configuration register (OTG_FS_DCFG) */
-#define OTG_FS_DCFG_DSPD		0x0003
-#define OTG_FS_DCFG_NZLSOHSK		0x0004
-#define OTG_FS_DCFG_DAD			0x07F0
-#define OTG_FS_DCFG_PFIVL		0x1800
-
-/* OTG_FS Device IN Endpoint Common Interrupt Mask Register (OTG_FS_DIEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_FS_DIEPMSK_BIM		(1 << 9)
-#define OTG_FS_DIEPMSK_TXFURM		(1 << 8)
-/* Bit 7 - Reserved */
-#define OTG_FS_DIEPMSK_INEPNEM		(1 << 6)
-#define OTG_FS_DIEPMSK_INEPNMM		(1 << 5)
-#define OTG_FS_DIEPMSK_ITTXFEMSK	(1 << 4)
-#define OTG_FS_DIEPMSK_TOM		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DIEPMSK_EPDM		(1 << 1)
-#define OTG_FS_DIEPMSK_XFRCM		(1 << 0)
-
-/* OTG_FS Device OUT Endpoint Common Interrupt Mask Register (OTG_FS_DOEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_FS_DOEPMSK_BOIM		(1 << 9)
-#define OTG_FS_DOEPMSK_OPEM		(1 << 8)
-/* Bit 7 - Reserved */
-#define OTG_FS_DOEPMSK_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_FS_DOEPMSK_OTEPDM		(1 << 4)
-#define OTG_FS_DOEPMSK_STUPM		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DOEPMSK_EPDM		(1 << 1)
-#define OTG_FS_DOEPMSK_XFRCM		(1 << 0)
-
-/* OTG_FS Device Control IN Endpoint 0 Control Register (OTG_FS_DIEPCTL0) */
-#define OTG_FS_DIEPCTL0_EPENA		(1 << 31)
-#define OTG_FS_DIEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_FS_DIEPCTLX_SD0PID		(1 << 28)
-#define OTG_FS_DIEPCTL0_SNAK		(1 << 27)
-#define OTG_FS_DIEPCTL0_CNAK		(1 << 26)
-#define OTG_FS_DIEPCTL0_TXFNUM_MASK	(0xf << 22)
-#define OTG_FS_DIEPCTL0_STALL		(1 << 21)
-/* Bit 20 - Reserved */
-#define OTG_FS_DIEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_FS_DIEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_FS_DIEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_FS_DIEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device Control OUT Endpoint 0 Control Register (OTG_FS_DOEPCTL0) */
-#define OTG_FS_DOEPCTL0_EPENA		(1 << 31)
-#define OTG_FS_DOEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_FS_DOEPCTLX_SD0PID		(1 << 28)
-#define OTG_FS_DOEPCTL0_SNAK		(1 << 27)
-#define OTG_FS_DOEPCTL0_CNAK		(1 << 26)
-/* Bits 25:22 - Reserved */
-#define OTG_FS_DOEPCTL0_STALL		(1 << 21)
-#define OTG_FS_DOEPCTL0_SNPM		(1 << 20)
-#define OTG_FS_DOEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_FS_DOEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_FS_DOEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_FS_DOEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_FS_DIEPINTx) */
-/* Bits 31:8 - Reserved */
-#define OTG_FS_DIEPINTX_TXFE		(1 << 7)
-#define OTG_FS_DIEPINTX_INEPNE		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_FS_DIEPINTX_ITTXFE		(1 << 4)
-#define OTG_FS_DIEPINTX_TOC		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DIEPINTX_EPDISD		(1 << 1)
-#define OTG_FS_DIEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_FS_DOEPINTx) */
-/* Bits 31:7 - Reserved */
-#define OTG_FS_DOEPINTX_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_FS_DOEPINTX_OTEPDIS		(1 << 4)
-#define OTG_FS_DOEPINTX_STUP		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DOEPINTX_EPDISD		(1 << 1)
-#define OTG_FS_DOEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device OUT Endpoint 0 Transfer Size Register (OTG_FS_DOEPTSIZ0) */
-/* Bit 31 - Reserved */
-#define OTG_FS_DIEPSIZ0_STUPCNT_1	(0x1 << 29)
-#define OTG_FS_DIEPSIZ0_STUPCNT_2	(0x2 << 29)
-#define OTG_FS_DIEPSIZ0_STUPCNT_3	(0x3 << 29)
-#define OTG_FS_DIEPSIZ0_STUPCNT_MASK	(0x3 << 29)
-/* Bits 28:20 - Reserved */
-#define OTG_FS_DIEPSIZ0_PKTCNT		(1 << 19)
-/* Bits 18:7 - Reserved */
-#define OTG_FS_DIEPSIZ0_XFRSIZ_MASK	(0x7f << 0)
 
 #endif

--- a/include/libopencm3/stm32/otg_hs.h
+++ b/include/libopencm3/stm32/otg_hs.h
@@ -22,66 +22,23 @@
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/otg_common.h>
 
-/* Core Global Control and Status Registers */
-#define OTG_GOTGCTL			0x000
-#define OTG_GOTGIN			0x004
-#define OTG_GAHBCFG			0x008
-#define OTG_GUSBCFG			0x00C
-#define OTG_GRSTCTL			0x010
-#define OTG_GINTSTS			0x014
-#define OTG_GINTMSK			0x018
-#define OTG_GRXSTSR			0x01C
-#define OTG_GRXSTSP			0x020
-#define OTG_GRXFSIZ			0x024
-#define OTG_GNPTXFSIZ			0x028
-#define OTG_GNPTXSTS			0x02C
-#define OTG_GCCFG			0x038
-#define OTG_CID				0x03C
-#define OTG_HPTXFSIZ			0x100
-#define OTG_DIEPTXF(x)			(0x104 + 4*(x-1))
+/* OTG_HS specific registers */
 
 /* Host-mode Control and Status Registers */
-#define OTG_HCFG			0x400
-#define OTG_HFIR			0x404
-#define OTG_HFNUM			0x408
-#define OTG_HPTXSTS			0x410
-#define OTG_HAINT			0x414
-#define OTG_HAINTMSK			0x418
-#define OTG_HPRT			0x440
-#define OTG_HCCHARx			0x500
-#define OTG_HCINTx			0x508
-#define OTG_HCINTMSKx			0x50C
-#define OTG_HCTSIZx			0x510
+#define OTG_HCSPLT(x)			(0x504 + 0x20*(x))
+#define OTG_HCDMA(x)			(0x514 + 0x20*(x))
 
 /* Device-mode Control and Status Registers */
-#define OTG_DCFG			0x800
-#define OTG_DCTL			0x804
-#define OTG_DSTS			0x808
-#define OTG_DIEPMSK			0x810
-#define OTG_DOEPMSK			0x814
-#define OTG_DAINT			0x818
-#define OTG_DAINTMSK			0x81C
-#define OTG_DVBUSDIS			0x828
-#define OTG_DVBUSPULSE			0x82C
-#define OTG_DIEPEMPMSK			0x834
-#define OTG_DIEPCTL0			0x900
-#define OTG_DIEPCTL(x)			(0x900 + 0x20*(x))
-#define OTG_DOEPCTL0			0xB00
-#define OTG_DOEPCTL(x)			(0xB00 + 0x20*(x))
-#define OTG_DIEPINT(x)			(0x908 + 0x20*(x))
-#define OTG_DOEPINT(x)			(0xB08 + 0x20*(x))
-#define OTG_DIEPTSIZ0			0x910
-#define OTG_DOEPTSIZ0			0xB10
-#define OTG_DIEPTSIZ(x)			(0x910 + 0x20*(x))
-#define OTG_DTXFSTS(x)			(0x918 + 0x20*(x))
-#define OTG_DOEPTSIZ(x)			(0xB10 + 0x20*(x))
+#define OTG_DEACHHINT			0x838
+#define OTG_DEACHHINTMSK			0x83C
+#define OTG_DIEPEACHMSK1		0x844
+#define OTG_DOEPEACHMSK1		0x884
+#define OTG_DIEPDMA(x)			(0x914 + 0x20*(x))
+#define OTG_DOEPDMA(x)			(0xB14 + 0x20*(x))
 
-/* Power and clock gating control and status register */
-#define OTG_PCGCCTL			0xE00
 
-/* Data FIFO */
-#define OTG_FIFO(x)			(((x) + 1) << 12)
 
 /***********************************************************************/
 
@@ -111,10 +68,12 @@
 #define OTG_HS_HAINT			MMIO32(USB_OTG_HS_BASE + OTG_HAINT)
 #define OTG_HS_HAINTMSK			MMIO32(USB_OTG_HS_BASE + OTG_HAINTMSK)
 #define OTG_HS_HPRT			MMIO32(USB_OTG_HS_BASE + OTG_HPRT)
-#define OTG_HS_HCCHARx			MMIO32(USB_OTG_HS_BASE + OTG_HCCHARx)
-#define OTG_HS_HCINTx			MMIO32(USB_OTG_HS_BASE + OTG_HCINTx)
-#define OTG_HS_HCINTMSKx		MMIO32(USB_OTG_HS_BASE + OTG_HCINTMSKx)
-#define OTG_HS_HCTSIZx			MMIO32(USB_OTG_HS_BASE + OTG_HCTSIZx)
+#define OTG_HS_HCCHAR(x)		MMIO32(USB_OTG_HS_BASE + OTG_HCCHAR(x))
+#define OTG_HS_HCSPLT(x) 		MMIO32(USB_OTG_HS_BASE + OTG_HCSPLT(x))
+#define OTG_HS_HCINT(x)			MMIO32(USB_OTG_HS_BASE + OTG_HCINT(x))
+#define OTG_HS_HCINTMSK(x)		MMIO32(USB_OTG_HS_BASE + OTG_HCINTMSK(x))
+#define OTG_HS_HCTSIZ(x)		MMIO32(USB_OTG_HS_BASE + OTG_HCTSIZ(x))
+#define OTG_HS_HCDMA(x)			MMIO32(USB_OTG_HS_BASE + OTG_HCDMA(x))
 
 /* Device-mode Control and Status Registers */
 #define OTG_HS_DCFG			MMIO32(USB_OTG_HS_BASE + OTG_DCFG)
@@ -140,6 +99,12 @@
 #define OTG_HS_DTXFSTS(x)		MMIO32(USB_OTG_HS_BASE + OTG_DTXFSTS(x))
 #define OTG_HS_DOEPTSIZ(x)		MMIO32(USB_OTG_HS_BASE + \
 						OTG_DOEPTSIZ(x))
+#define OTG_HS_DEACHHINT			MMIO32(USB_OTG_HS_BASE + OTG_DEACHHINT)
+#define OTG_HS_DEACHHINTMSK		MMIO32(USB_OTG_HS_BASE + OTG_DEACHHINTMSK)
+#define OTG_HS_DIEPEACHMSK		MMIO32(USB_OTG_HS_BASE + OTG_DIEPEACHMSK1)
+#define OTG_HS_DOEPEACHMSK		MMIO32(USB_OTG_HS_BASE + OTG_DOEPEACHMSK1)
+#define OTG_HS_DIEPDMA(x)		MMIO32(USB_OTG_HS_BASE + OTG_DIEPDMA(x))
+#define OTG_HS_DOEPDMA(x)		MMIO32(USB_OTG_HS_BASE + OTG_DOEPDMA(x))
 
 /* Power and clock gating control and status register */
 #define OTG_HS_PCGCCTL			MMIO32(USB_OTG_HS_BASE + OTG_PCGCCTL)
@@ -147,252 +112,52 @@
 /* Data FIFO */
 #define OTG_HS_FIFO(x)			(&MMIO32(USB_OTG_HS_BASE + OTG_FIFO(x)))
 
-/* Global CSRs */
-/* OTG_HS USB control registers (OTG_FS_GOTGCTL) */
-#define OTG_HS_GOTGCTL_BSVLD		(1 << 19)
-#define OTG_HS_GOTGCTL_ASVLD		(1 << 18)
-#define OTG_HS_GOTGCTL_DBCT		(1 << 17)
-#define OTG_HS_GOTGCTL_CIDSTS		(1 << 16)
-#define OTG_HS_GOTGCTL_DHNPEN		(1 << 11)
-#define OTG_HS_GOTGCTL_HSHNPEN		(1 << 10)
-#define OTG_HS_GOTGCTL_HNPRQ		(1 << 9)
-#define OTG_HS_GOTGCTL_HNGSCS		(1 << 8)
-#define OTG_HS_GOTGCTL_SRQ		(1 << 1)
-#define OTG_HS_GOTGCTL_SRQSCS		(1 << 0)
+/* Device-mode CSRs*/
+/* OTG device each endpoint interrupt register (OTG_DEACHINT) */
+/* Bits 31:18 - Reserved */
+#define OTG_DEACHHINT_OEP1INT	(1 << 17)
+/* Bits 16:2 - Reserved */
+#define OTG_DEACHHINT_IEP1INT	(1 << 1)
+/* Bit 0 - Reserved */
 
-/* OTG_FS AHB configuration register (OTG_HS_GAHBCFG) */
-#define OTG_HS_GAHBCFG_GINT		0x0001
-#define OTG_HS_GAHBCFG_TXFELVL		0x0080
-#define OTG_HS_GAHBCFG_PTXFELVL		0x0100
-
-/* OTG_FS USB configuration register (OTG_HS_GUSBCFG) */
-#define OTG_HS_GUSBCFG_TOCAL		0x00000003
-#define OTG_HS_GUSBCFG_SRPCAP		0x00000100
-#define OTG_HS_GUSBCFG_HNPCAP		0x00000200
-#define OTG_HS_GUSBCFG_TRDT_MASK	(0xf << 10)
-#define OTG_HS_GUSBCFG_TRDT_16BIT	(0x5 << 10)
-#define OTG_HS_GUSBCFG_TRDT_8BIT	(0x9 << 10)
-#define OTG_HS_GUSBCFG_NPTXRWEN		0x00004000
-#define OTG_HS_GUSBCFG_FHMOD		0x20000000
-#define OTG_HS_GUSBCFG_FDMOD		0x40000000
-#define OTG_HS_GUSBCFG_CTXPKT		0x80000000
-#define OTG_HS_GUSBCFG_PHYSEL		(1 << 6)
-
-/* OTG_FS reset register (OTG_HS_GRSTCTL) */
-#define OTG_HS_GRSTCTL_AHBIDL		(1 << 31)
-/* Bits 30:11 - Reserved */
-#define OTG_HS_GRSTCTL_TXFNUM_MASK	(0x1f << 6)
-#define OTG_HS_GRSTCTL_TXFFLSH		(1 << 5)
-#define OTG_HS_GRSTCTL_RXFFLSH		(1 << 4)
-/* Bit 3 - Reserved */
-#define OTG_HS_GRSTCTL_FCRST		(1 << 2)
-#define OTG_HS_GRSTCTL_HSRST		(1 << 1)
-#define OTG_HS_GRSTCTL_CSRST		(1 << 0)
-
-/* OTG_FS interrupt status register (OTG_HS_GINTSTS) */
-#define OTG_HS_GINTSTS_WKUPINT		(1 << 31)
-#define OTG_HS_GINTSTS_SRQINT		(1 << 30)
-#define OTG_HS_GINTSTS_DISCINT		(1 << 29)
-#define OTG_HS_GINTSTS_CIDSCHG		(1 << 28)
-/* Bit 27 - Reserved */
-#define OTG_HS_GINTSTS_PTXFE		(1 << 26)
-#define OTG_HS_GINTSTS_HCINT		(1 << 25)
-#define OTG_HS_GINTSTS_HPRTINT		(1 << 24)
-/* Bits 23:22 - Reserved */
-#define OTG_HS_GINTSTS_IPXFR		(1 << 21)
-#define OTG_HS_GINTSTS_INCOMPISOOUT	(1 << 21)
-#define OTG_HS_GINTSTS_IISOIXFR		(1 << 20)
-#define OTG_HS_GINTSTS_OEPINT		(1 << 19)
-#define OTG_HS_GINTSTS_IEPINT		(1 << 18)
-/* Bits 17:16 - Reserved */
-#define OTG_HS_GINTSTS_EOPF		(1 << 15)
-#define OTG_HS_GINTSTS_ISOODRP		(1 << 14)
-#define OTG_HS_GINTSTS_ENUMDNE		(1 << 13)
-#define OTG_HS_GINTSTS_USBRST		(1 << 12)
-#define OTG_HS_GINTSTS_USBSUSP		(1 << 11)
-#define OTG_HS_GINTSTS_ESUSP		(1 << 10)
-/* Bits 9:8 - Reserved */
-#define OTG_HS_GINTSTS_GONAKEFF		(1 << 7)
-#define OTG_HS_GINTSTS_GINAKEFF		(1 << 6)
-#define OTG_HS_GINTSTS_NPTXFE		(1 << 5)
-#define OTG_HS_GINTSTS_RXFLVL		(1 << 4)
-#define OTG_HS_GINTSTS_SOF		(1 << 3)
-#define OTG_HS_GINTSTS_OTGINT		(1 << 2)
-#define OTG_HS_GINTSTS_MMIS		(1 << 1)
-#define OTG_HS_GINTSTS_CMOD		(1 << 0)
-
-/* OTG_FS interrupt mask register (OTG_HS_GINTMSK) */
-#define OTG_HS_GINTMSK_MMISM		0x00000002
-#define OTG_HS_GINTMSK_OTGINT		0x00000004
-#define OTG_HS_GINTMSK_SOFM		0x00000008
-#define OTG_HS_GINTMSK_RXFLVLM		0x00000010
-#define OTG_HS_GINTMSK_NPTXFEM		0x00000020
-#define OTG_HS_GINTMSK_GINAKEFFM	0x00000040
-#define OTG_HS_GINTMSK_GONAKEFFM	0x00000080
-#define OTG_HS_GINTMSK_ESUSPM		0x00000400
-#define OTG_HS_GINTMSK_USBSUSPM		0x00000800
-#define OTG_HS_GINTMSK_USBRST		0x00001000
-#define OTG_HS_GINTMSK_ENUMDNEM		0x00002000
-#define OTG_HS_GINTMSK_ISOODRPM		0x00004000
-#define OTG_HS_GINTMSK_EOPFM		0x00008000
-#define OTG_HS_GINTMSK_EPMISM		0x00020000
-#define OTG_HS_GINTMSK_IEPINT		0x00040000
-#define OTG_HS_GINTMSK_OEPINT		0x00080000
-#define OTG_HS_GINTMSK_IISOIXFRM	0x00100000
-#define OTG_HS_GINTMSK_IISOOXFRM	0x00200000
-#define OTG_HS_GINTMSK_IPXFRM		0x00200000
-#define OTG_HS_GINTMSK_PRTIM		0x01000000
-#define OTG_HS_GINTMSK_HCIM		0x02000000
-#define OTG_HS_GINTMSK_PTXFEM		0x04000000
-#define OTG_HS_GINTMSK_CIDSCHGM		0x10000000
-#define OTG_HS_GINTMSK_DISCINT		0x20000000
-#define OTG_HS_GINTMSK_SRQIM		0x40000000
-#define OTG_HS_GINTMSK_WUIM		0x80000000
-
-/* OTG_FS Receive Status Pop Register (OTG_HS_GRXSTSP) */
-/* Bits 31:25 - Reserved */
-#define OTG_HS_GRXSTSP_FRMNUM_MASK		(0xf << 21)
-#define OTG_HS_GRXSTSP_PKTSTS_MASK		(0xf << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_GOUTNAK		(0x1 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_OUT		(0x2 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_OUT_COMP		(0x3 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_SETUP_COMP	(0x4 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_SETUP		(0x6 << 17)
-#define OTG_HS_GRXSTSP_DPID_MASK		(0x3 << 15)
-#define OTG_HS_GRXSTSP_DPID_DATA0		(0x0 << 15)
-#define OTG_HS_GRXSTSP_DPID_DATA1		(0x2 << 15)
-#define OTG_HS_GRXSTSP_DPID_DATA2		(0x1 << 15)
-#define OTG_HS_GRXSTSP_DPID_MDATA		(0x3 << 15)
-#define OTG_HS_GRXSTSP_BCNT_MASK		(0x7ff << 4)
-#define OTG_HS_GRXSTSP_EPNUM_MASK		(0xf << 0)
-
-/* OTG_FS general core configuration register (OTG_HS_GCCFG) */
-/* Bits 31:21 - Reserved */
-#define OTG_HS_GCCFG_SOFOUTEN		(1 << 20)
-#define OTG_HS_GCCFG_VBUSBSEN		(1 << 19)
-#define OTG_HS_GCCFG_VBUSASEN		(1 << 18)
-/* Bit 17 - Reserved */
-#define OTG_HS_GCCFG_PWRDWN		(1 << 16)
-/* Bits 15:0 - Reserved */
-
-
-/* Device-mode CSRs */
-/* OTG_FS device control register (OTG_HS_DCTL) */
-/* Bits 31:12 - Reserved */
-#define OTG_HS_DCTL_POPRGDNE		(1 << 11)
-#define OTG_HS_DCTL_CGONAK		(1 << 10)
-#define OTG_HS_DCTL_SGONAK		(1 << 9)
-#define OTG_HS_DCTL_SGINAK		(1 << 8)
-#define OTG_HS_DCTL_TCTL_MASK		(7 << 4)
-#define OTG_HS_DCTL_GONSTS		(1 << 3)
-#define OTG_HS_DCTL_GINSTS		(1 << 2)
-#define OTG_HS_DCTL_SDIS		(1 << 1)
-#define OTG_HS_DCTL_RWUSIG		(1 << 0)
-
-/* OTG_FS device configuration register (OTG_HS_DCFG) */
-#define OTG_HS_DCFG_DSPD		0x0003
-#define OTG_HS_DCFG_NZLSOHSK		0x0004
-#define OTG_HS_DCFG_DAD			0x07F0
-#define OTG_HS_DCFG_PFIVL		0x1800
-
-/* OTG_FS Device IN Endpoint Common Interrupt Mask Register (OTG_HS_DIEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_HS_DIEPMSK_BIM		(1 << 9)
-#define OTG_HS_DIEPMSK_TXFURM		(1 << 8)
+/* OTG device each in endpoint-1 interrupt register (OTG_DIEPEACHMSK1) */
+/* Bits 31:14 - Reserved */
+#define OTG_DIEPEACHMSK1_NAKM 		(1 << 13)
+/* Bits 12:10 - Reserved */
+#define OTG_DIEPEACHMSK1_BIM			(1 << 9)
+#define OTG_DIEPEACHMSK1_TXFURM		(1 << 8)
 /* Bit 7 - Reserved */
-#define OTG_HS_DIEPMSK_INEPNEM		(1 << 6)
-#define OTG_HS_DIEPMSK_INEPNMM		(1 << 5)
-#define OTG_HS_DIEPMSK_ITTXFEMSK	(1 << 4)
-#define OTG_HS_DIEPMSK_TOM		(1 << 3)
+#define OTG_DIEPEACHMSK1_INEPNEM		(1 << 6)
+#define OTG_DIEPEACHMSK1_INEPNMM		(1 << 5)
+#define OTG_DIEPEACHMSK1_ITTXFEMSK	(1 << 4)
+#define OTG_DIEPEACHMSK1_TOM			(1 << 3)
 /* Bit 2 - Reserved */
-#define OTG_HS_DIEPMSK_EPDM		(1 << 1)
-#define OTG_HS_DIEPMSK_XFRCM		(1 << 0)
+#define OTG_DIEPEACHMSK1_EPDM		(1 << 1)
+#define OTG_DIEPEACHMSK1_XFRCM		(1 << 0)
 
-/* OTG_FS Device OUT Endpoint Common Interrupt Mask Register (OTG_HS_DOEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_HS_DOEPMSK_BOIM		(1 << 9)
-#define OTG_HS_DOEPMSK_OPEM		(1 << 8)
-/* Bit 7 - Reserved */
-#define OTG_HS_DOEPMSK_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_HS_DOEPMSK_OTEPDM		(1 << 4)
-#define OTG_HS_DOEPMSK_STUPM		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_HS_DOEPMSK_EPDM		(1 << 1)
-#define OTG_HS_DOEPMSK_XFRCM		(1 << 0)
+/* OTG device each OUT endpoint-1 interrupt register (OTG_DOEPEACHMSK1) */
+/* Bits 31:15 - Reserved */
+#define OTG_DOEPEACHMSK1_NYETM		(1 << 14)
+#define OTG_DOEPEACHMSK1_NAKM		(1 << 13)
+#define OTG_DOEPEACHMSK1_BERRM		(1 << 12)
+/* Bits 11:10 - Reserved */
+#define OTG_DOEPEACHMSK1_BIM			(1 << 9)
+#define OTG_DOEPEACHMSK1_OPEM		(1 << 8)
+/* Bits 7:3 - Reserved */
+#define OTG_DOEPEACHMSK1_AHBERRM		(1 << 2)
+#define OTG_DOEPEACHMSK1_EPDM		(1 << 1)
+#define OTG_DOEPEACHMSK1_XFRCM		(1 << 0)
 
-/* OTG_FS Device Control IN Endpoint 0 Control Register (OTG_HS_DIEPCTL0) */
-#define OTG_HS_DIEPCTL0_EPENA		(1 << 31)
-#define OTG_HS_DIEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_HS_DIEPCTLX_SD0PID		(1 << 28)
-#define OTG_HS_DIEPCTL0_SNAK		(1 << 27)
-#define OTG_HS_DIEPCTL0_CNAK		(1 << 26)
-#define OTG_HS_DIEPCTL0_TXFNUM_MASK	(0xf << 22)
-#define OTG_HS_DIEPCTL0_STALL		(1 << 21)
-/* Bit 20 - Reserved */
-#define OTG_HS_DIEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_HS_DIEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_HS_DIEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_HS_DIEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device Control OUT Endpoint 0 Control Register (OTG_HS_DOEPCTL0) */
-#define OTG_HS_DOEPCTL0_EPENA		(1 << 31)
-#define OTG_HS_DOEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_HS_DOEPCTLX_SD0PID		(1 << 28)
-#define OTG_HS_DOEPCTL0_SNAK		(1 << 27)
-#define OTG_HS_DOEPCTL0_CNAK		(1 << 26)
-/* Bits 25:22 - Reserved */
-#define OTG_HS_DOEPCTL0_STALL		(1 << 21)
-#define OTG_HS_DOEPCTL0_SNPM		(1 << 20)
-#define OTG_HS_DOEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_HS_DOEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_HS_DOEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_HS_DOEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_HS_DIEPINTx) */
-/* Bits 31:8 - Reserved */
-#define OTG_HS_DIEPINTX_TXFE		(1 << 7)
-#define OTG_HS_DIEPINTX_INEPNE		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_HS_DIEPINTX_ITTXFE		(1 << 4)
-#define OTG_HS_DIEPINTX_TOC		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_HS_DIEPINTX_EPDISD		(1 << 1)
-#define OTG_HS_DIEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_HS_DOEPINTx) */
-/* Bits 31:7 - Reserved */
-#define OTG_HS_DOEPINTX_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_HS_DOEPINTX_OTEPDIS		(1 << 4)
-#define OTG_HS_DOEPINTX_STUP		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_HS_DOEPINTX_EPDISD		(1 << 1)
-#define OTG_HS_DOEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device OUT Endpoint 0 Transfer Size Register (OTG_HS_DOEPTSIZ0) */
-/* Bit 31 - Reserved */
-#define OTG_HS_DIEPSIZ0_STUPCNT_1	(0x1 << 29)
-#define OTG_HS_DIEPSIZ0_STUPCNT_2	(0x2 << 29)
-#define OTG_HS_DIEPSIZ0_STUPCNT_3	(0x3 << 29)
-#define OTG_HS_DIEPSIZ0_STUPCNT_MASK	(0x3 << 29)
-/* Bits 28:20 - Reserved */
-#define OTG_HS_DIEPSIZ0_PKTCNT		(1 << 19)
-/* Bits 18:7 - Reserved */
-#define OTG_HS_DIEPSIZ0_XFRSIZ_MASK	(0x7f << 0)
+/* Host-mode CSRs */
+/* OTG host channel-x split control register (OTG_HCSPLTx) */
+#define OTG_HCSPLT_SPLITEN		(1 << 31)
+/* Bits 30:17 - Reserved */
+#define OTG_HCSPLT_COMPLSPLT		(1 << 16)
+#define OTG_HCSPLT_XACTPOS_ALL	(0x3 << 14)
+#define OTG_HCSPLT_XACTPOS_BEGIN	(0x2 << 14)
+#define OTG_HCSPLT_XACTPOS_MID	(0x0 << 14)
+#define OTG_HCSPLT_XACTPOS_END	(0x1 << 14)
+#define OTG_HCSPLT_HUBADDR_MASK	(0x7f << 7)
+#define OTG_HCSPLT_PORTADDR_MASK	(0x7f << 0)
 
 #endif

--- a/lib/usb/usb_f107.c
+++ b/lib/usb/usb_f107.c
@@ -52,23 +52,23 @@ const struct _usbd_driver stm32f107_usb_driver = {
 /** Initialize the USB device controller hardware of the STM32. */
 static usbd_device *stm32f107_usbd_init(void)
 {
-	OTG_FS_GINTSTS = OTG_FS_GINTSTS_MMIS;
+	OTG_FS_GINTSTS = OTG_GINTSTS_MMIS;
 
-	OTG_FS_GUSBCFG |= OTG_FS_GUSBCFG_PHYSEL;
+	OTG_FS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;
 	/* Enable VBUS sensing in device mode and power down the PHY. */
-	OTG_FS_GCCFG |= OTG_FS_GCCFG_VBUSBSEN | OTG_FS_GCCFG_PWRDWN;
+	OTG_FS_GCCFG |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
 
 	/* Wait for AHB idle. */
-	while (!(OTG_FS_GRSTCTL & OTG_FS_GRSTCTL_AHBIDL));
+	while (!(OTG_FS_GRSTCTL & OTG_GRSTCTL_AHBIDL));
 	/* Do core soft reset. */
-	OTG_FS_GRSTCTL |= OTG_FS_GRSTCTL_CSRST;
-	while (OTG_FS_GRSTCTL & OTG_FS_GRSTCTL_CSRST);
+	OTG_FS_GRSTCTL |= OTG_GRSTCTL_CSRST;
+	while (OTG_FS_GRSTCTL & OTG_GRSTCTL_CSRST);
 
 	/* Force peripheral only mode. */
-	OTG_FS_GUSBCFG |= OTG_FS_GUSBCFG_FDMOD | OTG_FS_GUSBCFG_TRDT_MASK;
+	OTG_FS_GUSBCFG |= OTG_GUSBCFG_FDMOD | OTG_GUSBCFG_TRDT_MASK;
 
 	/* Full speed device. */
-	OTG_FS_DCFG |= OTG_FS_DCFG_DSPD;
+	OTG_FS_DCFG |= OTG_DCFG_DSPD;
 
 	/* Restart the PHY clock. */
 	OTG_FS_PCGCCTL = 0;
@@ -77,15 +77,15 @@ static usbd_device *stm32f107_usbd_init(void)
 	usbd_dev.fifo_mem_top = stm32f107_usb_driver.rx_fifo_size;
 
 	/* Unmask interrupts for TX and RX. */
-	OTG_FS_GAHBCFG |= OTG_FS_GAHBCFG_GINT;
-	OTG_FS_GINTMSK = OTG_FS_GINTMSK_ENUMDNEM |
-			 OTG_FS_GINTMSK_RXFLVLM |
-			 OTG_FS_GINTMSK_IEPINT |
-			 OTG_FS_GINTMSK_USBSUSPM |
-			 OTG_FS_GINTMSK_WUIM |
-			 OTG_FS_GINTMSK_SOFM;
+	OTG_FS_GAHBCFG |= OTG_GAHBCFG_GINT;
+	OTG_FS_GINTMSK = OTG_GINTMSK_ENUMDNEM |
+			 OTG_GINTMSK_RXFLVLM |
+			 OTG_GINTMSK_IEPINT |
+			 OTG_GINTMSK_USBSUSPM |
+			 OTG_GINTMSK_WUIM |
+			 OTG_GINTMSK_SOFM;
 	OTG_FS_DAINTMSK = 0xF;
-	OTG_FS_DIEPMSK = OTG_FS_DIEPMSK_XFRCM;
+	OTG_FS_DIEPMSK = OTG_DIEPMSK_XFRCM;
 
 	return &usbd_dev;
 }

--- a/lib/usb/usb_f207.c
+++ b/lib/usb/usb_f207.c
@@ -52,23 +52,23 @@ const struct _usbd_driver stm32f207_usb_driver = {
 /** Initialize the USB device controller hardware of the STM32. */
 static usbd_device *stm32f207_usbd_init(void)
 {
-	OTG_HS_GINTSTS = OTG_HS_GINTSTS_MMIS;
+	OTG_HS_GINTSTS = OTG_GINTSTS_MMIS;
 
-	OTG_HS_GUSBCFG |= OTG_HS_GUSBCFG_PHYSEL;
+	OTG_HS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;
 	/* Enable VBUS sensing in device mode and power down the PHY. */
-	OTG_HS_GCCFG |= OTG_HS_GCCFG_VBUSBSEN | OTG_HS_GCCFG_PWRDWN;
+	OTG_HS_GCCFG |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
 
 	/* Wait for AHB idle. */
-	while (!(OTG_HS_GRSTCTL & OTG_HS_GRSTCTL_AHBIDL));
+	while (!(OTG_HS_GRSTCTL & OTG_GRSTCTL_AHBIDL));
 	/* Do core soft reset. */
-	OTG_HS_GRSTCTL |= OTG_HS_GRSTCTL_CSRST;
-	while (OTG_HS_GRSTCTL & OTG_HS_GRSTCTL_CSRST);
+	OTG_HS_GRSTCTL |= OTG_GRSTCTL_CSRST;
+	while (OTG_HS_GRSTCTL & OTG_GRSTCTL_CSRST);
 
 	/* Force peripheral only mode. */
-	OTG_HS_GUSBCFG |= OTG_HS_GUSBCFG_FDMOD | OTG_HS_GUSBCFG_TRDT_MASK;
+	OTG_HS_GUSBCFG |= OTG_GUSBCFG_FDMOD | OTG_GUSBCFG_TRDT_MASK;
 
 	/* Full speed device. */
-	OTG_HS_DCFG |= OTG_HS_DCFG_DSPD;
+	OTG_HS_DCFG |= OTG_DCFG_DSPD;
 
 	/* Restart the PHY clock. */
 	OTG_HS_PCGCCTL = 0;
@@ -77,15 +77,15 @@ static usbd_device *stm32f207_usbd_init(void)
 	usbd_dev.fifo_mem_top = stm32f207_usb_driver.rx_fifo_size;
 
 	/* Unmask interrupts for TX and RX. */
-	OTG_HS_GAHBCFG |= OTG_HS_GAHBCFG_GINT;
-	OTG_HS_GINTMSK = OTG_HS_GINTMSK_ENUMDNEM |
-			 OTG_HS_GINTMSK_RXFLVLM |
-			 OTG_HS_GINTMSK_IEPINT |
-			 OTG_HS_GINTMSK_USBSUSPM |
-			 OTG_HS_GINTMSK_WUIM |
-			 OTG_HS_GINTMSK_SOFM;
+	OTG_HS_GAHBCFG |= OTG_GAHBCFG_GINT;
+	OTG_HS_GINTMSK = OTG_GINTMSK_ENUMDNEM |
+			 OTG_GINTMSK_RXFLVLM |
+			 OTG_GINTMSK_IEPINT |
+			 OTG_GINTMSK_USBSUSPM |
+			 OTG_GINTMSK_WUIM |
+			 OTG_GINTMSK_SOFM;
 	OTG_HS_DAINTMSK = 0xF;
-	OTG_HS_DIEPMSK = OTG_HS_DIEPMSK_XFRCM;
+	OTG_HS_DIEPMSK = OTG_DIEPMSK_XFRCM;
 
 	return &usbd_dev;
 }

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -35,7 +35,7 @@
 
 void stm32fx07_set_address(usbd_device *usbd_dev, uint8_t addr)
 {
-	REBASE(OTG_DCFG) = (REBASE(OTG_DCFG) & ~OTG_FS_DCFG_DAD) | (addr << 4);
+	REBASE(OTG_DCFG) = (REBASE(OTG_DCFG) & ~OTG_DCFG_DAD) | (addr << 4);
 }
 
 void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
@@ -52,27 +52,27 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 	if (addr == 0) { /* For the default control endpoint */
 		/* Configure IN part. */
 		if (max_size >= 64) {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_64;
+			REBASE(OTG_DIEPCTL0) = OTG_DIEPCTL0_MPSIZ_64;
 		} else if (max_size >= 32) {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_32;
+			REBASE(OTG_DIEPCTL0) = OTG_DIEPCTL0_MPSIZ_32;
 		} else if (max_size >= 16) {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_16;
+			REBASE(OTG_DIEPCTL0) = OTG_DIEPCTL0_MPSIZ_16;
 		} else {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_8;
+			REBASE(OTG_DIEPCTL0) = OTG_DIEPCTL0_MPSIZ_8;
 		}
 
 		REBASE(OTG_DIEPTSIZ0) =
-			(max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
+			(max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
 		REBASE(OTG_DIEPCTL0) |=
-			OTG_FS_DIEPCTL0_EPENA | OTG_FS_DIEPCTL0_SNAK;
+			OTG_DIEPCTL0_EPENA | OTG_DIEPCTL0_SNAK;
 
 		/* Configure OUT part. */
-		usbd_dev->doeptsiz[0] = OTG_FS_DIEPSIZ0_STUPCNT_1 |
-			OTG_FS_DIEPSIZ0_PKTCNT |
-			(max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
+		usbd_dev->doeptsiz[0] = OTG_DIEPSIZ0_STUPCNT_1 |
+			OTG_DIEPSIZ0_PKTCNT |
+			(max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
 		REBASE(OTG_DOEPTSIZ(0)) = usbd_dev->doeptsiz[0];
 		REBASE(OTG_DOEPCTL(0)) |=
-		    OTG_FS_DOEPCTL0_EPENA | OTG_FS_DIEPCTL0_SNAK;
+		    OTG_DOEPCTL0_EPENA | OTG_DIEPCTL0_SNAK;
 
 		REBASE(OTG_GNPTXFSIZ) = ((max_size / 4) << 16) |
 					 usbd_dev->driver->rx_fifo_size;
@@ -88,10 +88,10 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		usbd_dev->fifo_mem_top += max_size / 4;
 
 		REBASE(OTG_DIEPTSIZ(addr)) =
-		    (max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
+		    (max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
 		REBASE(OTG_DIEPCTL(addr)) |=
-		    OTG_FS_DIEPCTL0_EPENA | OTG_FS_DIEPCTL0_SNAK | (type << 18)
-		    | OTG_FS_DIEPCTL0_USBAEP | OTG_FS_DIEPCTLX_SD0PID
+		    OTG_DIEPCTL0_EPENA | OTG_DIEPCTL0_SNAK | (type << 18)
+		    | OTG_DIEPCTL0_USBAEP | OTG_DIEPCTLX_SD0PID
 		    | (addr << 22) | max_size;
 
 		if (callback) {
@@ -101,12 +101,12 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 	}
 
 	if (!dir) {
-		usbd_dev->doeptsiz[addr] = OTG_FS_DIEPSIZ0_PKTCNT |
-				 (max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
+		usbd_dev->doeptsiz[addr] = OTG_DIEPSIZ0_PKTCNT |
+				 (max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
 		REBASE(OTG_DOEPTSIZ(addr)) = usbd_dev->doeptsiz[addr];
-		REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_EPENA |
-		    OTG_FS_DOEPCTL0_USBAEP | OTG_FS_DIEPCTL0_CNAK |
-		    OTG_FS_DOEPCTLX_SD0PID | (type << 18) | max_size;
+		REBASE(OTG_DOEPCTL(addr)) |= OTG_DOEPCTL0_EPENA |
+		    OTG_DOEPCTL0_USBAEP | OTG_DIEPCTL0_CNAK |
+		    OTG_DOEPCTLX_SD0PID | (type << 18) | max_size;
 
 		if (callback) {
 			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
@@ -125,9 +125,9 @@ void stm32fx07_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall)
 {
 	if (addr == 0) {
 		if (stall) {
-			REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTL0_STALL;
+			REBASE(OTG_DIEPCTL(addr)) |= OTG_DIEPCTL0_STALL;
 		} else {
-			REBASE(OTG_DIEPCTL(addr)) &= ~OTG_FS_DIEPCTL0_STALL;
+			REBASE(OTG_DIEPCTL(addr)) &= ~OTG_DIEPCTL0_STALL;
 		}
 	}
 
@@ -135,17 +135,17 @@ void stm32fx07_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall)
 		addr &= 0x7F;
 
 		if (stall) {
-			REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTL0_STALL;
+			REBASE(OTG_DIEPCTL(addr)) |= OTG_DIEPCTL0_STALL;
 		} else {
-			REBASE(OTG_DIEPCTL(addr)) &= ~OTG_FS_DIEPCTL0_STALL;
-			REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTLX_SD0PID;
+			REBASE(OTG_DIEPCTL(addr)) &= ~OTG_DIEPCTL0_STALL;
+			REBASE(OTG_DIEPCTL(addr)) |= OTG_DIEPCTLX_SD0PID;
 		}
 	} else {
 		if (stall) {
-			REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_STALL;
+			REBASE(OTG_DOEPCTL(addr)) |= OTG_DOEPCTL0_STALL;
 		} else {
-			REBASE(OTG_DOEPCTL(addr)) &= ~OTG_FS_DOEPCTL0_STALL;
-			REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTLX_SD0PID;
+			REBASE(OTG_DOEPCTL(addr)) &= ~OTG_DOEPCTL0_STALL;
+			REBASE(OTG_DOEPCTL(addr)) |= OTG_DOEPCTLX_SD0PID;
 		}
 	}
 }
@@ -155,10 +155,10 @@ uint8_t stm32fx07_ep_stall_get(usbd_device *usbd_dev, uint8_t addr)
 	/* Return non-zero if STALL set. */
 	if (addr & 0x80) {
 		return (REBASE(OTG_DIEPCTL(addr & 0x7f)) &
-				OTG_FS_DIEPCTL0_STALL) ? 1 : 0;
+				OTG_DIEPCTL0_STALL) ? 1 : 0;
 	} else {
 		return (REBASE(OTG_DOEPCTL(addr)) &
-				OTG_FS_DOEPCTL0_STALL) ? 1 : 0;
+				OTG_DOEPCTL0_STALL) ? 1 : 0;
 	}
 }
 
@@ -172,9 +172,9 @@ void stm32fx07_ep_nak_set(usbd_device *usbd_dev, uint8_t addr, uint8_t nak)
 	usbd_dev->force_nak[addr] = nak;
 
 	if (nak) {
-		REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_SNAK;
+		REBASE(OTG_DOEPCTL(addr)) |= OTG_DOEPCTL0_SNAK;
 	} else {
-		REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_CNAK;
+		REBASE(OTG_DOEPCTL(addr)) |= OTG_DOEPCTL0_CNAK;
 	}
 }
 
@@ -187,14 +187,14 @@ uint16_t stm32fx07_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
 	addr &= 0x7F;
 
 	/* Return if endpoint is already enabled. */
-	if (REBASE(OTG_DIEPTSIZ(addr)) & OTG_FS_DIEPSIZ0_PKTCNT) {
+	if (REBASE(OTG_DIEPTSIZ(addr)) & OTG_DIEPSIZ0_PKTCNT) {
 		return 0;
 	}
 
 	/* Enable endpoint for transmission. */
-	REBASE(OTG_DIEPTSIZ(addr)) = OTG_FS_DIEPSIZ0_PKTCNT | len;
-	REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTL0_EPENA |
-				     OTG_FS_DIEPCTL0_CNAK;
+	REBASE(OTG_DIEPTSIZ(addr)) = OTG_DIEPSIZ0_PKTCNT | len;
+	REBASE(OTG_DIEPCTL(addr)) |= OTG_DIEPCTL0_EPENA |
+				     OTG_DIEPCTL0_CNAK;
 	volatile uint32_t *fifo = REBASE_FIFO(addr);
 
 	/* Copy buffer to endpoint FIFO, note - memcpy does not work */
@@ -226,9 +226,9 @@ uint16_t stm32fx07_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
 	}
 
 	REBASE(OTG_DOEPTSIZ(addr)) = usbd_dev->doeptsiz[addr];
-	REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_EPENA |
+	REBASE(OTG_DOEPCTL(addr)) |= OTG_DOEPCTL0_EPENA |
 	    (usbd_dev->force_nak[addr] ?
-	     OTG_FS_DOEPCTL0_SNAK : OTG_FS_DOEPCTL0_CNAK);
+	     OTG_DOEPCTL0_SNAK : OTG_DOEPCTL0_CNAK);
 
 	return len;
 }
@@ -239,34 +239,34 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 	uint32_t intsts = REBASE(OTG_GINTSTS);
 	int i;
 
-	if (intsts & OTG_FS_GINTSTS_ENUMDNE) {
+	if (intsts & OTG_GINTSTS_ENUMDNE) {
 		/* Handle USB RESET condition. */
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_ENUMDNE;
+		REBASE(OTG_GINTSTS) = OTG_GINTSTS_ENUMDNE;
 		usbd_dev->fifo_mem_top = usbd_dev->driver->rx_fifo_size;
 		_usbd_reset(usbd_dev);
 		return;
 	}
 
 	/* Note: RX and TX handled differently in this device. */
-	if (intsts & OTG_FS_GINTSTS_RXFLVL) {
+	if (intsts & OTG_GINTSTS_RXFLVL) {
 		/* Receive FIFO non-empty. */
 		uint32_t rxstsp = REBASE(OTG_GRXSTSP);
-		uint32_t pktsts = rxstsp & OTG_FS_GRXSTSP_PKTSTS_MASK;
-		if ((pktsts != OTG_FS_GRXSTSP_PKTSTS_OUT) &&
-		    (pktsts != OTG_FS_GRXSTSP_PKTSTS_SETUP)) {
+		uint32_t pktsts = rxstsp & OTG_GRXSTSP_PKTSTS_MASK;
+		if ((pktsts != OTG_GRXSTSP_PKTSTS_OUT) &&
+		    (pktsts != OTG_GRXSTSP_PKTSTS_SETUP)) {
 			return;
 		}
 
-		uint8_t ep = rxstsp & OTG_FS_GRXSTSP_EPNUM_MASK;
+		uint8_t ep = rxstsp & OTG_GRXSTSP_EPNUM_MASK;
 		uint8_t type;
-		if (pktsts == OTG_FS_GRXSTSP_PKTSTS_SETUP) {
+		if (pktsts == OTG_GRXSTSP_PKTSTS_SETUP) {
 			type = USB_TRANSACTION_SETUP;
 		} else {
 			type = USB_TRANSACTION_OUT;
 		}
 
 		/* Save packet size for stm32f107_ep_read_packet(). */
-		usbd_dev->rxbcnt = (rxstsp & OTG_FS_GRXSTSP_BCNT_MASK) >> 4;
+		usbd_dev->rxbcnt = (rxstsp & OTG_GRXSTSP_BCNT_MASK) >> 4;
 
 		/*
 		 * FIXME: Why is a delay needed here?
@@ -291,10 +291,10 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 
 	/*
 	 * There is no global interrupt flag for transmit complete.
-	 * The XFRC bit must be checked in each OTG_FS_DIEPINT(x).
+	 * The XFRC bit must be checked in each OTG_DIEPINT(x).
 	 */
 	for (i = 0; i < 4; i++) { /* Iterate over endpoints. */
-		if (REBASE(OTG_DIEPINT(i)) & OTG_FS_DIEPINTX_XFRC) {
+		if (REBASE(OTG_DIEPINT(i)) & OTG_DIEPINTX_XFRC) {
 			/* Transfer complete. */
 			if (usbd_dev->user_callback_ctr[i]
 						       [USB_TRANSACTION_IN]) {
@@ -302,37 +302,37 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 					[USB_TRANSACTION_IN](usbd_dev, i);
 			}
 
-			REBASE(OTG_DIEPINT(i)) = OTG_FS_DIEPINTX_XFRC;
+			REBASE(OTG_DIEPINT(i)) = OTG_DIEPINTX_XFRC;
 		}
 	}
 
-	if (intsts & OTG_FS_GINTSTS_USBSUSP) {
+	if (intsts & OTG_GINTSTS_USBSUSP) {
 		if (usbd_dev->user_callback_suspend) {
 			usbd_dev->user_callback_suspend();
 		}
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_USBSUSP;
+		REBASE(OTG_GINTSTS) = OTG_GINTSTS_USBSUSP;
 	}
 
-	if (intsts & OTG_FS_GINTSTS_WKUPINT) {
+	if (intsts & OTG_GINTSTS_WKUPINT) {
 		if (usbd_dev->user_callback_resume) {
 			usbd_dev->user_callback_resume();
 		}
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_WKUPINT;
+		REBASE(OTG_GINTSTS) = OTG_GINTSTS_WKUPINT;
 	}
 
-	if (intsts & OTG_FS_GINTSTS_SOF) {
+	if (intsts & OTG_GINTSTS_SOF) {
 		if (usbd_dev->user_callback_sof) {
 			usbd_dev->user_callback_sof();
 		}
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_SOF;
+		REBASE(OTG_GINTSTS) = OTG_GINTSTS_SOF;
 	}
 }
 
 void stm32fx07_disconnect(usbd_device *usbd_dev, bool disconnected)
 {
 	if (disconnected) {
-		REBASE(OTG_DCTL) |= OTG_FS_DCTL_SDIS;
+		REBASE(OTG_DCTL) |= OTG_DCTL_SDIS;
 	} else {
-		REBASE(OTG_DCTL) &= ~OTG_FS_DCTL_SDIS;
+		REBASE(OTG_DCTL) &= ~OTG_DCTL_SDIS;
 	}
 }


### PR DESCRIPTION
As discussed in [pull request 346](https://github.com/libopencm3/libopencm3/pull/346), 
this commit fixes the following things:   

* USB host register definitions added.
* Extracted common register and bitfield definitions
    	from 'otg_fs.h' and 'otg_hs.h'
    	into new file 'otg_common.h'.
    	Modified usb low-level drivers to adopt to new style of bitfields.
* Fixed typo OTG_GOTGIN -> OTG_GOTGINT (according to the datasheet)