### PR TITLE
Add 84Mhz for STM32F4.

### DIFF
--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -546,6 +546,7 @@ extern uint32_t rcc_apb2_frequency;
 
 typedef enum {
 	CLOCK_3V3_48MHZ,
+	CLOCK_3V3_84MHZ,
 	CLOCK_3V3_120MHZ,
 	CLOCK_3V3_168MHZ,
 	CLOCK_3V3_END

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -64,6 +64,19 @@ const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
 	},
+	{ /* 84MHz */
+		.pllm = 8,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_2,
+		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_5WS,
+		.apb1_frequency = 42000000,
+		.apb2_frequency = 84000000,
+	},
 	{ /* 120MHz */
 		.pllm = 8,
 		.plln = 240,
@@ -107,6 +120,19 @@ const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
+	},
+	{ /* 84MHz */
+		.pllm = 12,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_2,
+		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_5WS,
+		.apb1_frequency = 42000000,
+		.apb2_frequency = 84000000,
 	},
 	{ /* 120MHz */
 		.pllm = 12,
@@ -152,6 +178,19 @@ const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END] = {
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
 	},
+	{ /* 84MHz */
+		.pllm = 16,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_2,
+		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_5WS,
+		.apb1_frequency = 42000000,
+		.apb2_frequency = 84000000,
+	},
 	{ /* 120MHz */
 		.pllm = 16,
 		.plln = 240,
@@ -195,6 +234,19 @@ const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
+	},
+	{ /* 84MHz */
+		.pllm = 25,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_2,
+		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_5WS,
+		.apb1_frequency = 42000000,
+		.apb2_frequency = 84000000,
 	},
 	{ /* 120MHz */
 		.pllm = 25,


### PR DESCRIPTION
It seemed libopencm3 lacked 84Mhz support, which seems to work fine with this commit.