### PR TITLE
RCC request for comment

### DIFF
--- a/include/libopencm3/stm32/f4/pwr.h
+++ b/include/libopencm3/stm32/f4/pwr.h
@@ -72,14 +72,14 @@ LGPL License Terms @ref lgpl_license
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
-	SCALE1,
-	SCALE2,
-} vos_scale_t;
+enum pwr_vos_scale {
+	PWR_SCALE1,
+	PWR_SCALE2,
+};
 
 BEGIN_DECLS
 
-void pwr_set_vos_scale(vos_scale_t scale);
+void pwr_set_vos_scale(enum pwr_vos_scale scale);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -538,11 +538,6 @@ static inline void rcc_ltdc_set_clock_divr(uint8_t pllsaidivr)
 }
 
 /* --- Variable definitions ------------------------------------------------ */
-extern uint32_t rcc_ahb_frequency;
-extern uint32_t rcc_apb1_frequency;
-extern uint32_t rcc_apb2_frequency;
-
-/* --- Function prototypes ------------------------------------------------- */
 
 enum rcc_clock_3v3 {
 	RCC_CLOCK_3V3_48MHZ,
@@ -569,6 +564,7 @@ extern const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale *rcc_clock_scale_used;
 
 enum rcc_osc {
 	RCC_PLL,
@@ -821,6 +817,8 @@ enum rcc_periph_rst {
 #undef _REG_BIT
 
 #include <libopencm3/stm32/common/rcc_common_all.h>
+
+/* --- Function prototypes ------------------------------------------------- */
 
 BEGIN_DECLS
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -544,14 +544,14 @@ extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
-	CLOCK_3V3_48MHZ,
-	CLOCK_3V3_120MHZ,
-	CLOCK_3V3_168MHZ,
-	CLOCK_3V3_END
-} clock_3v3_t;
+enum rcc_clock_3v3 {
+	RCC_CLOCK_3V3_48MHZ,
+	RCC_CLOCK_3V3_120MHZ,
+	RCC_CLOCK_3V3_168MHZ,
+	RCC_CLOCK_3V3_END
+};
 
-typedef struct {
+struct rcc_clock_scale {
 	uint8_t pllm;
 	uint16_t plln;
 	uint8_t pllp;
@@ -563,15 +563,19 @@ typedef struct {
 	uint8_t power_save;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
-} clock_scale_t;
+};
 
-extern const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END];
-extern const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END];
-extern const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END];
-extern const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END];
 
 enum rcc_osc {
-	PLL, HSE, HSI, LSE, LSI
+	RCC_PLL,
+	RCC_HSE,
+	RCC_HSI,
+	RCC_LSE,
+	RCC_LSI
 };
 
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))
@@ -845,7 +849,7 @@ void rcc_set_main_pll_hsi(uint32_t pllm, uint32_t plln, uint32_t pllp,
 void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq);
 uint32_t rcc_system_clock_source(void);
-void rcc_clock_setup_hse_3v3(const clock_scale_t *clock);
+void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -558,6 +558,8 @@ struct rcc_clock_scale {
 	uint8_t power_save;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
+	uint32_t tim_apb1_frequency;
+	uint32_t tim_apb2_frequency;
 };
 
 extern const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END];

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -48,9 +48,18 @@ usart_reg_base
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud)
 {
+
+#if defined STM32F4
+	uint32_t clock = rcc_clock_scale_used->apb1_frequency;
+
+	if ((usart == USART1) ||
+	    (usart == USART6)) {
+		clock = rcc_clock_scale_used->apb2_frequency;
+	}
+#else
 	uint32_t clock = rcc_apb1_frequency;
 
-#if defined STM32F2 || defined STM32F4
+#if defined STM32F2
 	if ((usart == USART1) ||
 	    (usart == USART6)) {
 		clock = rcc_apb2_frequency;
@@ -59,6 +68,7 @@ void usart_set_baudrate(uint32_t usart, uint32_t baud)
 	if (usart == USART1) {
 		clock = rcc_apb2_frequency;
 	}
+#endif
 #endif
 
 	/*

--- a/lib/stm32/f4/pwr.c
+++ b/lib/stm32/f4/pwr.c
@@ -36,11 +36,11 @@
 
 #include <libopencm3/stm32/pwr.h>
 
-void pwr_set_vos_scale(vos_scale_t scale)
+void pwr_set_vos_scale(enum pwr_vos_scale scale)
 {
-	if (scale == SCALE1) {
+	if (scale == PWR_SCALE1) {
 		PWR_CR |= PWR_CR_VOS;
-	} else if (scale == SCALE2) {
+	} else if (scale == PWR_SCALE2) {
 		PWR_CR &= PWR_CR_VOS;
 	}
 }

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -44,10 +44,8 @@
 
 /**@{*/
 
-/* Set the default clock frequencies after reset. */
-uint32_t rcc_ahb_frequency = 16000000;
-uint32_t rcc_apb1_frequency = 16000000;
-uint32_t rcc_apb2_frequency = 16000000;
+/* Variable keeping the pointer to the rcc setup struct we used. */
+const struct rcc_clock_scale *rcc_clock_scale_used = 0;
 
 const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
@@ -569,9 +567,8 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	/* Wait for PLL clock to be selected. */
 	rcc_wait_for_sysclk_status(RCC_PLL);
 
-	/* Set the peripheral clock frequencies used. */
-	rcc_apb1_frequency = clock->apb1_frequency;
-	rcc_apb2_frequency = clock->apb2_frequency;
+	/* Keep memory of the config struct used for future reference. */
+	rcc_clock_scale_used = clock;
 
 	/* Disable internal high-speed oscillator. */
 	rcc_osc_off(RCC_HSI);

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -49,7 +49,7 @@ uint32_t rcc_ahb_frequency = 16000000;
 uint32_t rcc_apb1_frequency = 16000000;
 uint32_t rcc_apb2_frequency = 16000000;
 
-const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 8,
 		.plln = 96,
@@ -93,7 +93,7 @@ const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
 	},
 };
 
-const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 12,
 		.plln = 96,
@@ -137,7 +137,7 @@ const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END] = {
 	},
 };
 
-const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 16,
 		.plln = 96,
@@ -181,7 +181,7 @@ const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END] = {
 	},
 };
 
-const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 25,
 		.plln = 96,
@@ -228,19 +228,19 @@ const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END] = {
 void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYC;
 		break;
 	}
@@ -249,19 +249,19 @@ void rcc_osc_ready_int_clear(enum rcc_osc osc)
 void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -270,19 +270,19 @@ void rcc_osc_ready_int_enable(enum rcc_osc osc)
 void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR &= ~RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR &= ~RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR &= ~RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR &= ~RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR &= ~RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -291,19 +291,19 @@ void rcc_osc_ready_int_disable(enum rcc_osc osc)
 int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		return ((RCC_CIR & RCC_CIR_PLLRDYF) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		return ((RCC_CIR & RCC_CIR_HSERDYF) != 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		return ((RCC_CIR & RCC_CIR_HSIRDYF) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		return ((RCC_CIR & RCC_CIR_LSERDYF) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		return ((RCC_CIR & RCC_CIR_LSIRDYF) != 0);
 		break;
 	}
@@ -324,19 +324,19 @@ int rcc_css_int_flag(void)
 void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_BDCR & RCC_BDCR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
@@ -345,13 +345,13 @@ void rcc_wait_for_osc_ready(enum rcc_osc osc)
 void rcc_wait_for_sysclk_status(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_PLL);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSE);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSI);
 		break;
 	default:
@@ -363,19 +363,19 @@ void rcc_wait_for_sysclk_status(enum rcc_osc osc)
 void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR |= RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
 	}
@@ -384,19 +384,19 @@ void rcc_osc_on(enum rcc_osc osc)
 void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR &= ~RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR &= ~RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
 	}
@@ -415,15 +415,15 @@ void rcc_css_disable(void)
 void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -432,21 +432,19 @@ void rcc_osc_bypass_enable(enum rcc_osc osc)
 void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
 }
-
-
 
 void rcc_set_sysclk_source(uint32_t clk)
 {
@@ -527,24 +525,24 @@ uint32_t rcc_system_clock_source(void)
 	return (RCC_CFGR & 0x000c) >> 2;
 }
 
-void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
+void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
 
 	/* Enable external high-speed oscillator 8MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 
 	/* Enable/disable high performance mode */
 	if (!clock->power_save) {
-		pwr_set_vos_scale(SCALE1);
+		pwr_set_vos_scale(PWR_SCALE1);
 	} else {
-		pwr_set_vos_scale(SCALE2);
+		pwr_set_vos_scale(PWR_SCALE2);
 	}
 
 	/*
@@ -559,8 +557,8 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 			clock->pllp, clock->pllq);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Configure flash settings. */
 	flash_set_ws(clock->flash_config);
@@ -569,16 +567,14 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 	rcc_set_sysclk_source(RCC_CFGR_SW_PLL);
 
 	/* Wait for PLL clock to be selected. */
-	rcc_wait_for_sysclk_status(PLL);
+	rcc_wait_for_sysclk_status(RCC_PLL);
 
 	/* Set the peripheral clock frequencies used. */
 	rcc_apb1_frequency = clock->apb1_frequency;
 	rcc_apb2_frequency = clock->apb2_frequency;
 
 	/* Disable internal high-speed oscillator. */
-	rcc_osc_off(HSI);
+	rcc_osc_off(RCC_HSI);
 }
-
-
 
 /**@}*/

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -61,6 +61,8 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
+		.tim_apb1_frequency = 24000000,
+		.tim_apb2_frequency = 48000000,
 	},
 	{ /* 120MHz */
 		.pllm = 8,
@@ -75,6 +77,8 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
+		.tim_apb1_frequency = 30000000,
+		.tim_apb2_frequency = 60000000,
 	},
 	{ /* 168MHz */
 		.pllm = 8,
@@ -88,6 +92,8 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_5WS,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
+		.tim_apb1_frequency = 84000000,
+		.tim_apb2_frequency = 168000000,
 	},
 };
 
@@ -105,6 +111,8 @@ const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
+		.tim_apb1_frequency = 24000000,
+		.tim_apb2_frequency = 48000000,
 	},
 	{ /* 120MHz */
 		.pllm = 12,
@@ -119,6 +127,8 @@ const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
+		.tim_apb1_frequency = 60000000,
+		.tim_apb2_frequency = 120000000,
 	},
 	{ /* 168MHz */
 		.pllm = 12,
@@ -132,6 +142,8 @@ const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_5WS,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
+		.tim_apb1_frequency = 84000000,
+		.tim_apb2_frequency = 168000000,
 	},
 };
 
@@ -149,6 +161,8 @@ const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
+		.tim_apb1_frequency = 24000000,
+		.tim_apb2_frequency = 48000000,
 	},
 	{ /* 120MHz */
 		.pllm = 16,
@@ -163,6 +177,8 @@ const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
+		.tim_apb1_frequency = 60000000,
+		.tim_apb2_frequency = 120000000,
 	},
 	{ /* 168MHz */
 		.pllm = 16,
@@ -176,6 +192,8 @@ const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_5WS,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
+		.tim_apb1_frequency = 84000000,
+		.tim_apb2_frequency = 168000000,
 	},
 };
 
@@ -193,6 +211,8 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
+		.tim_apb1_frequency = 24000000,
+		.tim_apb2_frequency = 48000000,
 	},
 	{ /* 120MHz */
 		.pllm = 25,
@@ -207,6 +227,8 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
+		.tim_apb1_frequency = 60000000,
+		.tim_apb2_frequency = 120000000,
 	},
 	{ /* 168MHz */
 		.pllm = 25,
@@ -220,6 +242,8 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_5WS,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
+		.tim_apb1_frequency = 84000000,
+		.tim_apb2_frequency = 168000000,
 	},
 };
 


### PR DESCRIPTION
I am looking into the way RCC is being initialized. I do like the way it is done on F4 as it makes the code more readable and should make the code reasonably flexible without adding copy pasta functions as it is the case for F1. (the idea for F1 was that it is saving memory by being a single function and we use it only once in the code, the compiler will optimize out the other implementations)

This pull request is meant to start conversation on how we can retrieve the different resulting clocks after the RCC is set up.

Also I am adding some prefix changes in this patch to decrease the name space pollution by the library. That we could fold in into this upgrade as we will be breaking the current API anyways.

The proposed solution adds the resulting clock values to the clock scale struct. There are two alternatives to this solution that would introduce functions returning the currently set clocks.

This solution would be the basis for implementing similar approach for all the other chips supported by the library. This patch is meant only as an example.

Here is the list of possible solutions:
1. Store the clocks in the struct. (can be error prone and has copypasta issues and whoever writes the struct has to make sure they put the right values in)
2. Implement functions that return the current clock setting based on the last used scale struct. It will return wrong value if a developer decides to set the clock "by hand" instead of using the setup function and struct.
3. Implement functions that return the current clock setting based on the relevant register values set. I am not sure if we can access all of them without disturbing the system.
4. Code generation. Have a script in libopencm3 that generates static RCC functions and const variables containing everything. Might be the smallest memory footprint solution.

The solution 2 and 3 will likely cost more flash memory as the functions will likely be bigger than storing 4 additional variables in the scale struct. Also the functions have to be very careful that they take all factors into account and will likely have to be implemented differently for every chip supported by the library.

I am curious what your guys take on this is and if you can thing of even better ways of doing this that will use as little memory as possible, be accurate and introduce as little possible implementation bugs and so on.

This pull request is a continuation on the proposed solution in #286 and will impact #379 
