### PR TITLE
SAM3 peripheral ID, PMC, PIO

### DIFF
--- a/include/libopencm3/sam/3a/gpio.h
+++ b/include/libopencm3/sam/3a/gpio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,12 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_GPIO_H
+#define LIBOPENCM3_GPIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/pio.h>
+#include <libopencm3/sam/common/gpio_common_3a3u3x.h>
+
+
 #endif

--- a/include/libopencm3/sam/3a/pio.h
+++ b/include/libopencm3/sam/3a/pio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,11 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_PIO_H
+#define LIBOPENCM3_PIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pio_common_3a3u3x.h>
+
+
 #endif

--- a/include/libopencm3/sam/3a/pmc.h
+++ b/include/libopencm3/sam/3a/pmc.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PMC_H
+#define LIBOPENCM3_PMC_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pmc_common_all.h>
+#include <libopencm3/sam/common/pmc_common_3a3s3x.h>
+#include <libopencm3/sam/common/pmc_common_3a3u3x.h>
+
+/* --- Power Management Controller (PMC) registers ------------------------- */
+
+/* Peripheral Control Register */
+#define PMC_PCR				MMIO32(PMC_BASE + 0x010C)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC Master Clock Register (PMC_MCKR) -------------------------------- */
+
+/* PLLA Divide by 2 */
+#define PMC_MCKR_PLLADIV2		(0x01 << 12)
+
+
+/* --- PMC Peripheral Control Register (PMC_PCR) --------------------------- */
+
+/* Enable */
+#define PMC_PCR_EN			(0x01 << 28)
+
+/* Divisor Value */
+#define PMC_PCR_DIV_SHIFT		16
+#define PMC_PCR_DIV_MASK		(0x03 << PMC_PCR_DIV_SHIFT)
+#define PMC_PCR_DIV_PERIPH_DIV_MCK	(0x00 << PMC_PCR_DIV_SHIFT)
+#define PMC_PCR_DIV_PERIPH_DIV2_MCK	(0x01 << PMC_PCR_DIV_SHIFT)
+#define PMC_PCR_DIV_PERIPH_DIV4_MCK	(0x02 << PMC_PCR_DIV_SHIFT)
+
+/* Command */
+#define PMC_PCR_CMD			(0x01 << 12)
+
+/* Peripheral ID */
+#define PMC_PCR_PID_SHIFT		0
+#define PMC_PCR_PID_MASK		(0x3F << PMC_PCR_PID_SHIFT)
+
+
+#endif

--- a/include/libopencm3/sam/3n/gpio.h
+++ b/include/libopencm3/sam/3n/gpio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,12 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_GPIO_H
+#define LIBOPENCM3_GPIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/pio.h>
+#include <libopencm3/sam/common/gpio_common_3n3s.h>
+
+
 #endif

--- a/include/libopencm3/sam/3n/periph.h
+++ b/include/libopencm3/sam/3n/periph.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PERIPH_H
+#define LIBOPENCM3_PERIPH_H
+
+/* --- Peripheral Identifiers ---------------------------------------------- */
+#define PERIPH_SUPC		0
+#define PERIPH_RSTC		1
+#define PERIPH_RTC		2
+#define PERIPH_RTT		3
+#define PERIPH_WDG		4
+#define PERIPH_PMC		5
+#define PERIPH_EEFC		6
+#define PERIPH_UART0		8
+#define PERIPH_UART1		9
+#define PERIPH_PIOA		11
+#define PERIPH_PIOB		12
+#define PERIPH_PIOC		13
+#define PERIPH_USART0		14
+#define PERIPH_USART1		15
+#define PERIPH_TWI0		19
+#define PERIPH_TWI1		20
+#define PERIPH_SPI		21
+#define PERIPH_TC0		23
+#define PERIPH_TC1		24
+#define PERIPH_TC2		25
+#define PERIPH_TC3		26
+#define PERIPH_TC4		27
+#define PERIPH_TC5		28
+#define PERIPH_ADC		29
+#define PERIPH_DACC		30
+#define PERIPH_PWM		31
+
+
+#endif

--- a/include/libopencm3/sam/3n/pio.h
+++ b/include/libopencm3/sam/3n/pio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,11 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_PIO_H
+#define LIBOPENCM3_PIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pio_common_3n3s.h>
+
+
 #endif

--- a/include/libopencm3/sam/3n/pmc.h
+++ b/include/libopencm3/sam/3n/pmc.h
@@ -1,0 +1,139 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PMC_H
+#define LIBOPENCM3_PMC_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pmc_common_all.h>
+#include <libopencm3/sam/common/pmc_common_3n3u.h>
+
+/* --- Power Management Controller (PMC) registers ----------------------- */
+
+/* PMC Clock Generator PLL Register */
+#define CKGR_PLLR			CKGR_PLLAR
+
+/* Oscillator Calibration Register */
+#define PMC_OCR				MMIO32(PMC_BASE + 0x0110)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC Clock Generator Main Oscillator Register (CKGR_MOR) ------------- */
+
+/* Wait Mode Command */
+#define CKGR_MOR_WAITMODE		(0x01 << 2)
+
+
+/* --- PMC Clock Generator PLL Register (CKGR_PLLR) ---------------------- */
+/* CKGR_PLLAR on all other device subfamilies */
+
+/* must be set to program CKGR_PLLR */
+#define CKGR_PLLR_ONE			CKGR_PLLAR_ONE
+
+/* PLLA Multiplier */
+#define CKGR_PLLR_MUL_SHIFT		CKGR_PLLAR_MULA_SHIFT
+#define CKGR_PLLR_MUL_MASK		CKGR_PLLAR_MULA_MASK
+
+/* PLLA Counter */
+#define CKGR_PLLR_PLLCOUNT_SHIFT	CKGR_PLLAR_PLLACOUNT_SHIFT
+#define CKGR_PLLR_PLLCOUNT_MASK		CKGR_PLLAR_PLLACOUNT_MASK
+
+/* Divider */
+#define CKGR_PLLR_DIV_SHIFT		CKGR_PLLAR_DIVA_SHIFT
+#define CKGR_PLLR_DIV_MASK		CKGR_PLLAR_DIVA_MASK
+
+
+/* --- PMC Master Clock Register (PMC_MCKR) -------------------------------- */
+
+/* PLL Divide by 2 */
+#define PMC_MCKR_PLLDIV2		(0x01 << 12)
+
+/* Master Clock Source Selection */
+#define PMC_MCKR_CSS_PLL_CLK		(2 << PMC_MCKR_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 0 (PMC_PCK0) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK0_CSS_PLL_CLK		(2 << PMC_PCK0_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 1 (PMC_PCK1) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK1_CSS_PLL_CLK		(2 << PMC_PCK1_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 2 (PMC_PCK2) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK2_CSS_PLL_CLK		(2 << PMC_PCK2_CSS_SHIFT)
+
+
+/* --- PMC Interrupt Enable Register (PMC_IER) ----------------------------- */
+
+/* PLL Lock Interrupt Enable */
+#define PMC_IER_LOCK			PMC_IER_LOCKA
+
+
+/* --- PMC Interrupt Disable Register (PMC_IDR) ----------------------------- */
+
+/* PLL Lock Interrupt Disable */
+#define PMC_IDR_LOCK			PMC_IDR_LOCKA
+
+
+/* --- PMC Status Register (PMC_SR) ---------------------------------------- */
+
+/* PLL Lock Status */
+#define PMC_SR_LOCK			PMC_SR_LOCKA
+
+
+/* --- PMC Interrupt Mask Register (PMC_IMR) ----------------------------- */
+
+/* PLL Lock Interrupt Mask */
+#define PMC_IMR_LOCK			PMC_IMR_LOCKA
+
+
+/* --- PMC Oscillator Calibration Register (PMC_OCR) ----------------------- */
+
+/* Selection of RC Oscillator Calibration bits for 12 Mhz */
+#define PMC_OCR_SEL12			(0x01 << 23)
+
+/* RC Oscillator Calibration bits for 12 Mhz */
+#define PMC_OCR_CAL12_SHIFT		16
+#define PMC_OCR_CAL12_MASK		(0x7F << PMC_OCR_CAL12_SHIFT)
+
+/* Selection of RC Oscillator Calibration bits for 8 Mhz */
+#define PMC_OCR_SEL8			(0x01 << 15)
+
+/* RC Oscillator Calibration bits for 8 Mhz */
+#define PMC_OCR_CAL8_SHIFT		8
+#define PMC_OCR_CAL8_MASK		(0x7F << PMC_OCR_CAL8_SHIFT)
+
+/* Selection of RC Oscillator Calibration bits for 4 Mhz */
+#define PMC_OCR_SEL4			(0x01 << 7)
+
+/* RC Oscillator Calibration bits for 4 Mhz */
+#define PMC_OCR_CAL4_SHIFT		0
+#define PMC_OCR_CAL4_MASK		(0x7F << PMC_OCR_CAL12_SHIFT)
+
+
+#endif

--- a/include/libopencm3/sam/3s/gpio.h
+++ b/include/libopencm3/sam/3s/gpio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,12 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_GPIO_H
+#define LIBOPENCM3_GPIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/pio.h>
+#include <libopencm3/sam/common/gpio_common_3n3s.h>
+
+
 #endif

--- a/include/libopencm3/sam/3s/periph.h
+++ b/include/libopencm3/sam/3s/periph.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PERIPH_H
+#define LIBOPENCM3_PERIPH_H
+
+/* --- Peripheral Identifiers ---------------------------------------------- */
+#define PERIPH_SUPC		0
+#define PERIPH_RSTC		1
+#define PERIPH_RTC		2
+#define PERIPH_RTT		3
+#define PERIPH_WDG		4
+#define PERIPH_PMC		5
+#define PERIPH_EEFC		6
+#define PERIPH_UART0		8
+#define PERIPH_UART1		9
+#define PERIPH_SMC		10
+#define PERIPH_PIOA		11
+#define PERIPH_PIOB		12
+#define PERIPH_PIOC		13
+#define PERIPH_USART0		14
+#define PERIPH_USART1		15
+#define PERIPH_USART2		16
+#define PERIPH_HSMCI		18
+#define PERIPH_TWI0		19
+#define PERIPH_TWI1		20
+#define PERIPH_SPI		21
+#define PERIPH_SSC		22
+#define PERIPH_TC0		23
+#define PERIPH_TC1		24
+#define PERIPH_TC2		25
+#define PERIPH_TC3		26
+#define PERIPH_TC4		27
+#define PERIPH_TC5		28
+#define PERIPH_ADC		29
+#define PERIPH_DACC		30
+#define PERIPH_PWM		31
+#define PERIPH_CRCCU		32
+#define PERIPH_ACC		33
+#define PERIPH_UDP		34
+
+
+#endif

--- a/include/libopencm3/sam/3s/pio.h
+++ b/include/libopencm3/sam/3s/pio.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PIO_H
+#define LIBOPENCM3_PIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pio_common_3n3s.h>
+
+/* --- PIO registers ----------------------------------------------------- */
+
+/* Parallel Capture Mode Register */
+#define PIO_PCMR(port)			MMIO32((port) + 0x0150)
+
+/* Parallel Capture Interrupt Enable Register */
+#define PIO_PCIER(port)			MMIO32((port) + 0x0154)
+
+/* Parallel Capture Interrupt Disable Register */
+#define PIO_PCIDR(port)			MMIO32((port) + 0x0158)
+
+/* Parallel Capture Interrupt Mask Register */
+#define PIO_PCIMR(port)			MMIO32((port) + 0x015C)
+
+/* Parallel Capture Interrupt Status Register */
+#define PIO_PCISR(port)			MMIO32((port) + 0x0160)
+
+/* Parallel Capture Reception Holding Register */
+#define PIO_PCRHR(port)			MMIO32((port) + 0x0164)
+
+
+#endif

--- a/include/libopencm3/sam/3s/pmc.h
+++ b/include/libopencm3/sam/3s/pmc.h
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PMC_H
+#define LIBOPENCM3_PMC_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pmc_common_all.h>
+#include <libopencm3/sam/common/pmc_common_3a3s3x.h>
+
+/* --- Power Management Controller (PMC) registers ----------------------- */
+
+/* PLLB Register */
+#define CKGR_PLLBR			MMIO32(PMC_BASE + 0x002C)
+
+/* Oscillator Calibration Register */
+#define PMC_OCR				MMIO32(PMC_BASE + 0x0110)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC Clock Generator Main Clock Frequency Register (CKGR_MCFR) ------- */
+
+/* RC Oscillator Frequency Measure (write-only, only on atsam3s8) */
+#define CKGR_MCFR_RCMEAS		(0x01 << 20)
+
+
+/* --- PMC Clock Generator PLLB Register (CKGR_PLLBR) ---------------------- */
+
+/* PLLB Multiplier */
+#define CKGR_PLLBR_MULB_SHIFT		16
+#define CKGR_PLLBR_MULB_MASK		(0x7FF << CKGR_PLLBR_MULB_SHIFT)
+
+/* PLLA Counter */
+#define CKGR_PLLBR_PLLBCOUNT_SHIFT	8
+#define CKGR_PLLBR_PLLBCOUNT_MASK	(0x3F << CKGR_PLLBR_PLLBCOUNT_SHIFT)
+
+/* Divider */
+#define CKGR_PLLBR_DIVB_SHIFT		0
+#define CKGR_PLLBR_DIVB_MASK		(0xFF << CKGR_PLLBR_DIVB_SHIFT)
+
+
+/* --- PMC Master Clock Register (PMC_MCKR) -------------------------------- */
+
+/* PLLB Divide by 2 */
+#define PMC_MCKR_PLLBDIV2		(0x01 << 13)
+
+/* PLLA Divide by 2 */
+#define PMC_MCKR_PLLADIV2		(0x01 << 12)
+
+/* Master Clock Source Selection */
+#define PMC_MCKR_CSS_PLLB_CLK		(3 << PMC_MCKR_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 0 (PMC_PCK0) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK0_CSS_PLLB_CLK		(3 << PMC_PCK0_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 1 (PMC_PCK1) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK1_CSS_PLLB_CLK		(3 << PMC_PCK1_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 2 (PMC_PCK2) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK2_CSS_PLLB_CLK		(3 << PMC_PCK2_CSS_SHIFT)
+
+
+/* --- PMC Interrupt Enable Register (PMC_IER) ----------------------------- */
+
+/* PLLB Lock Interrupt Enable */
+#define PMC_IER_LOCKB			(0x01 << 2)
+
+
+/* --- PMC Interrupt Disable Register (PMC_IDR) ---------------------------- */
+
+/* PLLB Lock Interrupt Disable */
+#define PMC_IDR_LOCKB			(0x01 << 2)
+
+
+/* --- PMC Status Register (PMC_SR) ---------------------------------------- */
+
+/* PLLB Lock Status */
+#define PMC_SR_LOCKB			(0x01 << 2)
+
+
+/* --- PMC Interrupt Mask Register (PMC_IDR) ------------------------------- */
+
+/* PLLB Lock Interrupt Mask */
+#define PMC_IMR_LOCKB			(0x01 << 2)
+
+
+/* --- PMC Oscillator Calibration Register (PMC_OCR) ----------------------- */
+
+/* Selection of RC Oscillator Calibration bits for 12 Mhz */
+#define PMC_OCR_SEL12			(0x01 << 23)
+
+/* RC Oscillator Calibration bits for 12 Mhz */
+#define PMC_OCR_CAL12_SHIFT		16
+#define PMC_OCR_CAL12_MASK		(0x7F << PMC_OCR_CAL12_SHIFT)
+
+/* Selection of RC Oscillator Calibration bits for 8 Mhz */
+#define PMC_OCR_SEL8			(0x01 << 15)
+
+/* RC Oscillator Calibration bits for 8 Mhz */
+#define PMC_OCR_CAL8_SHIFT		8
+#define PMC_OCR_CAL8_MASK		(0x7F << PMC_OCR_CAL8_SHIFT)
+
+/* Selection of RC Oscillator Calibration bits for 4 Mhz */
+#define PMC_OCR_SEL4			(0x01 << 7)
+
+/* RC Oscillator Calibration bits for 4 Mhz */
+#define PMC_OCR_CAL4_SHIFT		0
+#define PMC_OCR_CAL4_MASK		(0x7F << PMC_OCR_CAL12_SHIFT)
+
+
+#endif

--- a/include/libopencm3/sam/3s/smc.h
+++ b/include/libopencm3/sam/3s/smc.h
@@ -1,0 +1,200 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_SMC_H
+#define LIBOPENCM3_SMC_H
+
+#include <libopencm3/sam/memorymap.h>
+
+
+/* Chip Select Defines */
+#define SMC_CS_0			0
+#define SMC_CS_1			1
+#define SMC_CS_2			2
+#define SMC_CS_3			3
+
+
+/* --- Static Memory Controller (SMC) registers ---------------------------- */
+
+/* Setup Register */
+#define SMC_SETUP(CS_number)		MMIO32(SMC_BASE + 0x10*(CS_number) + 0x00)
+
+/* Pulse Register */
+#define SMC_PULSE(CS_number)		MMIO32(SMC_BASE + 0x10*(CS_number) + 0x04)
+
+/* Cycle Register */
+#define SMC_CYCLE(CS_number)		MMIO32(SMC_BASE + 0x10*(CS_number) + 0x08)
+
+/* Mode Register */
+#define SMC_MODE(CS_number)		MMIO32(SMC_BASE + 0x10*(CS_number) + 0x0C)
+
+/* Off Chip Memory Scrambling Mode Register */
+#define SMC_OCMS			MMIO32(SMC_BASE + 0x80)
+
+/* Off Chip Memory Scrambling KEY1 Register */
+#define SMC_KEY1			MMIO32(SMC_BASE + 0x84)
+
+/* Off Chip Memory Scrambling KEY2 Register */
+#define SMC_KEY2			MMIO32(SMC_BASE + 0x88)
+
+/* Write Protect Mode Register */
+#define SMC_WPMR			MMIO32(SMC_BASE + 0xE4)
+
+/* Write Protect Status Register */
+#define SMC_WPSR			MMIO32(SMC_BASE + 0xE8)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- SMC Setup Register (SMC_SETUPx) ------------------------------------- */
+
+/* NCS Setup length in Read access */
+#define SMC_SETUP_NCS_RD_SETUP_SHIFT	24
+#define SMC_SETUP_NCS_RD_SETUP_MASK	(0x3F << SMC_SETUP_NCS_RD_SETUP_SHIFT)
+
+/* NRD Setup length */
+#define SMC_SETUP_NRD_SETUP_SHIFT	16
+#define SMC_SETUP_NRD_SETUP_MASK	(0x3F << SMC_SETUP_NRD_SETUP_SHIFT)
+
+/* NCS Setup length in Write access */
+#define SMC_SETUP_NCS_WR_SETUP_SHIFT	8
+#define SMC_SETUP_NCS_WR_SETUP_MASK	(0x3F << SMC_SETUP_NCS_WR_SETUP_SHIFT)
+
+/* NWE Setup Length */
+#define SMC_SETUP_NWE_SETUP_SHIFT	0
+#define SMC_SETUP_NWE_SETUP_MASK	(0x3F << SMC_SETUP_NWE_SETUP_SHIFT)
+
+
+/* --- SMC Pulse Register (SMC_PULSEx) ------------------------------------- */
+
+/* NCS Pulse Length in READ Access */
+#define SMC_PULSE_NCS_RD_PULSE_SHIFT	24
+#define SMC_PULSE_NCS_RD_PULSE_MASK	(0x7F << SMC_PULSE_NCS_RD_PULSE_SHIFT)
+
+/* NRD Pulse Length */
+#define SMC_PULSE_NRD_PULSE_SHIFT	16
+#define SMC_PULSE_NRD_PULSE_MASK	(0x7F << SMC_PULSE_NRD_PULSE_SHIFT)
+
+/* NCS Pulse Length in WRITE Access */
+#define SMC_PULSE_NCS_WR_PULSE_SHIFT	8
+#define SMC_PULSE_NCS_WR_PULSE_MASK	(0x7F << SMC_PULSE_NCS_WR_PULSE_SHIFT)
+
+/* NWE Pulse Length */
+#define SMC_PULSE_NWE_PULSE_SHIFT	0
+#define SMC_PULSE_NWE_PULSE_MASK	(0x7F << SMC_PULSE_NWE_PULSE_SHIFT)
+
+
+/* --- SMC Cycle Register (SMC_CYCLEx) ------------------------------------- */
+
+/* Total Read Cycle Length */
+#define SMC_CYCLE_NRD_CYCLE_SHIFT	16
+#define SMC_CYCLE_NRD_CYCLE_MASK	(0x1FF << SMC_CYCLE_NRD_CYCLE_SHIFT)
+
+/* Total Write Cycle Length */
+#define SMC_CYCLE_NWE_CYCLE_SHIFT	0
+#define SMC_CYCLE_NWE_CYCLE_MASK	(0x1FF << SMC_CYCLE_NWE_CYCLE_SHIFT)
+
+
+/* --- SMC MODE Register (SMC_MODEx) --------------------------------------- */
+
+/* Page Size */
+#define SMC_MODE_PS_SHIFT		28
+#define SMC_MODE_PS_MASK		(0x03 << SMC_MODE_PS_SHIFT)
+
+/* Page Size Values */
+#define SMC_MODE_PS_4_BYTE		(0x00 << SMC_MODE_PS_SHIFT)
+#define SMC_MODE_PS_8_BYTE		(0x01 << SMC_MODE_PS_SHIFT)
+#define SMC_MODE_PS_16_BYTE		(0x02 << SMC_MODE_PS_SHIFT)
+#define SMC_MODE_PS_32_BYTE		(0x03 << SMC_MODE_PS_SHIFT)
+
+/* Page Mode Enabled */
+#define SMC_MODE_PMEN			(1 << 24)
+
+/* TDF Optimization */
+#define SMC_MODE_TDF_MODE		(1 << 20)
+
+/* Data Float Time */
+#define SMC_MODE_TDF_CYCLES_SHIFT	16
+#define SMC_MODE_TDF_CYCLES_MASK	(0x0F << SMC_MODE_TDF_CYCLES_SHIFT)
+
+/* Data Bus Width */
+#define SMC_MODE_DBW_SHIFT		12
+#define SMC_MODE_DBW_MASK		(0x03 << SMC_MODE_DBW_SHIFT)
+
+/* Data Bus Width Values */
+#define SMC_MODE_DBW_8_BIT		(0x00 << SMC_MODE_DBW_SHIFT)
+#define SMC_MODE_DBW_16_BIT		(0x01 << SMC_MODE_DBW_SHIFT)
+#define SMC_MODE_DBW_32_BIT		(0x02 << SMC_MODE_DBW_SHIFT)
+
+/* NWAIT Mode */
+#define SMC_MODE_EXNW_MODE_SHIFT	4
+#define SMC_MODE_EXNW_MODE_MASK		(0x03 << SMC_MODE_EXNW_MODE_SHIFT)
+
+/* NWAIT Mode Values */
+#define SMC_MODE_EXNW_MODE_DISABLED	(0x00 << SMC_MODE_EXNW_MODE_SHIFT)
+#define SMC_MODE_EXNW_MODE_FROZEN	(0x02 << SMC_MODE_EXNW_MODE_SHIFT)
+#define SMC_MODE_EXNW_MODE_READY	(0x03 << SMC_MODE_EXNW_MODE_SHIFT)
+
+/* Write Mode */
+#define SMC_MODE_WRITE_MODE		(1 << 1)
+
+/* Read Mode */
+#define SMC_MODE_READ_MODE		(1 << 0)
+
+
+/* --- SMC OCMS Mode Register (SMC_OCMS) ----------------------------------- */
+
+/* Chip Select 3 Scrambling Enable */
+#define SMC_OCMS_CS3SE			(1 << 19)
+
+/* Chip Select 2 Scrambling Enable */
+#define SMC_OCMS_CS2SE			(1 << 18)
+
+/* Chip Select 1 Scrambling Enable */
+#define SMC_OCMS_CS1SE			(1 << 17)
+
+/* Chip Select 0 Scrambling Enable */
+#define SMC_OCMS_CS0SE			(1 << 16)
+
+/* Static Memory Controller Scrambling Enable */
+#define SMC_OCMS_SMSE			(1 << 0)
+
+
+/* --- SMC Write Protect Mode Register (SMC_WPMR) -------------------------- */
+
+/* Write Protect Key */
+#define SMC_WPMR_WPKEY_SHIFT		8
+#define SMC_WPMR_WPKEY_KEY		(0x534D43 << SMC_WPMR_WPKEY_SHIFT)
+
+/* Write Protect Enable */
+#define SMC_WPMR_WPEN			(1 << 0)
+
+
+/* --- SMC Write Protect Status Register (SMC_WPSR) ------------------------ */
+
+/* Write Protection Violation Source */
+#define SMC_WPSR_WP_VSRC_SHIFT		8
+#define SMC_WPSR_WP_VSRC_MASK		(0xFFFF << SMC_WPSR_WP_VSRC_SHIFT)
+
+/* Write Protect Enable */
+#define SMC_WPSR_WPVS			(1 << 0)
+
+
+#endif

--- a/include/libopencm3/sam/3u/gpio.h
+++ b/include/libopencm3/sam/3u/gpio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,12 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_GPIO_H
+#define LIBOPENCM3_GPIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/pio.h>
+#include <libopencm3/sam/common/gpio_common_3a3u3x.h>
+
+
 #endif

--- a/include/libopencm3/sam/3u/periph.h
+++ b/include/libopencm3/sam/3u/periph.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PERIPH_H
+#define LIBOPENCM3_PERIPH_H
+
+/* --- Peripheral Identifiers ---------------------------------------------- */
+#define PERIPH_SUPC		0
+#define PERIPH_RSTC		1
+#define PERIPH_RTC		2
+#define PERIPH_RTT		3
+#define PERIPH_WDG		4
+#define PERIPH_PMC		5
+#define PERIPH_EEFC0		6
+#define PERIPH_EEFC1		7
+#define PERIPH_UART		8
+#define PERIPH_SMC		9
+#define PERIPH_PIOA		10
+#define PERIPH_PIOB		11
+#define PERIPH_PIOC		12
+#define PERIPH_USART0		13
+#define PERIPH_USART1		14
+#define PERIPH_USART2		15
+#define PERIPH_USART3		16
+#define PERIPH_HSMCI		17
+#define PERIPH_TWI0		18
+#define PERIPH_TWI1		19
+#define PERIPH_SPI		20
+#define PERIPH_SSC		21
+#define PERIPH_TC0		22
+#define PERIPH_TC1		23
+#define PERIPH_TC2		24
+#define PERIPH_PWM		25
+#define PERIPH_ADC12B		26
+#define PERIPH_ADC		27
+#define PERIPH_DMAC		28
+#define PERIPH_UDPHS		29
+
+
+#endif

--- a/include/libopencm3/sam/3u/pio.h
+++ b/include/libopencm3/sam/3u/pio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,11 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_PIO_H
+#define LIBOPENCM3_PIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pio_common_3a3u3x.h>
+
+
 #endif

--- a/include/libopencm3/sam/3u/pmc.h
+++ b/include/libopencm3/sam/3u/pmc.h
@@ -1,7 +1,8 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,16 +18,21 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/pmc.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/pmc.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/pmc.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/pmc.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/pmc.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_PMC_H
+#define LIBOPENCM3_PMC_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pmc_common_all.h>
+#include <libopencm3/sam/common/pmc_common_3n3u.h>
+#include <libopencm3/sam/common/pmc_common_3a3u3x.h>
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC Clock Generator Main Oscillator Register (CKGR_MOR) ------------- */
+
+/* Wait Mode Command */
+#define CKGR_MOR_WAITMODE		(0x01 << 2)
+
+
 #endif

--- a/include/libopencm3/sam/3x/gpio.h
+++ b/include/libopencm3/sam/3x/gpio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,12 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_GPIO_H
+#define LIBOPENCM3_GPIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/pio.h>
+#include <libopencm3/sam/common/gpio_common_3a3u3x.h>
+
+
 #endif

--- a/include/libopencm3/sam/3x/pio.h
+++ b/include/libopencm3/sam/3x/pio.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -19,16 +17,11 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
-#else
-#       error "sam family not defined."
+#ifndef LIBOPENCM3_PIO_H
+#define LIBOPENCM3_PIO_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pio_common_3a3u3x.h>
+
+
 #endif

--- a/include/libopencm3/sam/3x/pmc.h
+++ b/include/libopencm3/sam/3x/pmc.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PMC_H
+#define LIBOPENCM3_PMC_H
+
+#include <libopencm3/sam/memorymap.h>
+#include <libopencm3/sam/common/pmc_common_all.h>
+#include <libopencm3/sam/common/pmc_common_3a3s3x.h>
+#include <libopencm3/sam/common/pmc_common_3a3u3x.h>
+
+/* --- Power Management Controller (PMC) registers ----------------------- */
+
+/* Peripheral Control Register */
+#define PMC_PCR				MMIO32(PMC_BASE + 0x010C)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC Master Clock Register (PMC_MCKR) -------------------------------- */
+
+/* PLLA Divide by 2 */
+#define PMC_MCKR_PLLADIV2		(0x01 << 12)
+
+
+/* --- PMC Peripheral Control Register (PMC_PCR) --------------------------- */
+
+/* Enable */
+#define PMC_PCR_EN			(0x01 << 28)
+
+/* Divisor Value */
+#define PMC_PCR_DIV_SHIFT		16
+#define PMC_PCR_DIV_MASK		(0x03 << PMC_PCR_DIV_SHIFT)
+#define PMC_PCR_DIV_PERIPH_DIV_MCK	(0x00 << PMC_PCR_DIV_SHIFT)
+#define PMC_PCR_DIV_PERIPH_DIV2_MCK	(0x01 << PMC_PCR_DIV_SHIFT)
+#define PMC_PCR_DIV_PERIPH_DIV4_MCK	(0x02 << PMC_PCR_DIV_SHIFT)
+
+/* Command */
+#define PMC_PCR_CMD			(0x01 << 12)
+
+/* Peripheral ID */
+#define PMC_PCR_PID_SHIFT		0
+#define PMC_PCR_PID_MASK		(0x3F << PMC_PCR_PID_SHIFT)
+
+
+#endif

--- a/include/libopencm3/sam/common/gpio_common_3a3u3x.h
+++ b/include/libopencm3/sam/common/gpio_common_3a3u3x.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Gareth McMullin <gareth@blacksphere.co.nz>
+ * COpyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA GPIO.H
+The order of header inclusion is important. gpio.h includes the device
+specific memorymap.h header before including this header file.*/
+
+#if defined(LIBOPENCM3_GPIO_H)
+
+#ifndef LIBOPENCM3_GPIO_COMMON_3A3U3X_H
+#define LIBOPENCM3_GPIO_COMMON_3A3U3X_H
+
+#include <libopencm3/sam/common/gpio_common_all.h>
+
+
+/* flags may be or'd together, but only contain one of
+ * GPOUTPUT, PERIPHA and PERIPHB */
+enum gpio_flags {
+	GPIO_FLAG_GPINPUT = 0,
+	GPIO_FLAG_GPOUTPUT = 1,
+	GPIO_FLAG_PERIPHA = 2,
+	GPIO_FLAG_PERIPHB = 3,
+	GPIO_FLAG_OPEN_DRAIN = (1 << 3),
+	GPIO_FLAG_PULL_UP = (1 << 4),
+};
+
+
+void gpio_init(uint32_t gpioport, uint32_t pins, enum gpio_flags flags);
+
+
+#endif
+
+#else
+#warning "gpio_common_3a3u3x.h should not be included explicitly, only via gpio.h"
+#endif

--- a/include/libopencm3/sam/common/gpio_common_3n3s.h
+++ b/include/libopencm3/sam/common/gpio_common_3n3s.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA GPIO.H
+The order of header inclusion is important. gpio.h includes the device
+specific memorymap.h header before including this header file.*/
+
+#if defined(LIBOPENCM3_GPIO_H)
+
+#ifndef LIBOPENCM3_GPIO_COMMON_3N3S_H
+#define LIBOPENCM3_GPIO_COMMON_3N3S_H
+
+#include <libopencm3/sam/common/gpio_common_all.h>
+
+
+/* flags may be or'd together, but only contain one of
+ * GPOUTPUT, PERIPHA, PERIPHB, PERIPHC and PERIPHD */
+enum gpio_flags {
+	GPIO_FLAG_GPINPUT = 0,
+	GPIO_FLAG_GPOUTPUT = 1,
+	GPIO_FLAG_PERIPHA = 2,
+	GPIO_FLAG_PERIPHB = 3,
+	GPIO_FLAG_PERIPHC = 4,
+	GPIO_FLAG_PERIPHD = 5,
+	GPIO_FLAG_OPEN_DRAIN = (1 << 3),
+	GPIO_FLAG_PULL_UP = (1 << 4),
+};
+
+
+void gpio_init(uint32_t gpioport, uint32_t pins, enum gpio_flags flags);
+
+
+#endif
+
+#else
+#warning "gpio_common_3n3s.h should not be included explicitly, only via gpio.h"
+#endif

--- a/include/libopencm3/sam/common/gpio_common_all.h
+++ b/include/libopencm3/sam/common/gpio_common_all.h
@@ -1,8 +1,7 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
+ * Copyright (C) 2013 Gareth McMullin <gareth@blacksphere.co.nz>
  * Copyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
  *
  * This library is free software: you can redistribute it and/or modify
@@ -19,16 +18,24 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/gpio.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/gpio.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/gpio.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/gpio.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/gpio.h>
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA GPIO.H
+The order of header inclusion is important. gpio.h includes the device
+specific memorymap.h header before including this header file.*/
+
+#if defined(LIBOPENCM3_GPIO_H)
+
+#ifndef LIBOPENCM3_GPIO_COMMON_ALL_H
+#define LIBOPENCM3_GPIO_COMMON_ALL_H
+
+#include <libopencm3/cm3/common.h>
+
+void gpio_set(uint32_t gpioport, uint32_t gpios);
+void gpio_clear(uint32_t gpioport, uint32_t gpios);
+void gpio_toggle(uint32_t gpioport, uint32_t gpios);
+
+
+#endif
+
 #else
-#       error "sam family not defined."
+#warning "gpio_common_all.h should not be included explicitly, only via gpio.h"
 #endif

--- a/include/libopencm3/sam/common/periph_common_3a3x.h
+++ b/include/libopencm3/sam/common/periph_common_3a3x.h
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PERIPH_H
+#define LIBOPENCM3_PERIPH_H
+
+/* --- Peripheral Identifiers ---------------------------------------------- */
+#define PERIPH_SUPC		0
+#define PERIPH_RSTC		1
+#define PERIPH_RTC		2
+#define PERIPH_RTT		3
+#define PERIPH_WDG		4
+#define PERIPH_PMC		5
+#define PERIPH_EEFC0		6
+#define PERIPH_EEFC1		7
+#define PERIPH_UART		8
+#define PERIPH_SMC_SDRAMC	9
+#define PERIPH_SDRAMC		10
+#define PERIPH_PIOA		11
+#define PERIPH_PIOB		12
+#define PERIPH_PIOC		13
+#define PERIPH_PIOD		14
+#define PERIPH_PIOE		15
+#define PERIPH_PIOF		16
+#define PERIPH_USART0		17
+#define PERIPH_USART1		18
+#define PERIPH_USART2		19
+#define PERIPH_USART3		20
+#define PERIPH_HSMCI		21
+#define PERIPH_TWI0		22
+#define PERIPH_TWI1		23
+#define PERIPH_SPI0		24
+#define PERIPH_SPI1		25
+#define PERIPH_SSC		26
+#define PERIPH_TC0		27
+#define PERIPH_TC1		28
+#define PERIPH_TC2		29
+#define PERIPH_TC3		30
+#define PERIPH_TC4		31
+#define PERIPH_TC5		32
+#define PERIPH_TC6		33
+#define PERIPH_TC7		34
+#define PERIPH_TC8		35
+#define PERIPH_PWM		36
+#define PERIPH_ADC		37
+#define PERIPH_DACC		38
+#define PERIPH_DMAC		39
+#define PERIPH_UOTGHS		40
+#define PERIPH_TRNG		41
+#define PERIPH_EMAC		42
+#define PERIPH_CAN0		43
+#define PERIPH_CAN1		44
+
+
+#endif

--- a/include/libopencm3/sam/common/pio_common_3a3u3x.h
+++ b/include/libopencm3/sam/common/pio_common_3a3u3x.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * COpyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA PIO.H
+The order of header inclusion is important. pio.h includes the device
+specific memorymap.h header before including this header file.*/
+
+#if defined(LIBOPENCM3_PIO_H)
+
+#ifndef LIBOPENCM3_PIO_COMMON_3A3U3X_H
+#define LIBOPENCM3_PIO_COMMON_3A3U3X_H
+
+#include <libopencm3/sam/common/pio_common_all.h>
+
+/* --- PIO registers ----------------------------------------------------- */
+
+/* Peripheral AB Select Register */
+#define PIO_ABSR(port)			MMIO32((port) + 0x0070)
+
+/* System Clock Glitch Input Filter Select Register */
+#define PIO_SCIFSR(port)		MMIO32((port) + 0x0080)
+
+/* Debouncing Input Filter Select Register */
+#define PIO_DIFSR(port)			MMIO32((port) + 0x0084)
+
+/* Glitch or Debouncing Input Filter Clock Selection Status Register */
+#define PIO_IFDGSR(port)		MMIO32((port) + 0x0088)
+
+
+#endif
+
+#else
+#warning "pio_common_3a3u3x.h should not be included explicitly, only via pio.h"
+#endif

--- a/include/libopencm3/sam/common/pio_common_3n3s.h
+++ b/include/libopencm3/sam/common/pio_common_3n3s.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * COpyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA PIO.H
+The order of header inclusion is important. pio.h includes the device
+specific memorymap.h header before including this header file.*/
+
+#if defined(LIBOPENCM3_PIO_H)
+
+#ifndef LIBOPENCM3_PIO_COMMON_3N3S_H
+#define LIBOPENCM3_PIO_COMMON_3N3S_H
+
+#include <libopencm3/sam/common/pio_common_all.h>
+
+/* --- PIO registers ----------------------------------------------------- */
+
+/* Peripheral Select Register 1 */
+#define PIO_ABCDSR1(port)		MMIO32((port) + 0x0070)
+
+/* Peripheral Select Register 2 */
+#define PIO_ABCDSR2(port)		MMIO32((port) + 0x0074)
+
+/* Input Filter Slow Clock Disable Register */
+#define PIO_IFSCDR(port)		MMIO32((port) + 0x0080)
+
+/* Input Filter Slow Clock Enable Register */
+#define PIO_IFSCER(port)		MMIO32((port) + 0x0084)
+
+/* Input Filter Slow Clock Status Register */
+#define PIO_IFSCSR(port)		MMIO32((port) + 0x0088)
+
+/* Pad Pull-down Disable Register */
+#define PIO_PPDDR(port)			MMIO32((port) + 0x0090)
+
+/* Pad Pull-down Enable Register */
+#define PIO_PPDER(port)			MMIO32((port) + 0x0094)
+
+/* Pad Pull-down Status Register */
+#define PIO_PPDSR(port)			MMIO32((port) + 0x0098)
+
+/* Schmitt Trigger Register */
+#define PIO_SCHMITT(port)		MMIO32((port) + 0x0100)
+
+
+#endif
+
+#else
+#warning "pio_common_3n3s.h should not be included explicitly, only via pio.h"
+#endif

--- a/include/libopencm3/sam/common/pio_common_all.h
+++ b/include/libopencm3/sam/common/pio_common_all.h
@@ -1,0 +1,168 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA PIO.H
+The order of header inclusion is important. pio.h includes the device
+specific memorymap.h header before including this header file.*/
+
+#if defined(LIBOPENCM3_PIO_H)
+
+#ifndef LIBOPENCM3_PIO_COMMON_ALL_H
+#define LIBOPENCM3_PIO_COMMON_ALL_H
+
+#include <libopencm3/cm3/common.h>
+
+/* --- Convenience macros ------------------------------------------------ */
+
+/* GPIO port base addresses (for convenience) */
+#define PIOA				PIOA_BASE
+#define PIOB				PIOB_BASE
+#define PIOC				PIOC_BASE
+#define PIOD				PIOD_BASE
+#define PIOE				PIOE_BASE
+#define PIOF				PIOF_BASE
+#define PIOG				PIOG_BASE
+#define PIOH				PIOH_BASE
+
+/* --- PIO registers ----------------------------------------------------- */
+
+/* PIO Enable Register */
+#define PIO_PER(port)			MMIO32((port) + 0x0000)
+
+/* PIO Disable Register */
+#define PIO_PDR(port)			MMIO32((port) + 0x0004)
+
+/* PIO Status Register */
+#define PIO_PSR(port)			MMIO32((port) + 0x0008)
+
+/* Output Enable Register */
+#define PIO_OER(port)			MMIO32((port) + 0x0010)
+
+/* Output Disable Register */
+#define PIO_ODR(port)			MMIO32((port) + 0x0014)
+
+/* Output Status Register */
+#define PIO_OSR(port)			MMIO32((port) + 0x0018)
+
+/* Glitch Input Filter Enable Register */
+#define PIO_IFER(port)			MMIO32((port) + 0x0020)
+
+/* Glitch Input Filter Disable Register */
+#define PIO_IFDR(port)			MMIO32((port) + 0x0024)
+
+/* Glitch Input Filter Status Register */
+#define PIO_IFSR(port)			MMIO32((port) + 0x0028)
+
+/* Set Output Data Register */
+#define PIO_SODR(port)			MMIO32((port) + 0x0030)
+
+/* Clear Output Data Register */
+#define PIO_CODR(port)			MMIO32((port) + 0x0034)
+
+/* Output Data Status Register */
+#define PIO_ODSR(port)			MMIO32((port) + 0x0038)
+
+/* Pin Data Status Register */
+#define PIO_PDSR(port)			MMIO32((port) + 0x003C)
+
+/* Interrupt Enable Register */
+#define PIO_IER(port)			MMIO32((port) + 0x0040)
+
+/* Interrupt Disable Register */
+#define PIO_IDR(port)			MMIO32((port) + 0x0044)
+
+/* Interrupt Mask Register */
+#define PIO_IMR(port)			MMIO32((port) + 0x0048)
+
+/* Interrupt Status Register */
+#define PIO_ISR(port)			MMIO32((port) + 0x004C)
+
+/* Multi-driver Enable Register */
+#define PIO_MDER(port)			MMIO32((port) + 0x0050)
+
+/* Multi-driver Disable Register */
+#define PIO_MDDR(port)			MMIO32((port) + 0x0054)
+
+/* Multi-driver Status Register */
+#define PIO_MDSR(port)			MMIO32((port) + 0x0058)
+
+/* Pull-up Disable Register */
+#define PIO_PUDR(port)			MMIO32((port) + 0x0060)
+
+/* Pull-up Enable Register */
+#define PIO_PUER(port)			MMIO32((port) + 0x0064)
+
+/* Pad Pull-up Status Register */
+#define PIO_PUSR(port)			MMIO32((port) + 0x0068)
+
+/* Slow Clock Divider Debouncing Register */
+#define PIO_SCDR(port)			MMIO32((port) + 0x008C)
+
+/* Output Write Enable */
+#define PIO_OWER(port)			MMIO32((port) + 0x00A0)
+
+/* Output Write Disable */
+#define PIO_OWDR(port)			MMIO32((port) + 0x00A4)
+
+/* Output Write Status Register */
+#define PIO_OWSR(port)			MMIO32((port) + 0x00A8)
+
+/* Additional Interrupt Modes Enable Register */
+#define PIO_AIMER(port)			MMIO32((port) + 0x00B0)
+
+/* Additional Interrupt Modes Disables Register */
+#define PIO_AIMDR(port)			MMIO32((port) + 0x00B4)
+
+/* Additional Interrupt Modes Mask Register */
+#define PIO_AIMMR(port)			MMIO32((port) + 0x00B8)
+
+/* Edge Select Register */
+#define PIO_ESR(port)			MMIO32((port) + 0x00C0)
+
+/* Level Select Register */
+#define PIO_LSR(port)			MMIO32((port) + 0x00C4)
+
+/* Edge/Level Status Register */
+#define PIO_ELSR(port)			MMIO32((port) + 0x00C8)
+
+/* Falling Edge/Low Level Select Register */
+#define PIO_FELLSR(port)		MMIO32((port) + 0x00D0)
+
+/* Rising Edge/High Level Select Register */
+#define PIO_REHLSR(port)		MMIO32((port) + 0x00D4)
+
+/* Fall/Rise - Low/High Status Register */
+#define PIO_FRLHSR(port)		MMIO32((port) + 0x00D8)
+
+/* Lock Status */
+#define PIO_LOCKSR(port)		MMIO32((port) + 0x00E0)
+
+/* Write Protect Mode Register */
+#define PIO_WPMR(port)			MMIO32((port) + 0x00E4)
+
+/* Write Protect Status Register */
+#define PIO_WPSR(port)			MMIO32((port) + 0x00E8)
+
+
+#endif
+
+#else
+#warning "pio_common_all.h should not be included explicitly, only via pio.h"
+#endif

--- a/include/libopencm3/sam/common/pmc_common_3a3s3x.h
+++ b/include/libopencm3/sam/common/pmc_common_3a3s3x.h
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if defined(LIBOPENCM3_PMC_H)
+
+#ifndef LIBOPENCM3_PMC_COMMON_3A3S3X_H
+#define LIBOPENCM3_PMC_COMMON_3A3S3X_H
+
+
+/* --- Power Management Controller (PMC) registers ----------------------- */
+
+/* Peripheral Clock Enable Register 0 */
+#define PMC_PCER0			MMIO32(PMC_BASE + 0x0010)
+
+/* Peripheral Clock Disable Register 0 */
+#define PMC_PCDR0			MMIO32(PMC_BASE + 0x0014)
+
+/* Peripheral Clock Status Register 0 */
+#define PMC_PCSR0			MMIO32(PMC_BASE + 0x0018)
+
+/* USB Clock Register */
+#define PMC_USB				MMIO32(PMC_BASE + 0x0038)
+
+/* Peripheral Clock Enable Register 1 */
+#define PMC_PCER1			MMIO32(PMC_BASE + 0x0100)
+
+/* Peripheral Clock Disable Register 1 */
+#define PMC_PCDR1			MMIO32(PMC_BASE + 0x0104)
+
+/* Peripheral Clock Status Register 1 */
+#define PMC_PCSR1			MMIO32(PMC_BASE + 0x0108)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC USB Clock Register (PMC_USB) ------------------------------------ */
+
+/* Divider for USB Clock */
+#define PMC_USB_USBDIV_SHIFT		8
+#define PMC_USB_USBDIV_MASK		(0x0F << PMC_USB_USBDIV_SHIFT)
+
+/* USB Input Clock Selection */
+#define PMC_USB_USBS			(0x01 << 0)
+
+
+#endif
+
+#else
+#warning "pmc_common_3a3s3x.h should not be included explicitly, only via pmc.h"
+#endif

--- a/include/libopencm3/sam/common/pmc_common_3a3u3x.h
+++ b/include/libopencm3/sam/common/pmc_common_3a3u3x.h
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if defined(LIBOPENCM3_PMC_H)
+
+#ifndef LIBOPENCM3_PMC_COMMON_3A3U3X_H
+#define LIBOPENCM3_PMC_COMMON_3A3U3X_H
+
+
+/* --- Power Management Controller (PMC) registers ----------------------- */
+
+/* UTMI Clock Register */
+#define CKGR_UCKR			MMIO32(PMC_BASE + 0x001C)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC UTMI Clock Configuration Register (CKGR_UCKR) ------------------- */
+
+/* UTMI PLL Start-up Time */
+#define CKGR_UCKR_UPLLCOUNT_SHIFT	20
+#define CKGR_UCKR_UPLLCOUNT_MASK	(0x0F << CKGR_UCKR_UPLLCOUNT_SHIFT)
+
+/* UTMI PLL Enable */
+#define CKGR_UCKR_UPLLEN		(0x01 << 16)
+
+/* --- PMC Master Clock Register (PMC_MCKR) -------------------------------- */
+
+/* UPLL Divide by 2 */
+#define PMC_MCKR_UPLLDIV2		(0x01 << 13)
+
+/* Master Clock Source Selection */
+#define PMC_MCKR_CSS_UPLL_CLK		(3 << PMC_MCKR_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 0 (PMC_PCK0) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK0_CSS_UPLL_CLK		(3 << PMC_PCK0_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 1 (PMC_PCK1) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK1_CSS_UPLL_CLK		(3 << PMC_PCK1_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 2 (PMC_PCK2) ------------------------ */
+
+/* Master Clock Source Selection */
+#define PMC_PCK2_CSS_UPLL_CLK		(3 << PMC_PCK2_CSS_SHIFT)
+
+
+/* --- PMC Interrupt Enable Register (PMC_IER) ----------------------------- */
+
+/* UTMI PLL Lock Interrupt Enable */
+#define PMC_IER_LOCKU			(0x01 << 6)
+
+
+/* --- PMC Interrupt Disable Register (PMC_IDR) ----------------------------- */
+
+/* UTMI PLL Lock Interrupt Disable */
+#define PMC_IDR_LOCKU			(0x01 << 6)
+
+
+/* --- PMC Status Register (PMC_SR) ---------------------------------------- */
+
+/* UTMI PLL Lock Status */
+#define PMC_SR_LOCKU			(0x01 << 6)
+
+
+/* --- PMC Interrupt Mask Register (PMC_IMR) ----------------------------- */
+
+/* UTMI PLL Lock Interrupt Mask */
+#define PMC_IMR_LOCKU			(0x01 << 6)
+
+
+#endif
+
+#else
+#warning "pmc_common_3a3u3x.h should not be included explicitly, only via pmc.h"
+#endif

--- a/include/libopencm3/sam/common/pmc_common_3n3u.h
+++ b/include/libopencm3/sam/common/pmc_common_3n3u.h
@@ -1,7 +1,7 @@
-/* This provides unification of code over SAM subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,16 +17,23 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(SAM3A)
-#       include <libopencm3/sam/3a/pmc.h>
-#elif defined(SAM3N)
-#       include <libopencm3/sam/3n/pmc.h>
-#elif defined(SAM3S)
-#       include <libopencm3/sam/3s/pmc.h>
-#elif defined(SAM3U)
-#       include <libopencm3/sam/3u/pmc.h>
-#elif defined(SAM3X)
-#       include <libopencm3/sam/3x/pmc.h>
+#if defined(LIBOPENCM3_PMC_H)
+
+#ifndef LIBOPENCM3_PMC_COMMON_3N3U_H
+#define LIBOPENCM3_PMC_COMMON_3N3U_H
+
+/* Peripheral Clock Enable Register */
+#define PMC_PCER			MMIO32(PMC_BASE + 0x0010)
+
+/* Peripheral Clock Disable Register */
+#define PMC_PCDR			MMIO32(PMC_BASE + 0x0014)
+
+/* Peripheral Clock Status Register */
+#define PMC_PCSR			MMIO32(PMC_BASE + 0x0018)
+
+
+#endif
+
 #else
-#       error "sam family not defined."
+#warning "pmc_common_3n3u.h should not be included explicitly, only via pmc.h"
 #endif

--- a/include/libopencm3/sam/common/pmc_common_all.h
+++ b/include/libopencm3/sam/common/pmc_common_all.h
@@ -1,0 +1,501 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if defined(LIBOPENCM3_PMC_H)
+
+#ifndef LIBOPENCM3_PMC_COMMON_ALL_H
+#define LIBOPENCM3_PMC_COMMON_ALL_H
+
+#include <libopencm3/cm3/common.h>
+
+/* --- Power Management Controller (PMC) registers ----------------------- */
+
+/* System Clock Enable Register */
+#define PMC_SCER			MMIO32(PMC_BASE + 0x0000)
+
+/* System Clock Disable Register */
+#define PMC_SCDR			MMIO32(PMC_BASE + 0x0004)
+
+/* System Clock Status Register */
+#define PMC_SCSR			MMIO32(PMC_BASE + 0x0008)
+
+/* Main Oscillator Register */
+#define CKGR_MOR			MMIO32(PMC_BASE + 0x0020)
+
+/* Main Clock Frequency Register */
+#define CKGR_MCFR			MMIO32(PMC_BASE + 0x0024)
+
+/* PLLA Register */
+#define CKGR_PLLAR			MMIO32(PMC_BASE + 0x0028)
+
+/* Master Clock Register */
+#define PMC_MCKR			MMIO32(PMC_BASE + 0x0030)
+
+/* Programmable Clock 0 Register */
+#define PMC_PCK0			MMIO32(PMC_BASE + 0x0040)
+
+/* Programmable Clock 1 Register */
+#define PMC_PCK1			MMIO32(PMC_BASE + 0x0044)
+
+/* Programmable Clock 2 Register */
+#define PMC_PCK2			MMIO32(PMC_BASE + 0x0048)
+
+/* Interrupt Enable Register */
+#define PMC_IER				MMIO32(PMC_BASE + 0x0060)
+
+/* Interrupt Disable Register */
+#define PMC_IDR				MMIO32(PMC_BASE + 0x0064)
+
+/* Status Register */
+#define PMC_SR				MMIO32(PMC_BASE + 0x0068)
+
+/* Interrupt Mask Register */
+#define PMC_IMR				MMIO32(PMC_BASE + 0x006C)
+
+/* Fast Startup Mode Register */
+#define PMC_FSMR			MMIO32(PMC_BASE + 0x0070)
+
+/* Fast Startup Polarity Register */
+#define PMC_FSPR			MMIO32(PMC_BASE + 0x0074)
+
+/* Fault Output Clear Register */
+#define PMC_FOCR			MMIO32(PMC_BASE + 0x0078)
+
+/* Write Protect Mode Register */
+#define PMC_WPMR			MMIO32(PMC_BASE + 0x00E4)
+
+/* Write Protect Status Register */
+#define PMC_WPSR			MMIO32(PMC_BASE + 0x00E8)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- PMC System Clock Enable Register (PMC_SCER) ------------------------- */
+
+/* Programmable Clock Output Enable */
+#define PMC_SCER_PCK0			(0x01 << 8)
+#define PMC_SCER_PCK1			(0x01 << 9)
+#define PMC_SCER_PCK2			(0x01 << 10)
+
+
+/* --- PMC System Clock Disable Register (PMC_SCDR) ------------------------ */
+
+/* Programmable Clock Output Disable */
+#define PMC_SCDR_PCK0			(0x01 << 8)
+#define PMC_SCDR_PCK1			(0x01 << 9)
+#define PMC_SCDR_PCK2			(0x01 << 10)
+
+
+/* --- PMC System Clock Status Register (PMC_SCSR) ------------------------- */
+
+/* Programmable Clock Output Status */
+#define PMC_SCSR_PCK0			(0x01 << 8)
+#define PMC_SCSR_PCK1			(0x01 << 9)
+#define PMC_SCSR_PCK2			(0x01 << 10)
+
+
+/* for bit definitions for PMC System Clock Enable/Disable/Status Register see
+ * periph.h */
+
+
+/* --- PMC Clock Generator Main Oscillator Register (CKGR_MOR) ------------- */
+
+/* Clock Failure Detector Enable */
+#define CKGR_MOR_CFDEN			(0x01 << 25)
+
+/* Main Oscillator Selection */
+#define CKGR_MOR_MOSCSEL		(0x01 << 24)
+
+/* Password for changing settings */
+#define CKGR_MOR_KEY			(0x37 << 16)
+
+/* Main Crystal Oscillator Start-up Time */
+#define CKGR_MOR_MOSCXTST_SHIFT		8
+#define CKGR_MOR_MOSCXTST_MASK		(0xFF << 8)
+
+/* Main On-Chip RC Oscillator Frequency Selection */
+#define CKGR_MOR_MOSCRCF_SHIFT		4
+#define CKGR_MOR_MOSCRCF_MASK		(0x07 << CKGR_MOR_MOSCRCF_SHIFT)
+
+/* Main On-Chip RC Oscillator selectable frequencies */
+#define CKGR_MOR_MOSCRCF_4MHZ		(0 << CKGR_MOR_MOSCRCF_SHIFT)
+#define CKGR_MOR_MOSCRCF_8MHZ		(1 << CKGR_MOR_MOSCRCF_SHIFT)
+#define CKGR_MOR_MOSCRCF_12MHZ		(2 << CKGR_MOR_MOSCRCF_SHIFT)
+
+/* Main On-Chip RC Oscillator Enable */
+#define CKGR_MOR_MOSCRCEN		(0x01 << 3)
+
+/* Main Crystal Oscillator Bypass */
+#define CKGR_MOR_MOSCXTBY		(0x01 << 1)
+
+/* Main Crystal Oscillator Enable */
+#define CKGR_MOR_MOSCXTEN		(0x01 << 0)
+
+
+/* --- PMC Clock Generator Main Clock Frequency Register (CKGR_MCFR) ------- */
+
+/* Main Clock Ready */
+#define CKGR_MCFR_MAINFRDY		(0x01 << 16)
+
+/* Main Clock Frequency */
+#define CKGR_MCFR_MAINF_SHIFT		0
+#define CKGR_MCFR_MAINF_MASK		(0xFFFF << CKGR_MCFR_MAINF_SHIFT)
+
+
+/* --- PMC Clock Generator PLLA Register (CKGR_PLLAR) ---------------------- */
+
+/* must be set to program CKGR_PLLAR */
+#define CKGR_PLLAR_ONE			(0x01 << 29)
+
+/* PLLA Multiplier */
+#define CKGR_PLLAR_MULA_SHIFT		16
+#define CKGR_PLLAR_MULA_MASK		(0x7FF << CKGR_PLLAR_MULA_SHIFT)
+
+/* PLLA Counter */
+#define CKGR_PLLAR_PLLACOUNT_SHIFT	8
+#define CKGR_PLLAR_PLLACOUNT_MASK	(0x3F << CKGR_PLLAR_PLLACOUNT_SHIFT)
+
+/* Divider */
+#define CKGR_PLLAR_DIVA_SHIFT		0
+#define CKGR_PLLAR_DIVA_MASK		(0xFF << CKGR_PLLAR_DIVA_SHIFT)
+
+
+/* --- PMC Master Clock Register (PMC_MCKR) -------------------------------- */
+
+/* Processor Clock Prescaler */
+#define PMC_MCKR_PRES_SHIFT		4
+#define PMC_MCKR_PRES_MASK		(0x07 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_1		(0 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_2		(1 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_4		(2 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_8		(3 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_16		(4 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_32		(5 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_64		(6 << PMC_MCKR_PRES_SHIFT)
+#define PMC_MCKR_PRES_CLK_3		(7 << PMC_MCKR_PRES_SHIFT)
+
+/* Master Clock Source Selection */
+#define PMC_MCKR_CSS_SHIFT		0
+#define PMC_MCKR_CSS_MASK		(0x03 << PMC_MCKR_CSS_SHIFT)
+#define PMC_MCKR_CSS_SLOW_CLK		(0 << PMC_MCKR_CSS_SHIFT)
+#define PMC_MCKR_CSS_MAIN_CLK		(1 << PMC_MCKR_CSS_SHIFT)
+#define PMC_MCKR_CSS_PLLA_CLK		(2 << PMC_MCKR_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 0 (PMC_PCK0) ------------------------ */
+
+/* Programmable Clock Prescaler */
+#define PMC_PCK0_PRES_SHIFT		4
+#define PMC_PCK0_PRES_MASK		(0x07 << PMC_PCK0_PRES_SHIFT)
+#define PMC_PCK0_PRES_CLK_1		(0 << PMC_PCK0_PRES_SHIFT)
+#define PMC_PCK0_PRES_CLK_2		(1 << PMC_PCK0_PRES_SHIFT)
+#define PMC_PCK0_PRES_CLK_4		(2 << PMC_PCK0_PRES_SHIFT)
+#define PMC_PCK0_PRES_CLK_8		(3 << PMC_PCK0_PRES_SHIFT)
+#define PMC_PCK0_PRES_CLK_16		(4 << PMC_PCK0_PRES_SHIFT)
+#define PMC_PCK0_PRES_CLK_32		(5 << PMC_PCK0_PRES_SHIFT)
+#define PMC_PCK0_PRES_CLK_64		(6 << PMC_PCK0_PRES_SHIFT)
+
+/* Master Clock Source Selection */
+#define PMC_PCK0_CSS_SHIFT		0
+#define PMC_PCK0_CSS_MASK		(0x07 << PMC_PCK0_CSS_SHIFT)
+#define PMC_PCK0_CSS_SLOW_CLK		(0 << PMC_PCK0_CSS_SHIFT)
+#define PMC_PCK0_CSS_MAIN_CLK		(1 << PMC_PCK0_CSS_SHIFT)
+#define PMC_PCK0_CSS_PLLA_CLK		(2 << PMC_PCK0_CSS_SHIFT)
+#define PMC_PCK0_CSS_MCK		(4 << PMC_PCK0_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 1 (PMC_PCK1) ------------------------ */
+
+/* Programmable Clock Prescaler */
+#define PMC_PCK1_PRES_SHIFT		4
+#define PMC_PCK1_PRES_MASK		(0x07 << PMC_PCK1_PRES_SHIFT)
+#define PMC_PCK1_PRES_CLK_1		(0 << PMC_PCK1_PRES_SHIFT)
+#define PMC_PCK1_PRES_CLK_2		(1 << PMC_PCK1_PRES_SHIFT)
+#define PMC_PCK1_PRES_CLK_4		(2 << PMC_PCK1_PRES_SHIFT)
+#define PMC_PCK1_PRES_CLK_8		(3 << PMC_PCK1_PRES_SHIFT)
+#define PMC_PCK1_PRES_CLK_16		(4 << PMC_PCK1_PRES_SHIFT)
+#define PMC_PCK1_PRES_CLK_32		(5 << PMC_PCK1_PRES_SHIFT)
+#define PMC_PCK1_PRES_CLK_64		(6 << PMC_PCK1_PRES_SHIFT)
+
+/* Master Clock Source Selection */
+#define PMC_PCK1_CSS_SHIFT		0
+#define PMC_PCK1_CSS_MASK		(0x07 << PMC_PCK1_CSS_SHIFT)
+#define PMC_PCK1_CSS_SLOW_CLK		(0 << PMC_PCK1_CSS_SHIFT)
+#define PMC_PCK1_CSS_MAIN_CLK		(1 << PMC_PCK1_CSS_SHIFT)
+#define PMC_PCK1_CSS_PLLA_CLK		(2 << PMC_PCK1_CSS_SHIFT)
+#define PMC_PCK1_CSS_MCK		(4 << PMC_PCK1_CSS_SHIFT)
+
+
+/* --- PMC Programmable Clock Register 2 (PMC_PCK2) ------------------------ */
+
+/* Programmable Clock Prescaler */
+#define PMC_PCK2_PRES_SHIFT		4
+#define PMC_PCK2_PRES_MASK		(0x07 << PMC_PCK2_PRES_SHIFT)
+#define PMC_PCK2_PRES_CLK_1		(0 << PMC_PCK2_PRES_SHIFT)
+#define PMC_PCK2_PRES_CLK_2		(1 << PMC_PCK2_PRES_SHIFT)
+#define PMC_PCK2_PRES_CLK_4		(2 << PMC_PCK2_PRES_SHIFT)
+#define PMC_PCK2_PRES_CLK_8		(3 << PMC_PCK2_PRES_SHIFT)
+#define PMC_PCK2_PRES_CLK_16		(4 << PMC_PCK2_PRES_SHIFT)
+#define PMC_PCK2_PRES_CLK_32		(5 << PMC_PCK2_PRES_SHIFT)
+#define PMC_PCK2_PRES_CLK_64		(6 << PMC_PCK2_PRES_SHIFT)
+
+/* Master Clock Source Selection */
+#define PMC_PCK2_CSS_SHIFT		0
+#define PMC_PCK2_CSS_MASK		(0x07 << PMC_PCK2_CSS_SHIFT)
+#define PMC_PCK2_CSS_SLOW_CLK		(0 << PMC_PCK2_CSS_SHIFT)
+#define PMC_PCK2_CSS_MAIN_CLK		(1 << PMC_PCK2_CSS_SHIFT)
+#define PMC_PCK2_CSS_PLLA_CLK		(2 << PMC_PCK2_CSS_SHIFT)
+#define PMC_PCK2_CSS_MCK		(4 << PMC_PCK2_CSS_SHIFT)
+
+
+/* --- PMC Interrupt Enable Register (PMC_IER) ----------------------------- */
+
+/* Clock Failure Detector Event Interrupt Enable */
+#define PMC_IER_CFDEV			(0x01 << 18)
+
+/* Main On-Chip RC Status Interrupt Enable */
+#define PMC_IER_MOSCRCS			(0x01 << 17)
+
+/* Main Oscillator Selection Status Interrupt Enable */
+#define PMC_IER_MOSCSELS		(0x01 << 16)
+
+/* Programmable Clock Ready 2 Interrupt Enable */
+#define PMC_IER_PCKRDY2			(0x01 << 10)
+
+/* Programmable Clock Ready 1 Interrupt Enable */
+#define PMC_IER_PCKRDY1			(0x01 << 9)
+
+/* Programmable Clock Ready 0 Interrupt Enable */
+#define PMC_IER_PCKRDY0			(0x01 << 8)
+
+/* Master Clock Ready Interrupt Enable */
+#define PMC_IER_MCKRDY			(0x01 << 3)
+
+/* PLLA Lock Interrupt Enable */
+#define PMC_IER_LOCKA			(0x01 << 1)
+
+/* Main Crystal Oscillator Status Interrupt Enable */
+#define PMC_IER_MOSCXTS			(0x01 << 0)
+
+
+/* --- PMC Interrupt Disable Register (PMC_IDR) ----------------------------- */
+
+/* Clock Failure Detector Event Interrupt Disable */
+#define PMC_IDR_CFDEV			(0x01 << 18)
+
+/* Main On-Chip RC Status Interrupt Disable */
+#define PMC_IDR_MOSCRCS			(0x01 << 17)
+
+/* Main Oscillator Selection Status Interrupt Disable */
+#define PMC_IDR_MOSCSELS		(0x01 << 16)
+
+/* Programmable Clock Ready 2 Interrupt Disable */
+#define PMC_IDR_PCKRDY2			(0x01 << 10)
+
+/* Programmable Clock Ready 1 Interrupt Disable */
+#define PMC_IDR_PCKRDY1			(0x01 << 9)
+
+/* Programmable Clock Ready 0 Interrupt Disable */
+#define PMC_IDR_PCKRDY0			(0x01 << 8)
+
+/* Master Clock Ready Interrupt Disable */
+#define PMC_IDR_MCKRDY			(0x01 << 3)
+
+/* PLLA Lock Interrupt Disable */
+#define PMC_IDR_LOCKA			(0x01 << 1)
+
+/* Main Crystal Oscillator Status Interrupt Disable */
+#define PMC_IDR_MOSCXTS			(0x01 << 0)
+
+
+/* --- PMC Status Register (PMC_SR) ---------------------------------------- */
+
+/* Clock Failure Detector Fault Output Status */
+#define PMC_SR_FOS			(0x01 << 20)
+
+/* Clock Failure Detector Status */
+#define PMC_SR_CFDS			(0x01 << 19)
+
+/* Clock Failure Detector Event */
+#define PMC_SR_CFDEV			(0x01 << 18)
+
+/* Main On-Chip RC Oscillator Status */
+#define PMC_SR_MOSCRCS			(0x01 << 17)
+
+/* Main Oscillator Selection Status */
+#define PMC_SR_MOSCSELS			(0x01 << 16)
+
+/* Programmable Clock 2 Ready Status */
+#define PMC_SR_PCKRDY2			(0x01 << 10)
+
+/* Programmable Clock 1 Ready Status */
+#define PMC_SR_PCKRDY1			(0x01 << 9)
+
+/* Programmable Clock 0 Ready Status */
+#define PMC_SR_PCKRDY0			(0x01 << 8)
+
+/* Slow Clock Oscillator Selection */
+#define PMC_SR_OSCSELS			(0x01 << 7)
+
+/* Master Clock Status */
+#define PMC_SR_MCKRDY			(0x01 << 3)
+
+/* PLLA Lock Status */
+#define PMC_SR_LOCKA			(0x01 << 1)
+
+/* Main XTAL Oscillator Status */
+#define PMC_SR_MOSCXTS			(0x01 << 0)
+
+
+/* --- PMC Interrupt Mask Register (PMC_IMR) ------------------------------- */
+
+/* Clock Failure Detector Event Interrupt Mask */
+#define PMC_IMR_CFDEV			(0x01 << 18)
+
+/* Main On-Chip RC Status Interrupt Mask */
+#define PMC_IMR_MOSCRCS			(0x01 << 17)
+
+/* Main Oscillator Selection Status Interrupt Mask */
+#define PMC_IMR_MOSCSELS		(0x01 << 16)
+
+/* Programmable Clock Ready 2 Interrupt Mask */
+#define PMC_IMR_PCKRDY2			(0x01 << 10)
+
+/* Programmable Clock Ready 1 Interrupt Mask */
+#define PMC_IMR_PCKRDY1			(0x01 << 9)
+
+/* Programmable Clock Ready 0 Interrupt Mask */
+#define PMC_IMR_PCKRDY0			(0x01 << 8)
+
+/* Master Clock Ready Interrupt Mask */
+#define PMC_IMR_MCKRDY			(0x01 << 3)
+
+/* PLLA Lock Interrupt Mask */
+#define PMC_IMR_LOCKA			(0x01 << 1)
+
+/* Main Crystal Oscillator Status Interrupt Mask */
+#define PMC_IMR_MOSCXTS			(0x01 << 0)
+
+
+/* --- PMC Fast Startup Mode Register (PMC_FSMR) --------------------------- */
+
+/* Low Power Mode */
+#define PMC_FSMR_LPM			(0x01 << 20)
+
+/* USB Alarm Enable */
+#define PMC_FSMR_USBAL			(0x01 << 18)
+
+/* RTC Alarm Enable */
+#define PMC_FSMR_RTCAL			(0x01 << 17)
+
+/* RTC Alarm Enable */
+#define PMC_FSMR_RTTAL			(0x01 << 16)
+
+/* Fast Startup Input Enable 0 to 15 */
+#define PMC_FSMR_FSTT15			(0x01 << 15)
+#define PMC_FSMR_FSTT14			(0x01 << 14)
+#define PMC_FSMR_FSTT13			(0x01 << 13)
+#define PMC_FSMR_FSTT12			(0x01 << 12)
+#define PMC_FSMR_FSTT11			(0x01 << 11)
+#define PMC_FSMR_FSTT10			(0x01 << 10)
+#define PMC_FSMR_FSTT9			(0x01 << 9)
+#define PMC_FSMR_FSTT8			(0x01 << 8)
+#define PMC_FSMR_FSTT7			(0x01 << 7)
+#define PMC_FSMR_FSTT6			(0x01 << 6)
+#define PMC_FSMR_FSTT5			(0x01 << 5)
+#define PMC_FSMR_FSTT4			(0x01 << 4)
+#define PMC_FSMR_FSTT3			(0x01 << 3)
+#define PMC_FSMR_FSTT2			(0x01 << 2)
+#define PMC_FSMR_FSTT1			(0x01 << 1)
+#define PMC_FSMR_FSTT0			(0x01 << 0)
+
+
+/* --- PMC Fast Startup Polarity Register (PMC_FSPR) ----------------------- */
+
+/* Fast Startup Input Polarity x */
+#define PMC_FSPR_FSTP15			(0x01 << 15)
+#define PMC_FSPR_FSTP14			(0x01 << 14)
+#define PMC_FSPR_FSTP13			(0x01 << 13)
+#define PMC_FSPR_FSTP12			(0x01 << 12)
+#define PMC_FSPR_FSTP11			(0x01 << 11)
+#define PMC_FSPR_FSTP10			(0x01 << 10)
+#define PMC_FSPR_FSTP9			(0x01 << 9)
+#define PMC_FSPR_FSTP8			(0x01 << 8)
+#define PMC_FSPR_FSTP7			(0x01 << 7)
+#define PMC_FSPR_FSTP6			(0x01 << 6)
+#define PMC_FSPR_FSTP5			(0x01 << 5)
+#define PMC_FSPR_FSTP4			(0x01 << 4)
+#define PMC_FSPR_FSTP3			(0x01 << 3)
+#define PMC_FSPR_FSTP2			(0x01 << 2)
+#define PMC_FSPR_FSTP1			(0x01 << 1)
+#define PMC_FSPR_FSTP0			(0x01 << 0)
+
+
+/* --- PMC Fault Output Clear Register (PMC_FOCR) -------------------------- */
+
+/* Fault Output Clear */
+#define PMC_FOCR_FOCLR			(0x01 << 0)
+
+
+/* --- PMC Write Protect Mode Register (PMC_WPMR) -------------------------- */
+
+/* Write Protect Key */
+#define PMC_WPMR_WPKEY_SHIFT		8
+#define PMC_WPMR_WPKEY			(0x504D43 << PMC_WPMR_WPKEY_SHIFT)
+
+/* Write Protect Enable */
+#define PMC_WPMR_WPEN			(0x01 << 0)
+
+
+/* --- PMC Write Protect Status Register (PMC_WPSR) ------------------------ */
+
+/* Write Protect Violation Source */
+#define PMC_WPSR_WPVSRC_SHIFT		8
+#define PMC_WPSR_WPVSRC_MASK		(0xFFFF << PMC_WPSR_WPVSRC_SHIFT)
+
+/* Write Protect Violation Status */
+#define PMC_WPSR_WPVS			(0x01 << 0)
+
+
+
+
+extern uint32_t pmc_mck_frequency;
+
+enum mck_src {
+	MCK_SRC_SLOW = 0,
+	MCK_SRC_MAIN = 1,
+	MCK_SRC_PLLA = 2,
+	MCK_SRC_UPLL = 3,
+};
+
+void pmc_mck_set_source(enum mck_src src);
+void pmc_xtal_enable(bool en, uint8_t startup_time);
+void pmc_plla_config(uint8_t mul, uint8_t div);
+void pmc_peripheral_clock_enable(uint8_t pid);
+void pmc_peripheral_clock_disable(uint8_t pid);
+void pmc_clock_setup_in_xtal_12mhz_out_84mhz(void);
+void pmc_clock_setup_in_rc_4mhz_out_84mhz(void);
+
+#endif
+
+#else
+#warning "pmc_common_all.h should not be included explicitly, only via pmc.h"
+#endif

--- a/include/libopencm3/sam/common/smc_common_3a3u3x.h
+++ b/include/libopencm3/sam/common/smc_common_3a3u3x.h
@@ -1,0 +1,550 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_SMC_H
+#define LIBOPENCM3_SMC_H
+
+#include <libopencm3/sam/memorymap.h>
+
+
+/* Chip Select Defines */
+#define SMC_CS_0			0
+#define SMC_CS_1			1
+#define SMC_CS_2			2
+#define SMC_CS_3			3
+
+
+/* --- Static Memory Controller (SMC) registers ---------------------------- */
+
+/* NFC Configuration Register */
+#define SMC_CFG				MMIO32(SMC_BASE + 0x00)
+
+/* NFC Control Register */
+#define SMC_CTRL			MMIO32(SMC_BASE + 0x04)
+
+/* NFC Status Register */
+#define SMC_SR				MMIO32(SMC_BASE + 0x08)
+
+/* NFC Interrupt Enable Register */
+#define SMC_IER				MMIO32(SMC_BASE + 0x0C)
+
+/* NFC Interrupt Disable Register */
+#define SMC_IDR				MMIO32(SMC_BASE + 0x10)
+
+/* Interrupt Mask Register */
+#define SMC_IMR				MMIO32(SMC_BASE + 0x14)
+
+/* NFC Address Cycle Zero Register */
+#define SMC_ADDR			MMIO32(SMC_BASE + 0x18)
+
+/* Bank Address Register */
+#define SMC_BANK			MMIO32(SMC_BASE + 0x1C)
+
+/* ECC Control Register */
+#define SMC_ECC_CTRL			MMIO32(SMC_BASE + 0x20)
+
+/* ECC Mode Register */
+#define SMC_ECC_MD			MMIO32(SMC_BASE + 0x24)
+
+/* ECC Status 1 Register */
+#define SMC_ECC_SR1			MMIO32(SMC_BASE + 0x28)
+
+/* ECC Parity 0 Register */
+#define SMC_ECC_PR0			MMIO32(SMC_BASE + 0x2C)
+
+/* ECC parity 1 Register */
+#define SMC_ECC_PR1			MMIO32(SMC_BASE + 0x30)
+
+/* ECC status 2 Register */
+#define SMC_ECC_SR2			MMIO32(SMC_BASE + 0x34)
+
+/* ECC parity 2 Register */
+#define SMC_ECC_PR2			MMIO32(SMC_BASE + 0x38)
+
+/* ECC parity 3 Register */
+#define SMC_ECC_PR3			MMIO32(SMC_BASE + 0x3C)
+
+/* ECC parity 4 Register */
+#define SMC_ECC_PR4			MMIO32(SMC_BASE + 0x40)
+
+/* ECC parity 5 Register */
+#define SMC_ECC_PR5			MMIO32(SMC_BASE + 0x44)
+
+/* ECC parity 6 Register */
+#define SMC_ECC_PR6			MMIO32(SMC_BASE + 0x48)
+
+/* ECC parity 7 Register */
+#define SMC_ECC_PR7			MMIO32(SMC_BASE + 0x4C)
+
+/* ECC parity 8 Register */
+#define SMC_ECC_PR8			MMIO32(SMC_BASE + 0x50)
+
+/* ECC parity 9 Register */
+#define SMC_ECC_PR9			MMIO32(SMC_BASE + 0x54)
+
+/* ECC parity 10 Register */
+#define SMC_ECC_PR10			MMIO32(SMC_BASE + 0x58)
+
+/* ECC parity 11 Register */
+#define SMC_ECC_PR11			MMIO32(SMC_BASE + 0x5C)
+
+/* ECC parity 12 Register */
+#define SMC_ECC_PR12			MMIO32(SMC_BASE + 0x60)
+
+/* ECC parity 13 Register */
+#define SMC_ECC_PR13			MMIO32(SMC_BASE + 0x64)
+
+/* ECC parity 14 Register */
+#define SMC_ECC_PR14			MMIO32(SMC_BASE + 0x68)
+
+/* ECC parity 15 Register */
+#define SMC_ECC_PR15			MMIO32(SMC_BASE + 0x6C)
+
+/* Setup Register */
+#define SMC_SETUP(CS_number)		MMIO32(SMC_BASE + 0x14*(CS_number) + 0x70)
+
+/* Pulse Register */
+#define SMC_PULSE(CS_number)		MMIO32(SMC_BASE + 0x14*(CS_number) + 0x74)
+
+/* Cycle Register */
+#define SMC_CYCLE(CS_number)		MMIO32(SMC_BASE + 0x14*(CS_number) + 0x78)
+
+/* Timings Register */
+#define SMC_TIMINGS(CS_number)		MMIO32(SMC_BASE + 0x14*(CS_number) + 0x7C)
+
+/* Mode Register */
+#define SMC_MODE(CS_number)		MMIO32(SMC_BASE + 0x14*(CS_number) + 0x80)
+
+/* Off Chip Memory Scrambling Mode Register */
+#define SMC_OCMS			MMIO32(SMC_BASE + 0x110)
+
+/* Off Chip Memory Scrambling KEY1 Register */
+#define SMC_KEY1			MMIO32(SMC_BASE + 0x114)
+
+/* Off Chip Memory Scrambling KEY2 Register */
+#define SMC_KEY2			MMIO32(SMC_BASE + 0x118)
+
+/* Write Protection Control Register */
+#define SMC_WPCR			MMIO32(SMC_BASE + 0x1E4)
+
+/* Write Protect Status Register */
+#define SMC_WPSR			MMIO32(SMC_BASE + 0x1E8)
+
+
+/* --- Register contents --------------------------------------------------- */
+
+
+/* --- SMC NFC Configuration Register (SMC_CFG) ---------------------------- */
+
+/* Data Timeout Multiplier */
+#define SMC_CFG_DTOMUL_SHIFT		20
+#define SMC_CFG_DTOMUL_MASK		(0x07 << SMC_DTOMUL_SHIFT)
+
+/* Data Timeout Multiplier Values */
+#define SMC_CFG_DTOMUL_X1		(0x00 << SMC_DTOMUL_SHIFT)
+#define SMC_CFG_DTOMUL_X16		(0x01 << SMC_DTOMUL_SHIFT)
+#define SMC_CFG_DTOMUL_X128		(0x02 << SMC_DTOMUL_SHIFT)
+#define SMC_CFG_DTOMUL_X256		(0x03 << SMC_DTOMUL_SHIFT)
+#define SMC_CFG_DTOMUL_X1024		(0x04 << SMC_DTOMUL_SHIFT)
+#define SMC_CFG_DTOMUL_X4096		(0x05 << SMC_DTOMUL_SHIFT)
+#define SMC_CFG_DTOMUL_X65536		(0x06 << SMC_DTOMUL_SHIFT)
+#define SMC_CFG_DTOMUL_X1048576		(0x07 << SMC_DTOMUL_SHIFT)
+
+/* Data Timeout Cycle Number */
+#define SMC_CFG_DTOCYC_SHIFT		16
+#define SMC_CFG_DTOCYC_MASK		(0x0F << SMC_DTOCYC_SHIFT)
+
+/* Ready/Busy Signal Edge Detection */
+#define SMC_CFG_RBEDGE			(1 << 13)
+
+/* Rising/Falling Edge Detection Control */
+#define SMC_CFG_EDGECTRL		(1 << 12)
+
+/* Read Spare Area */
+#define SMC_CFG_RSPARE			(1 << 9)
+
+/* Write Spare Area */
+#define SMC_CFG_WSPARE			(1 << 8)
+
+/* NAND Flash Page Size */
+#define SMC_CFG_PAGESIZE_SHIFT		0
+#define SMC_CFG_PAGESIZE_MASK		(0x03 << SMC_CFG_PAGESIZE_SHIFT)
+
+/* NAND Flash Page Size Values */
+#define SMC_CFG_PAGESIZE_PS512_16	(0x00 << SMC_CFG_PAGESIZE_SHIFT)
+#define SMC_CFG_PAGESIZE_PS1024_32	(0x01 << SMC_CFG_PAGESIZE_SHIFT)
+#define SMC_CFG_PAGESIZE_PS2048_64	(0x02 << SMC_CFG_PAGESIZE_SHIFT)
+#define SMC_CFG_PAGESIZE_PS4096_128	(0x03 << SMC_CFG_PAGESIZE_SHIFT)
+
+
+/* --- SMC NFC Control Register (SMC_CTRL) --------------------------------- */
+
+/* NAND Flash Controller Disable */
+#define SMC_CTRL_NFCDIS			(1 << 1)
+
+/* NAND Flash Controller Enable */
+#define SMC_CTRL_NFCEN			(1 << 0)
+
+
+/* --- SMC NFC Status Register (SMC_SR) ------------------------------------ */
+
+/* Ready/Busy Line 0 Edge Detected */
+#define SMC_SR_RB_EDGE0			(1 << 24)
+
+/* NFC Access Size Error */
+#define SMC_SR_NFCASE			(1 << 23)
+
+/* Accessing While Busy */
+#define SMC_SR_AWB			(1 << 22)
+
+/* Undefined Area Error */
+#define SMC_SR_UNDEF			(1 << 21)
+
+/* Data Timeout Error */
+#define SMC_SR_DTOE			(1 << 20)
+
+/* Command Done */
+#define SMC_SR_CMDDONE			(1 << 17)
+
+/* NFC Data Transfer Terminated */
+#define SMC_SR_XFRDONE			(1 << 16)
+
+/* NFC Chip Select ID */
+#define SMC_SR_NFCSID_SHIFT		12
+#define SMC_SR_NFCSID_MASK		(0x07 << SMC_SR_NFCSID_SHIFT)
+
+/* NFC Write/Read Operation */
+#define SMC_SR_NFCWR			(1 << 11)
+
+/* NFC Busy */
+#define SMC_SR_NFCBUSY			(1 << 8)
+
+/* Selected Ready Busy Falling Edge Detected */
+#define SMC_SR_RB_FALL			(1 << 5)
+
+/* Selected Ready Busy Rising Edge Detected */
+#define SMC_SR_RB_RISE			(1 << 4)
+
+/* NAND Flash Controller status */
+#define SMC_SR_SMCSTS			(1 << 0)
+
+
+/* --- SMC NFC Interrupt Enable Register (SMC_IER) ------------------------- */
+
+/* Ready/Busy Line 0 Interrupt Enable */
+#define SMC_IER_RB_EDGE0		(1 << 24)
+
+/* NFC Access Size Error Interrupt Enable */
+#define SMC_IER_NFCASE			(1 << 23)
+
+/* Accessing While Busy Interrupt Enable */
+#define SMC_IER_AWB			(1 << 22)
+
+/* Undefined Area Access Interrupt Enable */
+#define SMC_IER_UNDEF			(1 << 21)
+
+/* Data Timeout Error Interrupt Enable */
+#define SMC_IER_DTOE			(1 << 20)
+
+/* Command Done Interrupt Enable */
+#define SMC_IER_CMDDONE			(1 << 17)
+
+/* Transfer Done Interrupt Enable */
+#define SMC_IER_XFRDONE			(1 << 16)
+
+/* Ready Busy Falling Edge Detection Interrupt Enable */
+#define SMC_IER_RB_FALL			(1 << 5)
+
+/* Ready Busy Rising Edge Detection Interrupt Enable */
+#define SMC_IER_RB_RISE			(1 << 4)
+
+
+/* --- SMC NFC Interrupt Disable Register (SMC_IDR) ------------------------ */
+
+/* Ready/Busy Line 0 Interrupt Disable */
+#define SMC_IDR_RB_EDGE0		(1 << 24)
+
+/* NFC Access Size Error Interrupt Disable */
+#define SMC_IDR_NFCASE			(1 << 23)
+
+/* Accessing While Busy Interrupt Disable */
+#define SMC_IDR_AWB			(1 << 22)
+
+/* Undefined Area Access Interrupt Disable */
+#define SMC_IDR_UNDEF			(1 << 21)
+
+/* Data Timeout Error Interrupt Disable */
+#define SMC_IDR_DTOE			(1 << 20)
+
+/* Command Done Interrupt Disable */
+#define SMC_IDR_CMDDONE			(1 << 17)
+
+/* Transfer Done Interrupt Disable */
+#define SMC_IDR_XFRDONE			(1 << 16)
+
+/* Ready Busy Falling Edge Detection Interrupt Disable */
+#define SMC_IDR_RB_FALL			(1 << 5)
+
+/* Ready Busy Rising Edge Detection Interrupt Disable */
+#define SMC_IDR_RB_RISE			(1 << 4)
+
+
+/* --- SMC NFC Interrupt Mask Register (SMC_IMR) --------------------------- */
+
+/* Ready/Busy Line 0 Interrupt Mask */
+#define SMC_IMR_RB_EDGE0		(1 << 24)
+
+/* NFC Access Size Error Interrupt Mask */
+#define SMC_IMR_NFCASE			(1 << 23)
+
+/* Accessing While Busy Interrupt Mask */
+#define SMC_IMR_AWB			(1 << 22)
+
+/* Undefined Area Access Interrupt Mask */
+#define SMC_IMR_UNDEF			(1 << 21)
+
+/* Data Timeout Error Interrupt Mask */
+#define SMC_IMR_DTOE			(1 << 20)
+
+/* Command Done Interrupt Mask */
+#define SMC_IMR_CMDDONE			(1 << 17)
+
+/* Transfer Done Interrupt Mask */
+#define SMC_IMR_XFRDONE			(1 << 16)
+
+/* Ready Busy Falling Edge Detection Interrupt Mask */
+#define SMC_IMR_RB_FALL			(1 << 5)
+
+/* Ready Busy Rising Edge Detection Interrupt Mask */
+#define SMC_IMR_RB_RISE			(1 << 4)
+
+
+/* --- SMC NFC Address Cycle Zero Register (SMC_ADDR) ---------------------- */
+
+/* NAND Flash Array Address cycle 0 */
+#define SMC_ADDR_ADDR_CYCLE0_SHIFT	0
+#define SMC_ADDR_ADDR_CYCLE0_MASK	(0xFF << SMC_ADDR_ADDR_CYCLE0_SHIFT)
+
+
+/* --- SMC NFC Bank Register (SMC_BANK) ------------------------------------ */
+
+/* Bank Identifier */
+#define SMC_BANK_BANK_SHIFT		0
+#define SMC_BANK_BANK_MASK		(0x07 << SMC_BANK_BANK_SHIFT)
+
+
+/* --- SMC ECC Control Register (SMC_ECC_CTRL) ----------------------------- */
+
+/* Software Reset */
+#define SMC_ECC_CTRL_SWRST		(1 << 1)
+
+/* Reset ECC */
+#define SMC_ECC_CTRL_RST		(1 << 0)
+
+
+/* --- SMC ECC MODE Register (SMC_ECC_MD) ---------------------------------- */
+
+/* Type of Correction */
+#define SMC_ECC_MD_TYPCORREC_SHIFT	4
+#define SMC_ECC_MD_TYPCORREC_MASK	(0x03 << SMC_ECC_MD_TYPCORREC_SHIFT)
+
+/* Type of Correction Values */
+#define SMC_ECC_MD_TYPCORREC_CPAGE	(0x00 << SMC_ECC_MD_TYPCORREC_SHIFT)
+#define SMC_ECC_MD_TYPCORREC_C256B	(0x01 << SMC_ECC_MD_TYPCORREC_SHIFT)
+#define SMC_ECC_MD_TYPCORREC_C512B	(0x02 << SMC_ECC_MD_TYPCORREC_SHIFT)
+
+/* ECC Page Size */
+#define SMC_ECC_MD_ECC_PAGESIZE_SHIFT	0
+#define SMC_ECC_MD_ECC_PAGESIZE_MASK	(0x03 << SMC_ECC_MD_ECC_PAGESIZE_SHIFT)
+
+/* ECC Page Size Values */
+#define SMC_ECC_MD_ECC_PAGESIZE_PS512_16	(0x00 << SMC_ECC_MD_ECC_PAGESIZE_SHIFT)
+#define SMC_ECC_MD_ECC_PAGESIZE_PS1024_32	(0x01 << SMC_ECC_MD_ECC_PAGESIZE_SHIFT)
+#define SMC_ECC_MD_ECC_PAGESIZE_PS2048_64	(0x02 << SMC_ECC_MD_ECC_PAGESIZE_SHIFT)
+#define SMC_ECC_MD_ECC_PAGESIZE_PS4096_128	(0x03 << SMC_ECC_MD_ECC_PAGESIZE_SHIFT)
+
+
+/* --- SMC ECC Status Register 1 (SMC_ECC_SR1) ----------------------------- */
+/* currently unimplemented */
+
+
+/* --- SMC ECC Status Register 2 (SMC_ECC_SR2) ----------------------------- */
+/* currently unimplemented */
+
+
+/* --- SMC ECC Parity Register 0 (SMC_ECC_PR0) ----------------------------- */
+/* currently unimplemented */
+
+
+/* --- SMC ECC Parity Register 1 (SMC_ECC_PR1) ----------------------------- */
+/* currently unimplemented */
+
+
+/* --- SMC ECC Parity Registers (SMC_ECC_PRx) ------------------------------ */
+/* currently unimplemented */
+
+
+/* --- SMC Setup Register (SMC_SETUPx) ------------------------------------- */
+
+/* NCS Setup length in Read access */
+#define SMC_SETUP_NCS_RD_SETUP_SHIFT	24
+#define SMC_SETUP_NCS_RD_SETUP_MASK	(0x3F << SMC_SETUP_NCS_RD_SETUP_SHIFT)
+
+/* NRD Setup length */
+#define SMC_SETUP_NRD_SETUP_SHIFT	16
+#define SMC_SETUP_NRD_SETUP_MASK	(0x3F << SMC_SETUP_NRD_SETUP_SHIFT)
+
+/* NCS Setup length in Write access */
+#define SMC_SETUP_NCS_WR_SETUP_SHIFT	8
+#define SMC_SETUP_NCS_WR_SETUP_MASK	(0x3F << SMC_SETUP_NCS_WR_SETUP_SHIFT)
+
+/* NWE Setup Length */
+#define SMC_SETUP_NWE_SETUP_SHIFT	0
+#define SMC_SETUP_NWE_SETUP_MASK	(0x3F << SMC_SETUP_NWE_SETUP_SHIFT)
+
+
+/* --- SMC Pulse Register (SMC_PULSEx) ------------------------------------- */
+
+/* NCS Pulse Length in READ Access */
+#define SMC_PULSE_NCS_RD_PULSE_SHIFT	24
+#define SMC_PULSE_NCS_RD_PULSE_MASK	(0x3F << SMC_PULSE_NCS_RD_PULSE_SHIFT)
+
+/* NRD Pulse Length */
+#define SMC_PULSE_NRD_PULSE_SHIFT	16
+#define SMC_PULSE_NRD_PULSE_MASK	(0x3F << SMC_PULSE_NRD_PULSE_SHIFT)
+
+/* NCS Pulse Length in WRITE Access */
+#define SMC_PULSE_NCS_WR_PULSE_SHIFT	8
+#define SMC_PULSE_NCS_WR_PULSE_MASK	(0x3F << SMC_PULSE_NCS_WR_PULSE_SHIFT)
+
+/* NWE Pulse Length */
+#define SMC_PULSE_NWE_PULSE_SHIFT	0
+#define SMC_PULSE_NWE_PULSE_MASK	(0x3F << SMC_PULSE_NWE_PULSE_SHIFT)
+
+
+/* --- SMC Cycle Register (SMC_CYCLEx) ------------------------------------- */
+
+/* Total Read Cycle Length */
+#define SMC_CYCLE_NRD_CYCLE_SHIFT	16
+#define SMC_CYCLE_NRD_CYCLE_MASK	(0x1FF << SMC_CYCLE_NRD_CYCLE_SHIFT)
+
+/* Total Write Cycle Length */
+#define SMC_CYCLE_NWE_CYCLE_SHIFT	0
+#define SMC_CYCLE_NWE_CYCLE_MASK	(0x1FF << SMC_CYCLE_NWE_CYCLE_SHIFT)
+
+
+/* --- SMC Timings Register (SMC_TIMINGSx) --------------------------------- */
+
+/* NAND Flash Selection */
+#define SMC_TIMINGS_NFSEL		(1 << 31)
+
+/* Ready/Busy Line Selection */
+#define SMC_TIMINGS_RBNSEL_SHIFT	28
+#define SMC_TIMINGS_RBNSEL_MASK		(0x07 << SMC_TIMINGS_RBNSEL_SHIFT)
+
+/* WEN High to REN to Busy */
+#define SMC_TIMINGS_TWB_SHIFT		24
+#define SMC_TIMINGS_TWB_MASK		(0x0F << SMC_TIMINGS_TWB_SHIFT)
+
+/* Ready to REN Low Delay */
+#define SMC_TIMINGS_TRR_SHIFT		16
+#define SMC_TIMINGS_TRR_MASK		(0x0F << SMC_TIMINGS_TRR_SHIFT)
+
+/* Off Chip Memory Scrambling Enable */
+#define SMC_TIMINGS_OCMS		(1 << 12)
+
+/* ALE to REN Low Delay */
+#define SMC_TIMINGS_TAR_SHIFT		8
+#define SMC_TIMINGS_TAR_MASK		(0x0F << SMC_TIMINGS_TAR_SHIFT)
+
+/* ALE to Data Start */
+#define SMC_TIMINGS_TADL_SHIFT		4
+#define SMC_TIMINGS_TADL_MASK		(0x0F << SMC_TIMINGS_TADL_SHIFT)
+
+/* CLE to REN Low Delay */
+#define SMC_TIMINGS_TCLR_SHIFT		0
+#define SMC_TIMINGS_TCLR_MASK		(0x0F << SMC_TIMINGS_TCLR_SHIFT)
+
+
+/* --- SMC Mode Register (SMC_MODEx) --------------------------------------- */
+
+/* TDF Optimization */
+#define SMC_MODE_TDF_MODE		(1 << 20)
+
+/* Data Float Time */
+#define SMC_MODE_TDF_CYCLES_SHIFT	16
+#define SMC_MODE_TDF_CYCLES_MASK	(0x0F << SMC_MODE_TDF_CYCLES_SHIFT)
+
+/* Data Bus Width */
+#define SMC_MODE_DBW			(1 << 12)
+
+/* Data Bus Width Values */
+#define SMC_MODE_DBW_BIT_8		(0 << 12)
+#define SMC_MODE_DBW_BIT_16		(1 << 12)
+
+/* Byte Access Type */
+#define SMC_MODE_BAT			(1 << 8)
+
+/* NWAIT Mode */
+#define SMC_MODE_EXNW_MODE_SHIFT	4
+#define SMC_MODE_EXNW_MODE_MASK		(0x03 << SMC_MODE_EXNW_MODE_SHIFT)
+
+/* NWAIT Mode Values */
+#define SMC_MODE_EXNW_MODE_DISABLED	(0x00 << SMC_MODE_EXNW_MODE_SHIFT)
+#define SMC_MODE_EXNW_MODE_FROZEN	(0x02 << SMC_MODE_EXNW_MODE_SHIFT)
+#define SMC_MODE_EXNW_MODE_READY	(0x03 << SMC_MODE_EXNW_MODE_SHIFT)
+
+/* Write Mode */
+#define SMC_MODE_WRITE_MODE		(1 << 1)
+
+/* Read Mode */
+#define SMC_MODE_READ_MODE		(1 << 0)
+
+
+/* --- SMC OCMS Register (SMC_OCMS) ---------------------------------------- */
+
+/* SRAM Scrambling Enable */
+#define SMC_OCMS_SRSE			(1 << 1)
+
+/* Static Memory Controller Scrambling Enable */
+#define SMC_OCMS_SMSE			(1 << 0)
+
+
+/* --- SMC Write Protection Control (SMC_WPCR) ----------------------------- */
+
+/* Write Protect Key */
+#define SMC_WPCR_WPKEY_SHIFT		8
+#define SMC_WPCR_WPKEY_KEY		(0x534D43 << SMC_WPCR_WPKEY_SHIFT)
+
+/* Write Protect Enable */
+#define SMC_WPCR_WPEN			(1 << 0)
+
+
+/* --- SMC Write Protection Status (SMC_WPSR) ------------------------------ */
+
+/* Write Protection Violation Source */
+#define SMC_WPSR_WP_VSRC_SHIFT		8
+#define SMC_WPSR_WP_VSRC_MASK		(0xFFFF << SMC_WPSR_WP_VSRC_SHIFT)
+
+/* Write Protection Violation Status */
+#define SMC_WPSR_WP_VS_SHIFT		0
+#define SMC_WPSR_WP_VS_MASK		(0x0F << SMC_WPSR_WP_VS_SHIFT)
+
+
+#endif

--- a/include/libopencm3/sam/periph.h
+++ b/include/libopencm3/sam/periph.h
@@ -1,0 +1,32 @@
+/* This provides unification of code over SAM subfamilies */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if defined(SAM3A)
+#       include <libopencm3/sam/common/periph_common_3a3x.h>
+#elif defined(SAM3N)
+#       include <libopencm3/sam/3n/periph.h>
+#elif defined(SAM3S)
+#       include <libopencm3/sam/3s/periph.h>
+#elif defined(SAM3U)
+#       include <libopencm3/sam/3u/periph.h>
+#elif defined(SAM3X)
+#       include <libopencm3/sam/common/periph_common_3a3x.h>
+#else
+#       error "sam family not defined."
+#endif

--- a/include/libopencm3/sam/pio.h
+++ b/include/libopencm3/sam/pio.h
@@ -1,7 +1,9 @@
+/* This provides unification of code over SAM subfamilies */
+
 /*
  * This file is part of the libopencm3 project.
  *
- * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,80 +19,16 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SAM_PIO_H
-#define SAM_PIO_H
-
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/sam/memorymap.h>
-
-/* --- Convenience macros ------------------------------------------------ */
-
-/* GPIO port base addresses (for convenience) */
-#define PIOA				PIOA_BASE
-#define PIOB				PIOB_BASE
-#define PIOC				PIOC_BASE
-#define PIOD				PIOD_BASE
-#define PIOE				PIOE_BASE
-#define PIOF				PIOF_BASE
-#define PIOG				PIOG_BASE
-#define PIOH				PIOH_BASE
-
-/* --- PIO registers ----------------------------------------------------- */
-
-#define PIO_PER(port)			MMIO32((port) + 0x0000)
-#define PIO_PDR(port)			MMIO32((port) + 0x0004)
-#define PIO_PSR(port)			MMIO32((port) + 0x0008)
-/* 0x000C - Reserved */
-#define PIO_OER(port)			MMIO32((port) + 0x0010)
-#define PIO_ODR(port)			MMIO32((port) + 0x0014)
-#define PIO_OSR(port)			MMIO32((port) + 0x0018)
-/* 0x001C - Reserved */
-#define PIO_IFER(port)			MMIO32((port) + 0x0020)
-#define PIO_IFDR(port)			MMIO32((port) + 0x0024)
-#define PIO_IFSR(port)			MMIO32((port) + 0x0028)
-/* 0x002C - Reserved */
-#define PIO_SODR(port)			MMIO32((port) + 0x0030)
-#define PIO_CODR(port)			MMIO32((port) + 0x0034)
-#define PIO_ODSR(port)			MMIO32((port) + 0x0038)
-#define PIO_PDSR(port)			MMIO32((port) + 0x003C)
-#define PIO_IER(port)			MMIO32((port) + 0x0040)
-#define PIO_IDR(port)			MMIO32((port) + 0x0044)
-#define PIO_IMR(port)			MMIO32((port) + 0x0048)
-#define PIO_ISR(port)			MMIO32((port) + 0x004C)
-#define PIO_MDER(port)			MMIO32((port) + 0x0050)
-#define PIO_MDDR(port)			MMIO32((port) + 0x0054)
-#define PIO_MDSR(port)			MMIO32((port) + 0x0058)
-/* 0x005C - Reserved */
-#define PIO_PUDR(port)			MMIO32((port) + 0x0060)
-#define PIO_PUER(port)			MMIO32((port) + 0x0064)
-#define PIO_PUSR(port)			MMIO32((port) + 0x0068)
-/* 0x006C - Reserved */
-#define PIO_ABSR(port)			MMIO32((port) + 0x0070)
-/* 0x0074-0x007C - Reserved */
-#define PIO_SCIFSR(port)		MMIO32((port) + 0x0080)
-#define PIO_DIFSR(port)			MMIO32((port) + 0x0084)
-#define PIO_IFDGSR(port)		MMIO32((port) + 0x0088)
-#define PIO_SCDR(port)			MMIO32((port) + 0x008C)
-/* 0x0090-0x009C - Reserved */
-#define PIO_OWER(port)			MMIO32((port) + 0x00A0)
-#define PIO_OWDR(port)			MMIO32((port) + 0x00A4)
-#define PIO_OWSR(port)			MMIO32((port) + 0x00A8)
-/* 0x00AC - Reserved */
-#define PIO_AIMER(port)			MMIO32((port) + 0x00B0)
-#define PIO_AIMDR(port)			MMIO32((port) + 0x00B4)
-#define PIO_AIMMR(port)			MMIO32((port) + 0x00B8)
-/* 0x00BC - Reserved */
-#define PIO_ESR(port)			MMIO32((port) + 0x00C0)
-#define PIO_LSR(port)			MMIO32((port) + 0x00C4)
-#define PIO_ELSR(port)			MMIO32((port) + 0x00C8)
-/* 0x00CC - Reserved */
-#define PIO_FELLSR(port)		MMIO32((port) + 0x00D0)
-#define PIO_REHLSR(port)		MMIO32((port) + 0x00D4)
-#define PIO_FRLHSR(port)		MMIO32((port) + 0x00D8)
-/* 0x00DC - Reserved */
-#define PIO_LOCKSR(port)		MMIO32((port) + 0x00E0)
-#define PIO_WPMR(port)			MMIO32((port) + 0x00E4)
-#define PIO_WPSR(port)			MMIO32((port) + 0x00E8)
-/* 0x00EC-0x0144 - Reserved */
-
+#if defined(SAM3A)
+#       include <libopencm3/sam/3a/pio.h>
+#elif defined(SAM3N)
+#       include <libopencm3/sam/3n/pio.h>
+#elif defined(SAM3S)
+#       include <libopencm3/sam/3s/pio.h>
+#elif defined(SAM3U)
+#       include <libopencm3/sam/3u/pio.h>
+#elif defined(SAM3X)
+#       include <libopencm3/sam/3x/pio.h>
+#else
+#       error "sam family not defined."
 #endif

--- a/include/libopencm3/sam/smc.h
+++ b/include/libopencm3/sam/smc.h
@@ -1,0 +1,32 @@
+/* This provides unification of code over SAM subfamilies */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if defined(SAM3A)
+#       include <libopencm3/sam/common/smc_common_3a3u3x.h>
+#elif defined(SAM3N)
+#       error "sam3n doesn't have a static memory controller."
+#elif defined(SAM3S)
+#       include <libopencm3/sam/3s/smc.h>
+#elif defined(SAM3U)
+#       include <libopencm3/sam/common/smc_common_3a3u3x.h>
+#elif defined(SAM3X)
+#       include <libopencm3/sam/common/smc_common_3a3u3x.h>
+#else
+#       error "sam family not defined."
+#endif

--- a/lib/sam/3a/Makefile
+++ b/lib/sam/3a/Makefile
@@ -29,7 +29,7 @@ CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
 		  -ffunction-sections -fdata-sections -MD -DSAM3A
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/3n/Makefile
+++ b/lib/sam/3n/Makefile
@@ -29,7 +29,7 @@ CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
 		  -ffunction-sections -fdata-sections -MD -DSAM3N
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o usart.o
 
 VPATH += ../../cm3:../common
 

--- a/lib/sam/3s/Makefile
+++ b/lib/sam/3s/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
 		  -ffunction-sections -fdata-sections -MD -DSAM3S
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/3u/Makefile
+++ b/lib/sam/3u/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
 		  -ffunction-sections -fdata-sections -MD -DSAM3U
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/3x/Makefile
+++ b/lib/sam/3x/Makefile
@@ -29,7 +29,7 @@ CFLAGS		= -Os -g -Wall -Wextra -I../../../include -fno-common \
 		  -ffunction-sections -fdata-sections -MD -DSAM3X
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/common/gpio_common_3a3u3x.c
+++ b/lib/sam/common/gpio_common_3a3u3x.c
@@ -1,0 +1,73 @@
+/** @addtogroup gpio_defines
+ *
+ * @brief <b>Access functions for the SAM3A/U/X I/O Controller</b>
+ * @ingroup SAM3_defines
+ * LGPL License Terms @ref lgpl_license
+ * @author @htmlonly &copy; @endhtmlonly 2012
+ * Gareth McMullin <gareth@blacksphere.co.nz>
+ * @author @htmlonly &copy; @endhtmlonly 2014
+ * Felix Held <felix-libopencm3@felixheld.de>
+ *
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/sam/gpio.h>
+
+
+/** @brief Initialize GPIO pins
+ *
+ * @param[in] port uint32_t: GPIO Port base address
+ * @param[in] pin uint32_t
+ * @param[in] flags enum gpio_flags
+ */
+void gpio_init(uint32_t port, uint32_t pins, enum gpio_flags flags)
+{
+	switch (flags & 0x7) {
+	case GPIO_FLAG_GPINPUT:
+		PIO_ODR(port) = pins;
+		PIO_PER(port) = pins;
+		break;
+	case GPIO_FLAG_GPOUTPUT:
+		PIO_OER(port) = pins;
+		PIO_PER(port) = pins;
+		break;
+	case GPIO_FLAG_PERIPHA:
+		PIO_ABSR(port) &= ~pins;
+		PIO_PDR(port) = pins;
+		break;
+	case GPIO_FLAG_PERIPHB:
+		PIO_ABSR(port) |= pins;
+		PIO_PDR(port) = pins;
+	}
+
+	if (flags & GPIO_FLAG_OPEN_DRAIN) {
+		PIO_MDER(port) = pins;
+	} else {
+		PIO_MDDR(port) = pins;
+	}
+
+	if (flags & GPIO_FLAG_PULL_UP) {
+		PIO_PUER(port) = pins;
+	} else {
+		PIO_PUDR(port) = pins;
+	}
+}

--- a/lib/sam/common/gpio_common_all.c
+++ b/lib/sam/common/gpio_common_all.c
@@ -1,0 +1,66 @@
+/** @addtogroup gpio_defines
+ *
+ * @brief <b>Access functions for the SAM3 I/O Controller</b>
+ * @ingroup SAM3_defines
+ * LGPL License Terms @ref lgpl_license
+ * @author @htmlonly &copy; @endhtmlonly 2012
+ * Gareth McMullin <gareth@blacksphere.co.nz>
+ * @author @htmlonly &copy; @endhtmlonly 2014
+ * Felix Held <felix-libopencm3@felixheld.de>
+ *
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2014 Felix Held <felix-libopencm3@felixheld.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/sam/gpio.h>
+
+/** @brief Atomic set output
+ *
+ * @param[in] gpioport uint32_t: GPIO Port base address
+ * @param[in] gpios uint32_t
+ */
+void gpio_set(uint32_t gpioport, uint32_t gpios)
+{
+	PIO_SODR(gpioport) = gpios;
+}
+
+/** @brief Atomic clear output
+ *
+ * @param[in] gpioport uint32_t: GPIO Port base address
+ * @param[in] gpios uint32_t
+ */
+void gpio_clear(uint32_t gpioport, uint32_t gpios)
+{
+	PIO_CODR(gpioport) = gpios;
+}
+
+/** @brief Toggle output
+ *
+ * @param[in] gpioport uint32_t: GPIO Port base address
+ * @param[in] gpios uint32_t
+ */
+void gpio_toggle(uint32_t gpioport, uint32_t gpios)
+{
+	uint32_t odsr = PIO_ODSR(gpioport);
+	PIO_CODR(gpioport) = odsr & gpios;
+	PIO_SODR(gpioport) = ~odsr & gpios;
+}
+

--- a/lib/sam/common/pmc.c
+++ b/lib/sam/common/pmc.c
@@ -44,20 +44,29 @@ void pmc_plla_config(uint8_t mul, uint8_t div)
 
 void pmc_peripheral_clock_enable(uint8_t pid)
 {
+#if defined(PMC_PCER1)
 	if (pid < 32) {
 		PMC_PCER0 = 1 << pid;
 	} else {
 		PMC_PCER1 = 1 << (pid & 31);
 	}
+#else
+	//SAM3N and SAM3U only have one Peripheral Clock Enable Register
+	PMC_PCER = 1 << pid;
+#endif
 }
 
 void pmc_peripheral_clock_disable(uint8_t pid)
 {
+#if defined(PMC_PCER1)
 	if (pid < 32) {
 		PMC_PCDR0 = 1 << pid;
 	} else {
 		PMC_PCDR1 = 1 << (pid & 31);
 	}
+#else
+	PMC_PCDR = 1 << pid;
+#endif
 }
 
 void pmc_mck_set_source(enum mck_src src)


### PR DESCRIPTION
add the peripheral IDs, support for the power management controller and the GPIOs for all SAM3 subfamilies