### PR TITLE
[cortex.h] Added missing include

### DIFF
--- a/include/libopencm3/cm3/cortex.h
+++ b/include/libopencm3/cm3/cortex.h
@@ -31,6 +31,8 @@
 #ifndef LIBOPENCM3_CORTEX_H
 #define LIBOPENCM3_CORTEX_H
 
+#include <libopencm3/cm3/common.h>
+
 /**@{*/
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The include adds missing definitions of bool and uint32_t.

If included in code, this header will produce 'unknown type' compilation errors unless stdbool.h and stdint.h are included before it. In order for the header file to be self-sufficient, stdbool.h and stdint.h need to be included. Since most headers here seem to include common.h when they need them, I did that too.
