### PR TITLE
stm32: common: Extract MCO source setting

### DIFF
--- a/include/libopencm3/stm32/common/rcc_common_all.h
+++ b/include/libopencm3/stm32/common/rcc_common_all.h
@@ -49,6 +49,8 @@ void rcc_periph_reset_pulse(enum rcc_periph_rst rst);
 void rcc_periph_reset_hold(enum rcc_periph_rst rst);
 void rcc_periph_reset_release(enum rcc_periph_rst rst);
 
+void rcc_set_mco(uint32_t mcosrc);
+
 END_DECLS
 /**@}*/
 

--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -95,16 +95,16 @@ Control</b>
 #define RCC_CFGR_MCOPRE_DIV128			(7 << RCC_CFGR_MCOPRE_SHIFT)
 
 #define RCC_CFGR_MCO_SHIFT			24
-#define RCC_CFGR_MCO				(15 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_NOCLK			(0 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_HSI14			(1 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_LSI			(2 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_LSE			(3 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_SYSCLK			(4 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_HSI			(5 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_HSE			(6 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_PLL			(7 << RCC_CFGR_MCO_SHIFT)
-#define RCC_CFGR_MCO_HSI48			(8 << RCC_CFGR_MCO_SHIFT)/*f07*/
+#define RCC_CFGR_MCO_MASK			0xf
+#define RCC_CFGR_MCO_NOCLK			0
+#define RCC_CFGR_MCO_HSI14			1
+#define RCC_CFGR_MCO_LSI			2
+#define RCC_CFGR_MCO_LSE			3
+#define RCC_CFGR_MCO_SYSCLK			4
+#define RCC_CFGR_MCO_HSI			5
+#define RCC_CFGR_MCO_HSE			6
+#define RCC_CFGR_MCO_PLL			7
+#define RCC_CFGR_MCO_HSI48			8
 
 #define RCC_CFGR_PLLMUL_SHIFT			18
 #define RCC_CFGR_PLLMUL				(0x0F << RCC_CFGR_PLLMUL_SHIFT)
@@ -506,7 +506,6 @@ void rcc_set_pll_multiplication_factor(uint32_t mul);
 void rcc_set_ppre(uint32_t ppre);
 void rcc_set_hpre(uint32_t hpre);
 void rcc_set_prediv(uint32_t prediv);
-void rcc_set_mco(uint32_t mcosrc);
 enum rcc_osc rcc_system_clock_source(void);
 enum rcc_osc rcc_usb_clock_source(void);
 void rcc_clock_setup_in_hsi_out_8mhz(void);

--- a/include/libopencm3/stm32/f1/rcc.h
+++ b/include/libopencm3/stm32/f1/rcc.h
@@ -77,9 +77,6 @@
 
 /* --- RCC_CFGR values ----------------------------------------------------- */
 
-#define RCC_CFGR_MCO_SHIFT			24
-#define RCC_CFGR_MCO				(0xF << RCC_CFGR_MCO_SHIFT)
-
 #define RCC_CFGR_OTGFSPRE			(1 << 22) /* Connectivity line */
 #define RCC_CFGR_USBPRE				(1 << 22) /* LD,MD, HD, XL */
 
@@ -112,6 +109,8 @@
 @ingroup STM32F1xx_rcc_defines
 
 @{*/
+#define RCC_CFGR_MCO_SHIFT			24
+#define RCC_CFGR_MCO_MASK			0xf
 #define RCC_CFGR_MCO_NOCLK			0x0
 #define RCC_CFGR_MCO_SYSCLK			0x4
 #define RCC_CFGR_MCO_HSICLK			0x5
@@ -690,7 +689,6 @@ void rcc_osc_on(enum rcc_osc osc);
 void rcc_osc_off(enum rcc_osc osc);
 void rcc_css_enable(void);
 void rcc_css_disable(void);
-void rcc_set_mco(uint32_t mcosrc);
 void rcc_osc_bypass_enable(enum rcc_osc osc);
 void rcc_osc_bypass_disable(enum rcc_osc osc);
 void rcc_set_sysclk_source(uint32_t clk);

--- a/include/libopencm3/stm32/f2/rcc.h
+++ b/include/libopencm3/stm32/f2/rcc.h
@@ -130,10 +130,13 @@
 
 /* MCO1: Microcontroller clock output 1 */
 #define RCC_CFGR_MCO1_SHIFT			21
+#define RCC_CFGR_MCO1_MASK			0x3
 #define RCC_CFGR_MCO1_HSI			0x0
 #define RCC_CFGR_MCO1_LSE			0x1
 #define RCC_CFGR_MCO1_HSE			0x2
 #define RCC_CFGR_MCO1_PLL			0x3
+#define RCC_CFGR_MCO_SHIFT			RCC_CFGR_MCO1_SHIFT
+#define RCC_CFGR_MCO_MASK			RCC_CFGR_MCO1_MASK
 
 /* RTCPRE: HSE division factor for RTC clock */
 #define RCC_CFGR_RTCPRE_SHIFT			16

--- a/include/libopencm3/stm32/f3/rcc.h
+++ b/include/libopencm3/stm32/f3/rcc.h
@@ -89,6 +89,7 @@
 
 /* MCO: Microcontroller clock output */
 #define RCC_CFGR_MCO_SHIFT			24
+#define RCC_CFGR_MCO_MASK			0x7
 #define RCC_CFGR_MCO_DISABLED			0x0
 /*Reserve RCC_CFGR_MCO				0x1*/
 #define RCC_CFGR_MCO_LSI			0x2

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -141,6 +141,8 @@
 #define RCC_CFGR_MCO1_LSE			0x1
 #define RCC_CFGR_MCO1_HSE			0x2
 #define RCC_CFGR_MCO1_PLL			0x3
+#define RCC_CFGR_MCO_SHIFT			RCC_CFGR_MCO1_SHIFT
+#define RCC_CFGR_MCO_MASK			RCC_CFGR_MCO1_MASK
 
 /* RTCPRE: HSE division factor for RTC clock */
 #define RCC_CFGR_RTCPRE_SHIFT			16

--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -136,6 +136,8 @@
 #define RCC_CFGR_MCO_LSICLK			0x6
 #define RCC_CFGR_MCO_LSECLK			0x7
 #define RCC_CFGR_MCO_HSI48CLK			0x8
+#define RCC_CFGR_MCO_SHIFT			24
+#define RCC_CFGR_MCO_MASK			0xf
 
 /* PLL Output division selection */
 #define RCC_CFGR_PLLDIV_DIV2	0x1

--- a/include/libopencm3/stm32/l1/rcc.h
+++ b/include/libopencm3/stm32/l1/rcc.h
@@ -119,6 +119,8 @@
 #define RCC_CFGR_MCOPRE_DIV4	    2
 #define RCC_CFGR_MCOPRE_DIV8	    3
 #define RCC_CFGR_MCOPRE_DIV16	    4
+#define RCC_CFGR_MCOPRE_SHIFT       28
+#define RCC_CFGR_MCOPRE             (0x7 << RCC_CFGR_MCOPRE_SHIFT)
 
 /* MCO: Microcontroller clock output */
 #define RCC_CFGR_MCO_NOCLK			0x0
@@ -129,6 +131,8 @@
 #define RCC_CFGR_MCO_PLLCLK			0x5
 #define RCC_CFGR_MCO_LSICLK			0x6
 #define RCC_CFGR_MCO_LSECLK			0x7
+#define RCC_CFGR_MCO_SHIFT			24
+#define RCC_CFGR_MCO_MASK			0x7
 
 /* PLL Output division selection */
 #define RCC_CFGR_PLLDIV_DIV2	0x1

--- a/lib/stm32/common/rcc_common_all.c
+++ b/lib/stm32/common/rcc_common_all.c
@@ -182,6 +182,21 @@ void rcc_periph_reset_release(enum rcc_periph_rst rst)
 {
 	_RCC_REG(rst) &= ~_RCC_BIT(rst);
 }
+
+/** @brief Select the source of Microcontroller Clock Output
+ *
+ * Exact sources available depend on your target.  On devices with multiple
+ * MCO pins, this function controls MCO1
+ *
+ * @parame[in] mcosrc the unshifted source bits
+ */
+
+void rcc_set_mco(uint32_t mcosrc)
+{
+	RCC_CFGR = (RCC_CFGR & ~(RCC_CFGR_MCO_MASK << RCC_CFGR_MCO_SHIFT)) |
+			(mcosrc << RCC_CFGR_MCO_SHIFT);
+}
+
 /**@}*/
 
 #undef _RCC_REG

--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -488,11 +488,6 @@ void rcc_set_prediv(uint32_t prediv)
 }
 
 
-void rcc_set_mco(uint32_t mcosrc)
-{
-	RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_MCO) | mcosrc;
-}
-
 /*---------------------------------------------------------------------------*/
 /** @brief RCC Get the System Clock Source.
  *

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -594,13 +594,6 @@ void rcc_set_prediv1_source(uint32_t rccsrc)
 		RCC_CFGR2 &= ~RCC_CFGR2_PREDIV1SRC;
 }
 
-void rcc_set_mco(uint32_t mcosrc)
-{
-	RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_MCO) |
-			(mcosrc << RCC_CFGR_MCO_SHIFT);
-
-}
-
 /*---------------------------------------------------------------------------*/
 /** @brief RCC Get the System Clock Source.
 


### PR DESCRIPTION
This adds MCO source selection to some targets, and removes and standardizes
the mask/shift usage for all targets.  For devices that support MCO2, this
supports only MCO1.  No attempt has been made to extract MCO prescaler, which
is not available on all F1 and F3.

This is a replacement for https://github.com/libopencm3/libopencm3/pull/395
