### PR TITLE
usb: add endpoint address calculation macros

### DIFF
--- a/include/libopencm3/usb/usbstd.h
+++ b/include/libopencm3/usb/usbstd.h
@@ -213,6 +213,10 @@ struct usb_endpoint_descriptor {
 } __attribute__((packed));
 #define USB_DT_ENDPOINT_SIZE		7
 
+/* USB bEndpointAddress helper macros */
+#define USB_ENDPOINT_ADDR_OUT(x) (x)
+#define USB_ENDPOINT_ADDR_IN(x) (0x80 | (x))
+
 /* USB Endpoint Descriptor bmAttributes bit definitions */
 #define USB_ENDPOINT_ATTR_CONTROL		0x00
 #define USB_ENDPOINT_ATTR_ISOCHRONOUS		0x01


### PR DESCRIPTION
Some people find it easier to read without the direction bit included.

This is intended as a replacement for: https://github.com/libopencm3/libopencm3/pull/339

Debate points are the length of the macro, but it keeps it standard with the rest of the usb defines.