### PR TITLE
added 84 MHz sysclk as option since this is maximum for stm32f401

### DIFF
--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -548,6 +548,7 @@ extern uint32_t rcc_apb2_frequency;
 
 typedef enum {
 	CLOCK_3V3_48MHZ,
+	CLOCK_3V3_84MHZ,
 	CLOCK_3V3_120MHZ,
 	CLOCK_3V3_168MHZ,
 	CLOCK_3V3_END

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -64,6 +64,20 @@ const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
 	},
+	{ /* 84MHz */
+		.pllm = 8,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.power_save = 1,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_3WS,
+		.apb1_frequency = 21000000,
+		.apb2_frequency = 42000000,
+	},
 	{ /* 120MHz */
 		.pllm = 8,
 		.plln = 240,
@@ -107,6 +121,20 @@ const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END] = {
 				FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
+	},
+		{ /* 84MHz */
+		.pllm = 12,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.power_save = 1,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_3WS,
+		.apb1_frequency = 21000000,
+		.apb2_frequency = 42000000,
 	},
 	{ /* 120MHz */
 		.pllm = 12,
@@ -152,6 +180,20 @@ const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END] = {
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
 	},
+		{ /* 84MHz */
+		.pllm = 16,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.power_save = 1,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_3WS,
+		.apb1_frequency = 21000000,
+		.apb2_frequency = 42000000,
+	},
 	{ /* 120MHz */
 		.pllm = 16,
 		.plln = 240,
@@ -196,6 +238,21 @@ const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END] = {
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
 	},
+		{ /* 84MHz */
+		.pllm = 25,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.power_save = 1,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_3WS,
+		.apb1_frequency = 21000000,
+		.apb2_frequency = 42000000,
+	},
+
 	{ /* 120MHz */
 		.pllm = 25,
 		.plln = 240,


### PR DESCRIPTION
Added 84Mhz as a SYSCLK option when running on HSE oscillator.
This is the maximum frequency for STM32F401