### PR TITLE
USB Premature end of control IN

### DIFF
--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -243,6 +243,13 @@ void _usbd_control_out(usbd_device *usbd_dev, uint8_t ea)
 		}
 		break;
 	case STATUS_OUT:
+	case DATA_IN:
+	case LAST_DATA_IN:
+		/* Why handle DATA_IN and LAST_DATA_IN?
+		 *  because the Host can send a OUT(0byte) packet
+		 *  to prematurely end a control IN transfer.
+		 *  so that it dont have to read all data.
+		 */
 		usbd_ep_read_packet(usbd_dev, 0, NULL, 0);
 		usbd_dev->control_state.state = IDLE;
 		if (usbd_dev->control_state.complete) {


### PR DESCRIPTION
Handle corner case: Host can send a 0byte OUT packet in middle of data stage to proceed to status stage without reading full data.

Seen: in case device descriptor size (18byte) is greater than ep0 size (see test), then host can terminate the Control IN transfer by sending a 0byte OUT in middle of the Data stage, leading to premature arrival of status stage which is not handled properly.

test: ep0 sizes can only be 8, 16, 32, 64 bytes as per USB specs. so, 8 and 16 byte ep0 will not work without this patch.
usually unable to fetch descriptor and device not responding to address will arise because device is in incorrect state due above case.

seen and fix on STM32F04 with ep0 size 16 and 8 bytes. 
Linux localhost.localdomain 3.14.27-100.fc19.x86_64 #1 SMP Wed Dec 17 19:36:34 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux