### PR TITLE
sam: add USB (full speed) driver for SAM3S family

### DIFF
--- a/include/libopencm3/sam/3s/pmc.h
+++ b/include/libopencm3/sam/3s/pmc.h
@@ -56,6 +56,10 @@
 #define CKGR_PLLBR_DIVB_SHIFT		0
 #define CKGR_PLLBR_DIVB_MASK		(0xFF << CKGR_PLLBR_DIVB_SHIFT)
 
+/* --- PMC System Clock Enable Register (PMC_SCER) ------------------------- */
+
+/* USB Device Port Clock Enable */
+#define PMC_SCER_UDP			(0x01 << 7)
 
 /* --- PMC Master Clock Register (PMC_MCKR) -------------------------------- */
 
@@ -134,5 +138,12 @@
 #define PMC_OCR_CAL4_SHIFT		0
 #define PMC_OCR_CAL4_MASK		(0x7F << PMC_OCR_CAL12_SHIFT)
 
+enum usbck_src {
+	USBCK_SRC_PLLA = 0,
+	USBCK_SRC_PLLB = 1,
+};
+
+void pmc_usb_set_source(enum usbck_src src);
+void pmc_pllb_config(uint8_t mul, uint8_t div);
 
 #endif

--- a/include/libopencm3/sam/udp.h
+++ b/include/libopencm3/sam/udp.h
@@ -1,0 +1,134 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Owen Kirby <osk@exegin.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SAM3X_UDP_H
+#define SAM3X_UDP_H
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/sam/memorymap.h>
+
+/* --- USB Device Port registers ------------------------------------------ */
+
+#define UDP_FRM_NUM			MMIO32(UDP_BASE + 0x00)
+#define UDP_GLB_STAT		MMIO32(UDP_BASE + 0x04)
+#define UDP_FADDR			MMIO32(UDP_BASE + 0x08)
+/* 0x0C reserved */
+#define UDP_IER				MMIO32(UDP_BASE + 0x10)
+#define UDP_IDR				MMIO32(UDP_BASE + 0x14)
+#define UDP_IMR				MMIO32(UDP_BASE + 0x18)
+#define UDP_ISR				MMIO32(UDP_BASE + 0x1C)
+#define UDP_ICR				MMIO32(UDP_BASE + 0x20)
+/* 0x24 reserved */
+#define UDP_RST				MMIO32(UDP_BASE + 0x28)
+/* 0x2C reserved */
+#define UDP_CSR(x)			MMIO32(UDP_BASE + 0x30 + 0x4*(x))
+#define UDP_FDR(x)			MMIO32(UDP_BASE + 0x50 + 0x4*(x))
+/* 0x70 reserved */
+#define UDP_TXVC			MMIO32(UDP_BASE + 0x74)
+/* 0x78:0xFC reserved */
+
+/* UDP Frame Number Register (UDP_FRM_NUM) */
+/* Bits [31:18] - Reserved */
+#define UDP_FRM_NUM_OK			(0x01 << 17)
+#define UDP_FRM_NUM_ERR			(0x01 << 16)
+/* Bits [15:11] - Reserved */
+#define UDP_FRM_NUM_MASK		(0x7FF << 0)
+
+/* UDP Global State Register (UDP_GLB_STAT) */
+/* Bits [31:5] - Reserved */
+#define UDP_GLB_STAT_RMWUPE		(0x01 << 4)
+#define UDP_GLB_STAT_RSMINPR	(0x01 << 3)
+#define UDP_GLB_STAT_ESR		(0x01 << 2)
+#define UDP_GLB_STAT_CONFG		(0x01 << 1)
+#define UDP_GLB_STAT_FADDEN		(0x01 << 0)
+
+/* UDP Function Address Register (UDP_FADDR) */
+/* Bits [31:9] - Reserved */
+#define UDP_FADDR_FEN			(0x01 << 8)
+/* Bit 7 - Reserved */
+#define UDP_FADDR_MASK			(0x7F << 0)
+
+/* UDP Interrupt Registers (UDP_IER, UDP_IDR, UDP_IMR, UDP_ISR, and UDP_ICR) */
+/* Bits [31:14] - Reserved */
+#define UDP_INT_WAKEUP			(0x01 << 13)
+#define UDP_INT_ENDBUSRES		(0x01 << 12)
+#define UDP_INT_SOFINT			(0x01 << 11)
+#define UDP_INT_EXTRSM			(0x01 << 10)
+#define UDP_INT_RXRSM			(0x01 << 9)
+#define UDP_INT_RXSUSP			(0x01 << 8)
+#define UDP_INT_EP(x)			(0x01 << (x))
+
+/* UDP Reset Endpoint Register (UDP_RST) */
+/* Bits [31:8] - Reserved */
+#define UDP_RST_EP(x)			(0x01 << (x))
+#define UDP_RST_ALL				(0xFF << 0)
+
+/* UDP Endpoint Control and Stauts Register (UDP_CSR(x)) */
+/* Bits [31:27] - Reserved */
+#define UDP_CSR_RXBYTECNT_MASK		(0x7FF << 16)
+#define UDP_CSR_GET_RXBYTECNT(x)	(((x) >> 16) & 0x7FF)
+#define UDP_CSR_EPEDS				(0x01 << 15)
+/* Bits [14:12] - Reserved */
+#define UDP_CSR_DTGLE				(0x01 << 11)
+#define UDP_CSR_EPTYPE_MASK			(0x07 << 8)
+#define UDP_CSR_EPTYPE_IN	 		(0x04 << 8)
+#define UDP_CSR_EPTYPE_CTRL			(0x00 << 8)
+#define UDP_CSR_EPTYPE_ISO			(0x01 << 8)
+#define UDP_CSR_EPTYPE_BULK			(0x02 << 8)
+#define UDP_CSR_EPTYPE_INT			(0x03 << 8)
+#define UDP_CSR_EPTYPE_ISO_OUT		(UDP_CSR_EPTYPE_ISO)
+#define UDP_CSR_EPTYPE_ISO_IN		(UDP_CSR_EPTYPE_ISO | UDP_CSR_EPTYPE_IN)
+#define UDP_CSR_EPTYPE_BULK_OUT		(UDP_CSR_EPTYPE_BULK)
+#define UDP_CSR_EPTYPE_BULK_IN		(UDP_CSR_EPTYPE_BULK | UDP_CSR_EPTYPE_IN)
+#define UDP_CSR_EPTYPE_INT_OUT		(UDP_CSR_EPTYPE_INT)
+#define UDP_CSR_EPTYPE_INT_IN		(UDP_CSR_EPTYPE_INT | UDP_CSR_EPTYPE_IN)
+#define UDP_CSR_DIR					(0x01 << 7)
+#define UDP_CSR_RX_DATA_BK1			(0x01 << 6)
+#define UDP_CSR_FORCESTALL			(0x01 << 5)
+#define UDP_CSR_TXPKTRDY			(0x01 << 4)
+#define UDP_CSR_STALLSENT			(0x01 << 3)
+#define UDP_CSR_ISOERROR			(0x01 << 3)
+#define UDP_CSR_RXSETUP				(0x01 << 2)
+#define UDP_CSR_RX_DATA_BK0			(0x01 << 1)
+#define UDP_CSR_TXCOMP				(0x01 << 0)
+/* UDP_CSRx bits that must be set high for a no-op. */
+#define UDP_CSR_WRITE_NOP		 	(UDP_CSR_TXCOMP | UDP_CSR_RX_DATA_BK0 | \
+									UDP_CSR_RXSETUP | UDP_CSR_STALLSENT | \
+									UDP_CSR_ISOERROR | UDP_CSR_RX_DATA_BK1)
+
+/* UDP FIFO Data Register (UDP_FDR(x)) */
+/* Bits [31:8] - Reserved */
+#define UDP_FDR_MASK			(0xFF << 0)
+
+/* UDP Transceiver Control Register (UDP_TXVC) */
+/* Bits [31:10] - Reserved */
+#define UDP_TXVC_PUON			(0x01 << 9)
+#define UDP_TXVC_TXVDIS			(0x01 << 8)
+/* Bits [7:0] - Reserved */
+
+/* USB Endpoint description */
+#define UDP_EP_COUNT			8
+#define UDP_EP_DUAL_BANK(x)		((x != 0) && (x != 3))
+#define UDP_EP_MAX_SIZE(x)		( ((x == 4) || (x == 5)) ? 512 : 64)
+#define UDP_EP_SUPPORT_CTRL(x)	(!UDP_EP_DUAL_BANK(x))
+#define UDP_EP_SUPPORT_ISO(x)	UDP_EP_DUAL_BANK(x)
+/* All endpoint support bulk and interrupt transfers */
+
+#endif
+

--- a/include/libopencm3/sam/usb.h
+++ b/include/libopencm3/sam/usb.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SAM3X_USB_H
+#define SAM3X_USB_H
+
+#if defined(SAM3A)
+#elif defined(SAM3N)
+#elif defined(SAM3S)
+#       include <libopencm3/sam/udp.h>
+#elif defined(SAM3U)
+#elif defined(SAM3X)
+#else
+#       error "sam family not defined."
+#endif
+
+#endif
+

--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -57,6 +57,7 @@ extern const usbd_driver stm32f107_usb_driver;
 extern const usbd_driver stm32f207_usb_driver;
 #define otgfs_usb_driver stm32f107_usb_driver
 #define otghs_usb_driver stm32f207_usb_driver
+extern const usbd_driver sam_udp_usb_driver;
 
 /* <usb.c> */
 extern usbd_device * usbd_init(const usbd_driver *driver,

--- a/lib/sam/3s/Makefile
+++ b/lib/sam/3s/Makefile
@@ -31,7 +31,9 @@ CFLAGS		= -Os -Wall -Wextra -I../../../include -fno-common \
 CFLAGS          += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
-OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o usart.o
+OBJS		= gpio_common_all.o gpio_common_3n3s.o pmc.o pmc_common_3s.o usart.o
+
+OBJS		+= usb.o usb_control.o usb_standard.o usb_sam_udp.o usb_msc.o
 
 VPATH += ../../usb:../../cm3:../common
 

--- a/lib/sam/common/pmc_common_3s.c
+++ b/lib/sam/common/pmc_common_3s.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Owen Kirby <oskirby@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/sam/pmc.h>
+
+void pmc_pllb_config(uint8_t mul, uint8_t div)
+{
+	CKGR_PLLBR = ((mul - 1) << 16) | CKGR_PLLBR_PLLBCOUNT_MASK | div;
+	while (!(PMC_SR & PMC_SR_LOCKB));
+}
+
+void pmc_usb_set_source(enum usbck_src src)
+{
+	PMC_USB = (PMC_USB & ~PMC_USB_USBDIV_MASK) | src;
+	PMC_SCER = PMC_SCER_UDP;
+}
+
+

--- a/lib/usb/usb_sam_udp.c
+++ b/lib/usb/usb_sam_udp.c
@@ -1,0 +1,313 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Owen Kirby <osk@exegin.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/sam/pmc.h>
+#include <libopencm3/sam/usb.h>
+#include <libopencm3/sam/periph.h>
+#include <libopencm3/usb/usbd.h>
+#include "usb_private.h"
+
+static usbd_device *udp_init(void);
+static void udp_set_address(usbd_device *usbd_dev, uint8_t addr);
+static void udp_ep_setup(usbd_device *usbd_dev, uint8_t addr,
+					uint8_t type, uint16_t max_size,
+					void (*callback) (usbd_device *usbd_dev, uint8_t ep));
+static void udp_endpoints_reset(usbd_device *usbd_dev);
+static void udp_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall);
+static uint8_t udp_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);
+static void udp_ep_nak_set(usbd_device *usbd_dev, uint8_t addr, uint8_t nak);
+static uint16_t udp_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
+					  const void *buf, uint16_t len);
+static uint16_t udp_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
+					 void *buf, uint16_t len);
+static void udp_poll(usbd_device *usbd_dev);
+
+static struct _usbd_device udp_dev;
+
+const struct _usbd_driver sam_udp_usb_driver = {
+	.init = udp_init,
+	.set_address = udp_set_address,
+	.ep_setup = udp_ep_setup,
+	.ep_reset = udp_endpoints_reset,
+	.ep_stall_set = udp_ep_stall_set,
+	.ep_stall_get = udp_ep_stall_get,
+	.ep_nak_set = udp_ep_nak_set,
+	.ep_write_packet = udp_ep_write_packet,
+	.ep_read_packet = udp_ep_read_packet,
+	.poll = udp_poll,
+};
+
+static void
+udp_csr_set(uint8_t ep, uint32_t bits)
+{
+	uint32_t csr = UDP_CSR(ep);
+	UDP_CSR(ep) = csr | UDP_CSR_WRITE_NOP | bits;
+	while ((UDP_CSR(ep) & bits) != bits);
+} /* udp_csr_set */
+
+static void
+udp_csr_clear(uint8_t ep, uint32_t bits)
+{
+	uint32_t csr = (UDP_CSR(ep) | UDP_CSR_WRITE_NOP) & ~bits;
+	UDP_CSR(ep) = csr;
+	while ((UDP_CSR(ep) & bits) == bits);
+} /* udp_csr_clear */
+
+/** Initialize the USB device port hardware of the SAM. */
+static usbd_device *udp_init(void)
+{
+	/* Reset the transceiver. */
+	pmc_peripheral_clock_enable(PERIPH_UDP);
+	UDP_TXVC &= ~UDP_TXVC_TXVDIS;
+	UDP_TXVC |= UDP_TXVC_PUON;
+	
+	/* Enable interrupts. */
+	UDP_IER = UDP_INT_WAKEUP | UDP_INT_SOFINT |
+			UDP_INT_EXTRSM | UDP_INT_RXRSM | UDP_INT_RXSUSP;
+	return &udp_dev;
+}
+
+static void udp_set_address(usbd_device *dev, uint8_t addr)
+{
+	(void)dev;
+	UDP_FADDR = (addr & UDP_FADDR_MASK) | UDP_FADDR_FEN;
+	UDP_GLB_STAT = (addr) ? UDP_GLB_STAT_FADDEN : 0;
+} /* udp_set_address */
+
+static void udp_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
+				   uint16_t max_size,
+				   void (*callback) (usbd_device *usbd_dev, uint8_t ep))
+{
+	uint8_t dir = (addr & 0x80) ? USB_TRANSACTION_IN : USB_TRANSACTION_OUT;
+	uint32_t csr = UDP_CSR_WRITE_NOP | UDP_CSR_EPEDS;
+	addr &= 0x7f;
+	if (addr >= UDP_EP_COUNT) {
+		return;
+	}
+	
+	/* Set the endpoint configuration. */
+	if (dir == USB_TRANSACTION_IN) csr |= UDP_CSR_EPTYPE_IN;
+	UDP_RST |= UDP_RST_EP(addr);
+	UDP_RST &= ~UDP_RST_EP(addr);
+	switch (type) {
+	case USB_ENDPOINT_ATTR_CONTROL:
+		if (!UDP_EP_SUPPORT_CTRL(addr)) return; /* TODO: Handle errors? */
+		UDP_CSR(addr) = csr | UDP_CSR_EPTYPE_CTRL;
+		break;
+	
+	case USB_ENDPOINT_ATTR_ISOCHRONOUS:
+		if (!UDP_EP_SUPPORT_ISO(addr)) return; /* TODO: Handle errors? */
+		UDP_CSR(addr) = csr | UDP_CSR_EPTYPE_ISO;
+		break;
+	
+	case USB_ENDPOINT_ATTR_BULK:
+		UDP_CSR(addr) = csr | UDP_CSR_EPTYPE_BULK;
+		break;
+	
+	case USB_ENDPOINT_ATTR_INTERRUPT:
+		UDP_CSR(addr) = csr | UDP_CSR_EPTYPE_INT;
+		break;
+	}
+	if (callback) {
+		dev->user_callback_ctr[addr][dir] = (void *)callback;
+	}
+	
+	/* TODO: What if the selected size is too big for the endpoint? */
+	/* TODO: min(UDP_EP_MAX_SIZE(addr), max_size)? */
+	dev->pm_top += max_size;
+	
+	/* Enable the endpoint interrupts. */
+	UDP_IER = UDP_INT_EP(addr);
+}
+
+static void udp_endpoints_reset(usbd_device *dev)
+{
+	UDP_RST = UDP_RST_ALL;
+	UDP_RST = 0;
+	dev->pm_top = 0x40 + (2 * dev->desc->bMaxPacketSize0);
+	
+	/* If the current config is non-zero, we are entering the configured state,
+	 * otherwise, fall back to the address state. */
+	UDP_GLB_STAT = (dev->current_config) ? UDP_GLB_STAT_CONFG : UDP_GLB_STAT_FADDEN;
+} /* udp_endpoints_reset */ 
+
+static void udp_ep_stall_set(usbd_device *dev, uint8_t addr,
+				   uint8_t stall)
+{
+	(void)dev;
+	addr &= 0x7F;
+	if (addr >= UDP_EP_COUNT) {
+		return;
+	}
+	if (stall) {
+		udp_csr_set(addr, UDP_CSR_FORCESTALL);
+	} else {
+		udp_csr_clear(addr, UDP_CSR_FORCESTALL | UDP_CSR_STALLSENT);
+	}
+}
+
+static uint8_t udp_ep_stall_get(usbd_device *dev, uint8_t addr)
+{
+	(void)dev;
+	addr &= 0x7F;
+	if (addr >= UDP_EP_COUNT) {
+		return 0;
+	}
+	return ((UDP_CSR(addr) & UDP_CSR_FORCESTALL) == UDP_CSR_FORCESTALL);
+}
+
+static void udp_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
+{
+	(void)dev;
+	/* It does not make sence to force NAK on IN endpoints. */
+	if (addr & 0x80) {
+		return;
+	}
+	if (addr >= UDP_EP_COUNT) {
+		return;
+	}
+	/* Disable the endpoint to force a NAK. */
+	if (nak) {
+		udp_csr_clear(addr, UDP_CSR_EPEDS);
+	} else {
+		udp_csr_set(addr, UDP_CSR_EPEDS);
+	}
+}
+
+static uint16_t udp_ep_write_packet(usbd_device *dev, uint8_t addr,
+					 const void *buf, uint16_t len)
+{
+	(void)dev;
+	const uint8_t *p = buf;
+	const uint8_t *end = p + len;
+	addr &= 0x7F;
+	if (addr >= UDP_EP_COUNT) {
+		return 0;
+	}
+	
+	/* TODO: This assumes a non ping-pong endpoint, we could improve throughput
+	 * on ping-pong endpoints by skipping this check to fill the 2nd FIFO, but
+	 * then we need to add some bookkeeping to know if the 2nd FIFO is already
+	 * in use or not.
+	 */
+	if ((UDP_CSR(addr) & UDP_CSR_TXPKTRDY) == UDP_CSR_TXPKTRDY) {
+		return 0;
+	}
+	
+	while (p < end) UDP_FDR(addr) = *p++;
+	udp_csr_set(addr, UDP_CSR_TXPKTRDY);
+	return len;
+}
+
+static uint16_t udp_ep_read_packet(usbd_device *dev, uint8_t addr,
+					 void *buf, uint16_t len)
+{
+	(void)dev;
+	uint32_t csr, rxbit;
+	uint8_t *p = buf;
+	uint8_t *end;
+	if (addr >= UDP_EP_COUNT) {
+		return 0;
+	}
+	
+	/* TODO: What happens when both FIFOs of a ping-pong endpoint are filled? */
+	csr = UDP_CSR(addr);
+	rxbit = csr & (UDP_CSR_RX_DATA_BK0 | UDP_CSR_RX_DATA_BK1 | UDP_CSR_RXSETUP);
+	if (rxbit == 0) {
+		return 0;
+	}
+
+	len = MIN(UDP_CSR_GET_RXBYTECNT(csr), len);
+	end = p + len;
+	while (p < end) *p++ = UDP_FDR(addr);
+	if ((csr & UDP_CSR_RXSETUP) && (*(uint8_t*)buf & 0x80)) {
+		udp_csr_set(addr, UDP_CSR_DIR);
+	}
+	udp_csr_clear(addr, rxbit);
+	return len;
+}
+
+static void udp_poll_ep(usbd_device *dev, uint8_t ep)
+{
+	uint32_t csr = UDP_CSR(ep);
+	
+	if (csr & UDP_CSR_RXSETUP) {
+		if (dev->user_callback_ctr[ep][USB_TRANSACTION_SETUP]) {
+			dev->user_callback_ctr[ep][USB_TRANSACTION_SETUP](dev, ep);
+		} else {
+			udp_csr_clear(ep, UDP_CSR_RXSETUP);
+		}
+	}
+	if (csr & (UDP_CSR_RX_DATA_BK0 | UDP_CSR_RX_DATA_BK1)) {
+		if (dev->user_callback_ctr[ep][USB_TRANSACTION_OUT]) {
+			dev->user_callback_ctr[ep][USB_TRANSACTION_OUT](dev, ep);
+		} else {
+			udp_csr_clear(ep, UDP_CSR_RX_DATA_BK0 | UDP_CSR_RX_DATA_BK1);
+		}
+	}
+	if (csr & UDP_CSR_TXCOMP) {
+		if (dev->user_callback_ctr[ep][USB_TRANSACTION_IN]) {
+			dev->user_callback_ctr[ep][USB_TRANSACTION_IN](dev, ep);
+		}
+		udp_csr_clear(ep, UDP_CSR_TXCOMP);
+	}
+	if (csr & UDP_CSR_STALLSENT) {
+		UDP_CSR(ep) = (csr | UDP_CSR_WRITE_NOP) & ~UDP_CSR_STALLSENT;
+	}
+}
+
+static void udp_poll(usbd_device *dev)
+{
+	int i;
+
+	if (UDP_ISR & UDP_INT_ENDBUSRES) {
+		dev->pm_top = 0x40; /* ??? */
+		_usbd_reset(dev);
+		UDP_ICR = UDP_INT_ENDBUSRES;
+		return;
+	}
+
+	/* Endpoint interrupts. */
+	for (i = 0; i < UDP_EP_COUNT; i++) {
+		if (UDP_ISR & UDP_INT_EP(i)) udp_poll_ep(dev, i);
+	}
+
+	if (UDP_ISR & UDP_INT_RXSUSP) {
+		UDP_ICR = UDP_INT_RXSUSP;
+		if (dev->user_callback_suspend) {
+			dev->user_callback_suspend();
+		}
+	}
+
+	if (UDP_ISR & (UDP_INT_WAKEUP | UDP_INT_RXRSM)) {
+		UDP_ICR = UDP_INT_WAKEUP | UDP_INT_RXRSM;
+		if (dev->user_callback_resume) {
+			dev->user_callback_resume();
+		}
+	}
+
+	if (UDP_ISR & UDP_INT_SOFINT) {
+		UDP_ICR = UDP_INT_SOFINT;
+		if (dev->user_callback_sof) {
+			dev->user_callback_sof();
+		}
+	}
+}


### PR DESCRIPTION
This adds a full-speed USB driver for the SAM3S family. In the Atmel datasheets this is referred to as the UDP peripheral, and is common to the SAM3S, SAM4S and SAM4E chips.