### PR TITLE
sam: add UART helper functions.

### DIFF
--- a/include/libopencm3/sam/uart.h
+++ b/include/libopencm3/sam/uart.h
@@ -23,16 +23,21 @@
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/sam/memorymap.h>
 
+/* --- Convenience macros ------------------------------------------------ */
+#define UART				UART_BASE
+#define UART0				UART0_BASE
+#define UART1				UART1_BASE
+
 /* --- Universal Asynchronous Receiver Transmitter (UART) registers ------- */
-#define UART_CR				MMIO32(UART_BASE + 0x0000)
-#define UART_MR				MMIO32(UART_BASE + 0x0004)
-#define UART_IER			MMIO32(UART_BASE + 0x0008)
-#define UART_IDR			MMIO32(UART_BASE + 0x000C)
-#define UART_IMR			MMIO32(UART_BASE + 0x0010)
-#define UART_SR				MMIO32(UART_BASE + 0x0014)
-#define UART_RHR			MMIO32(UART_BASE + 0x0018)
-#define UART_THR			MMIO32(UART_BASE + 0x001C)
-#define UART_BRGR			MMIO32(UART_BASE + 0x0020)
+#define UART_CR(x)			MMIO32((x) + 0x0000)
+#define UART_MR(x)			MMIO32((x) + 0x0004)
+#define UART_IER(x)			MMIO32((x) + 0x0008)
+#define UART_IDR(x)			MMIO32((x) + 0x000C)
+#define UART_IMR(x)			MMIO32((x) + 0x0010)
+#define UART_SR(x)			MMIO32((x) + 0x0014)
+#define UART_RHR(x)			MMIO32((x) + 0x0018)
+#define UART_THR(x)			MMIO32((x) + 0x001C)
+#define UART_BRGR(x)		MMIO32((x) + 0x0020)
 /* 0x0024:0x003C - Reserved */
 /* 0x004C:0x00FC - Reserved */
 /* 0x0100:0x0124 - PDC Area */
@@ -80,6 +85,35 @@
 /* Bit [2] - Reserved */
 #define UART_SR_TXRDY			(0x01 << 1)
 #define UART_SR_RXRDY			(0x01 << 0)
+
+enum uart_parity {
+	UART_PARITY_EVEN,
+	UART_PARITY_ODD,
+	UART_PARITY_SPACE,
+	UART_PARITY_MARK,
+	UART_PARITY_NONE,
+};
+
+enum uart_mode {
+	UART_MODE_DISABLED,
+	UART_MODE_RX,
+	UART_MODE_TX,
+	UART_MODE_TX_RX,
+};
+
+void uart_set_baudrate(uint32_t uart, uint32_t baud);
+void uart_set_parity(uint32_t uart, enum uart_parity);
+void uart_set_mode(uint32_t uart, enum uart_mode);
+void uart_enable(uint32_t uart);
+void uart_disable(uint32_t uart);
+void uart_send(uint32_t uart, uint8_t data);
+uint8_t uart_recv(uint32_t uart);
+void uart_wait_send_ready(uint32_t uart);
+void uart_wait_recv_ready(uint32_t uart);
+void uart_send_blocking(uint32_t uart, uint8_t data);
+uint8_t uart_recv_blocking(uint32_t uart);
+void uart_enable_rx_interrupt(uint32_t uart);
+void uart_disable_rx_interrupt(uint32_t uart);
 
 #endif
 

--- a/lib/sam/3a/Makefile
+++ b/lib/sam/3a/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -Wall -Wextra -I../../../include -fno-common \
 CFLAGS          += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o uart.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/3n/Makefile
+++ b/lib/sam/3n/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -Wall -Wextra -I../../../include -fno-common \
 CFLAGS          += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o uart.o usart.o
 
 VPATH += ../../cm3:../common
 

--- a/lib/sam/3s/Makefile
+++ b/lib/sam/3s/Makefile
@@ -31,7 +31,7 @@ CFLAGS		= -Os -Wall -Wextra -I../../../include -fno-common \
 CFLAGS          += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o uart.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/3u/Makefile
+++ b/lib/sam/3u/Makefile
@@ -31,7 +31,7 @@ CFLAGS		= -Os -Wall -Wextra -I../../../include -fno-common \
 CFLAGS          += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o uart.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/3x/Makefile
+++ b/lib/sam/3x/Makefile
@@ -30,7 +30,7 @@ CFLAGS		= -Os -Wall -Wextra -I../../../include -fno-common \
 CFLAGS          += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3a3u3x.o pmc.o uart.o usart.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/common/uart.c
+++ b/lib/sam/common/uart.c
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2014 Owen Kirby <oskirby@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/sam/uart.h>
+#include <libopencm3/sam/pmc.h>
+
+void uart_set_baudrate(uint32_t uart, uint32_t baud)
+{
+	UART_BRGR(uart) = pmc_mck_frequency / (16 * baud);
+}
+
+void uart_set_parity(uint32_t uart, enum uart_parity par)
+{
+	UART_MR(uart) = (UART_MR(uart) & ~UART_MR_PAR_MASK) | (par << 9);
+}
+
+void uart_set_mode(uint32_t uart, enum uart_mode mode)
+{
+	UART_CR(uart) = (mode & UART_MODE_RX) ? UART_CR_RXEN : UART_CR_RXDIS;
+	UART_CR(uart) = (mode & UART_MODE_TX) ? UART_CR_TXEN : UART_CR_TXDIS;
+}
+
+void uart_enable(uint32_t uart)
+{
+	(void)uart;
+}
+
+void uart_disable(uint32_t uart)
+{
+	(void)uart;
+}
+
+void uart_send(uint32_t uart, uint8_t data)
+{
+	UART_THR(uart) = data;
+}
+
+void uart_send_blocking(uint32_t uart, uint8_t data)
+{
+	while (!(UART_SR(uart) & UART_SR_TXRDY));
+	uart_send(uart, data);
+}
+
+uint8_t uart_recv(uint32_t uart)
+{
+	return UART_RHR(uart) & 0xff;
+}
+
+uint8_t uart_recv_blocking(uint32_t uart)
+{
+	while (!(UART_SR(uart) & UART_SR_RXRDY));
+	return uart_recv(uart);
+}
+
+void uart_enable_rx_interrupt(uint32_t uart)
+{
+	UART_IER(uart) = UART_SR_RXRDY;
+}
+
+void uart_disable_rx_interrupt(uint32_t uart)
+{
+	UART_IDR(uart) = UART_SR_RXRDY;
+}
+


### PR DESCRIPTION
This patch adds some helper functions to access the UART on the Atmel SAM chips. The UART appears to be common across all of the SAM3 variants. The API was chosen to be as close to the USART as possible.