### PR TITLE
STM32 FS USB support for L0, F0, F1

### DIFF
--- a/include/libopencm3/stm32/common/usb_common_all.h
+++ b/include/libopencm3/stm32/common/usb_common_all.h
@@ -1,0 +1,309 @@
+/** @defgroup adc_defines USB Defines
+
+@brief <b>Defined Constants and Types for the STM32F1xx USB Module</b>
+
+@ingroup STM32F1xx_defines
+
+@version 1.0.0
+
+@author @htmlonly &copy; @endhtmlonly 2009
+Piotr Esden-Tempski <piotr@esden.net>
+
+@date 11 March 2013
+
+LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Piotr Esden-Tempski <piotr@esden.net>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+/** @cond */
+#ifdef LIBOPENCM3_USB_H
+/** @endcond */
+#ifndef LIBOPENCM3_USB_COMMON_ALL_H
+#define LIBOPENCM3_USB_COMMON_ALL_H
+
+#include <libopencm3/stm32/tools.h>
+
+/* --- USB base addresses -------------------------------------------------- */
+
+/* USB packet buffer memory base address. */
+#define USB_PMA_BASE		0x40006000L
+
+/* --- USB general registers ----------------------------------------------- */
+
+/* USB Control register */
+#define USB_CNTR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x40))
+/* USB Interrupt status register */
+#define USB_ISTR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x44))
+/* USB Frame number register */
+#define USB_FNR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x48))
+/* USB Device address register */
+#define USB_DADDR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x4C))
+/* USB Buffer table address register */
+#define USB_BTABLE_REG		(&MMIO32(USB_DEV_FS_BASE + 0x50))
+
+#define USB_LPMCSR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x54))
+#define USB_BDCR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x58))
+
+/* USB EP register */
+#define USB_EP_REG(EP)		(&MMIO32(USB_DEV_FS_BASE) + (EP))
+
+/* --- USB control register masks / bits ----------------------------------- */
+
+/* Interrupt mask bits, set to 1 to enable interrupt generation */
+#define USB_CNTR_CTRM		0x8000
+#define USB_CNTR_PMAOVRM	0x4000
+#define USB_CNTR_ERRM		0x2000
+#define USB_CNTR_WKUPM		0x1000
+#define USB_CNTR_SUSPM		0x0800
+#define USB_CNTR_RESETM		0x0400
+#define USB_CNTR_SOFM		0x0200
+#define USB_CNTR_ESOFM		0x0100
+
+/* Request/Force bits */
+#define USB_CNTR_L1REQM		0x0080 /* F0 port */
+#define USB_CNTR_L1RESUME	0x0020 /* F0 port */
+#define USB_CNTR_RESUME		0x0010 /* Resume request */
+#define USB_CNTR_FSUSP		0x0008 /* Force suspend */
+#define USB_CNTR_LP_MODE	0x0004 /* Low-power mode */
+#define USB_CNTR_PWDN		0x0002 /* Power down */
+#define USB_CNTR_FRES		0x0001 /* Force reset */
+
+/* --- USB interrupt status register masks / bits -------------------------- */
+
+#define USB_ISTR_CTR		0x8000 /* Correct Transfer */
+#define USB_ISTR_PMAOVR		0x4000 /* Packet Memory Area Over / Underrun */
+#define USB_ISTR_ERR		0x2000 /* Error */
+#define USB_ISTR_WKUP		0x1000 /* Wake up */
+#define USB_ISTR_SUSP		0x0800 /* Suspend mode request */
+#define USB_ISTR_RESET		0x0400 /* USB RESET request */
+#define USB_ISTR_SOF		0x0200 /* Start Of Frame */
+#define USB_ISTR_ESOF		0x0100 /* Expected Start Of Frame */
+#define USB_ISTR_L1REQ		0x0080
+#define USB_ISTR_DIR		0x0010 /* Direction of transaction */
+#define USB_ISTR_EP_ID		0x000F /* Endpoint Identifier */
+
+/* --- USB interrupt status register manipulators -------------------------- */
+
+/* Note: CTR is read only! */
+#define USB_CLR_ISTR_PMAOVR()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_PMAOVR)
+#define USB_CLR_ISTR_ERR()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_ERR)
+#define USB_CLR_ISTR_WKUP()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_WKUP)
+#define USB_CLR_ISTR_SUSP()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_SUSP)
+#define USB_CLR_ISTR_RESET()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_RESET)
+#define USB_CLR_ISTR_SOF()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_SOF)
+#define USB_CLR_ISTR_ESOF()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_ESOF)
+
+/* --- USB device address register masks / bits ---------------------------- */
+
+#define USB_DADDR_ENABLE	0x0080
+#define USB_DADDR_ADDR		0x007F
+
+#define USB_LPMCSR_BESL_SHIFT	4
+#define USB_LPMCSR_BESL		(15 << USB_LPMCSR_BESL_SHIFT)
+
+#define USB_LPMCSR_REMWAKE	(1 << 3)
+#define USB_LPMCSR_LPMACK	(1 << 1)
+#define USB_LPMCSR_LPMEN	(1 << 0)
+
+#define USB_BDCR_DPPU		(1 << 15)
+#define USB_BDCR_PS2DET		(1 << 7)
+#define USB_BDCR_SDET		(1 << 6)
+#define USB_BDCR_PDET		(1 << 5)
+#define USB_BDCR_DCDET		(1 << 4)
+#define USB_BDCR_SDEN		(1 << 3)
+#define USB_BDCR_PDEN		(1 << 2)
+#define USB_BDCR_DCDEN		(1 << 1)
+#define USB_BDCR_BCDEN		(1 << 0)
+
+/* --- USB device address register manipulators ---------------------------- */
+
+/* --- USB endpoint register offsets --------------------------------------- */
+
+#define USB_EP0			0
+#define USB_EP1			1
+#define USB_EP2			2
+#define USB_EP3			3
+#define USB_EP4			4
+#define USB_EP5			5
+#define USB_EP6			6
+#define USB_EP7			7
+
+/* --- USB endpoint register masks / bits ---------------------------------- */
+
+/* Masks and toggle bits */
+#define USB_EP_RX_CTR		0x8000 /* Correct transfer RX */
+#define USB_EP_RX_DTOG		0x4000 /* Data toggle RX */
+#define USB_EP_RX_STAT		0x3000 /* Endpoint status for RX */
+
+#define USB_EP_SETUP		0x0800 /* Setup transaction completed */
+#define USB_EP_TYPE		0x0600 /* Endpoint type */
+#define USB_EP_KIND		0x0100 /* Endpoint kind.
+				* When set and type=bulk    -> double buffer
+				* When set and type=control -> status out
+				*/
+
+#define USB_EP_TX_CTR		0x0080 /* Correct transfer TX */
+#define USB_EP_TX_DTOG		0x0040 /* Data toggle TX */
+#define USB_EP_TX_STAT		0x0030 /* Endpoint status for TX */
+
+#define USB_EP_ADDR		0x000F /* Endpoint Address */
+
+/* Masking all toggle bits */
+#define USB_EP_NTOGGLE_MSK	(USB_EP_RX_CTR | \
+				 USB_EP_SETUP | \
+				 USB_EP_TYPE | \
+				 USB_EP_KIND | \
+				 USB_EP_TX_CTR | \
+				 USB_EP_ADDR)
+
+/* All non toggle bits plus EP_RX toggle bits */
+#define USB_EP_RX_STAT_TOG_MSK	(USB_EP_RX_STAT | USB_EP_NTOGGLE_MSK)
+/* All non toggle bits plus EP_TX toggle bits */
+#define USB_EP_TX_STAT_TOG_MSK	(USB_EP_TX_STAT | USB_EP_NTOGGLE_MSK)
+
+/* Endpoint status bits for USB_EP_RX_STAT bit field */
+#define USB_EP_RX_STAT_DISABLED	0x0000
+#define USB_EP_RX_STAT_STALL	0x1000
+#define USB_EP_RX_STAT_NAK	0x2000
+#define USB_EP_RX_STAT_VALID	0x3000
+
+/* Endpoint status bits for USB_EP_TX_STAT bit field */
+#define USB_EP_TX_STAT_DISABLED	0x0000
+#define USB_EP_TX_STAT_STALL	0x0010
+#define USB_EP_TX_STAT_NAK	0x0020
+#define USB_EP_TX_STAT_VALID	0x0030
+
+/* Endpoint type bits for USB_EP_TYPE bit field */
+#define USB_EP_TYPE_BULK	0x0000
+#define USB_EP_TYPE_CONTROL	0x0200
+#define USB_EP_TYPE_ISO		0x0400
+#define USB_EP_TYPE_INTERRUPT	0x0600
+
+/* --- USB endpoint register manipulators ---------------------------------- */
+
+/*
+ * Set USB endpoint tx/rx status.
+ *
+ * USB status field is changed using an awkward toggle mechanism, that
+ * is why we use some helper macros for that.
+ */
+#define USB_SET_EP_RX_STAT(EP, STAT) \
+	TOG_SET_REG_BIT_MSK(USB_EP_REG(EP), USB_EP_RX_STAT_TOG_MSK, STAT)
+
+#define USB_SET_EP_TX_STAT(EP, STAT) \
+	TOG_SET_REG_BIT_MSK(USB_EP_REG(EP), USB_EP_TX_STAT_TOG_MSK, STAT)
+
+/*
+ * Macros for clearing and setting USB endpoint register bits that do
+ * not use the toggle mechanism.
+ *
+ * Because the register contains some bits that use the toggle
+ * mechanism we need a helper macro here. Otherwise the code gets really messy.
+ */
+#define USB_CLR_EP_NTOGGLE_BIT(EP, BIT) \
+	CLR_REG_BIT_MSK(USB_EP_REG(EP), USB_EP_NTOGGLE_MSK, BIT)
+
+#define USB_CLR_EP_RX_CTR(EP) \
+	USB_CLR_EP_NTOGGLE_BIT(EP, USB_EP_RX_CTR)
+
+#define USB_CLR_EP_TX_CTR(EP) \
+	USB_CLR_EP_NTOGGLE_BIT(EP, USB_EP_TX_CTR)
+
+#define USB_SET_EP_TYPE(EP, TYPE) \
+	SET_REG(USB_EP_REG(EP), \
+		(GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK & \
+		(~USB_EP_TYPE))) | TYPE)
+
+#define USB_SET_EP_KIND(EP) \
+	SET_REG(USB_EP_REG(EP), \
+		(GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK & \
+		(~USB_EP_KIND))) | USB_EP_KIND)
+
+#define USB_CLR_EP_KIND(EP) \
+	SET_REG(USB_EP_REG(EP), \
+		(GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK & (~USB_EP_KIND))))
+
+#define USB_SET_EP_STAT_OUT(EP)	USB_SET_EP_KIND(EP)
+#define USB_CLR_EP_STAT_OUT(EP)	USB_CLR_EP_KIND(EP)
+
+#define USB_SET_EP_ADDR(EP, ADDR) \
+	SET_REG(USB_EP_REG(EP), \
+		((GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK & \
+		(~USB_EP_ADDR))) | ADDR))
+
+/* Macros for clearing DTOG bits */
+#define USB_CLR_EP_TX_DTOG(EP) \
+	SET_REG(USB_EP_REG(EP), \
+		GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK | USB_EP_TX_DTOG))
+
+#define USB_CLR_EP_RX_DTOG(EP) \
+	SET_REG(USB_EP_REG(EP), \
+		GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK | USB_EP_RX_DTOG))
+
+/* --- USB BTABLE registers ------------------------------------------------ */
+
+#define USB_GET_BTABLE		GET_REG(USB_BTABLE_REG)
+
+#define USB_EP_TX_ADDR(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 0) * 2))
+
+#define USB_EP_TX_COUNT(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 2) * 2))
+
+#define USB_EP_RX_ADDR(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 4) * 2))
+
+#define USB_EP_RX_COUNT(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 6) * 2))
+
+/* --- USB BTABLE manipulators --------------------------------------------- */
+
+#define USB_GET_EP_TX_ADDR(EP)		GET_REG(USB_EP_TX_ADDR(EP))
+#define USB_GET_EP_TX_COUNT(EP)		GET_REG(USB_EP_TX_COUNT(EP))
+#define USB_GET_EP_RX_ADDR(EP)		GET_REG(USB_EP_RX_ADDR(EP))
+#define USB_GET_EP_RX_COUNT(EP)		GET_REG(USB_EP_RX_COUNT(EP))
+#define USB_SET_EP_TX_ADDR(EP, ADDR)	SET_REG(USB_EP_TX_ADDR(EP), ADDR)
+#define USB_SET_EP_TX_COUNT(EP, COUNT)	SET_REG(USB_EP_TX_COUNT(EP), COUNT)
+#define USB_SET_EP_RX_ADDR(EP, ADDR)	SET_REG(USB_EP_RX_ADDR(EP), ADDR)
+#define USB_SET_EP_RX_COUNT(EP, COUNT)	SET_REG(USB_EP_RX_COUNT(EP), COUNT)
+
+#define USB_GET_EP_TX_BUFF(EP) \
+	(USB_PMA_BASE + (uint8_t *)(USB_GET_EP_TX_ADDR(EP) * 2))
+
+#define USB_GET_EP_RX_BUFF(EP) \
+	(USB_PMA_BASE + (uint8_t *)(USB_GET_EP_RX_ADDR(EP) * 2))
+
+/**@}*/
+
+#endif
+/** @cond */
+#else
+#warning "usb_common_all.h should not be included explicitly, only via usb.h"
+#endif
+/** @endcond */
+

--- a/include/libopencm3/stm32/common/usb_common_v1.h
+++ b/include/libopencm3/stm32/common/usb_common_v1.h
@@ -1,0 +1,74 @@
+/** @addtogroup usb_defines
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA USB.H
+ * The order of header inclusion is important. usart.h includes the device
+ * specific memorymap.h header before including this header file.*/
+
+/** @cond */
+#ifdef LIBOPENCM3_USB_H
+/** @endcond */
+#ifndef LIBOPENCM3_USB_COMMON_V1_H
+#define LIBOPENCM3_USB_COMMON_V1_H
+
+#include <libopencm3/stm32/common/usb_common_all.h>
+
+/* --- USB BTABLE registers ------------------------------------------------ */
+
+/*****************************************************************************/
+/* Module definitions                                                        */
+/*****************************************************************************/
+
+/*****************************************************************************/
+/* Register definitions                                                      */
+/*****************************************************************************/
+
+/*****************************************************************************/
+/* Register values                                                           */
+/*****************************************************************************/
+
+/* USB_BTABLE Values ------------------------------------------------------- */
+
+#define USB_EP_TX_ADDR(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 0) * 2))
+
+#define USB_EP_TX_COUNT(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 2) * 2))
+
+#define USB_EP_RX_ADDR(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 4) * 2))
+
+#define USB_EP_RX_COUNT(EP) \
+	((uint32_t *)(USB_PMA_BASE + (USB_GET_BTABLE + EP * 8 + 6) * 2))
+
+/* --- USB BTABLE manipulators --------------------------------------------- */
+
+#define USB_GET_EP_TX_BUFF(EP) \
+	(USB_PMA_BASE + (uint8_t *)(USB_GET_EP_TX_ADDR(EP) * 2))
+
+#define USB_GET_EP_RX_BUFF(EP) \
+	(USB_PMA_BASE + (uint8_t *)(USB_GET_EP_RX_ADDR(EP) * 2))
+
+#endif
+/** @cond */
+#else
+#warning "usb_common_v1.h should not be included directly, only via usb.h"
+#endif
+/** @endcond */
+

--- a/include/libopencm3/stm32/common/usb_common_v2.h
+++ b/include/libopencm3/stm32/common/usb_common_v2.h
@@ -1,0 +1,105 @@
+/** @addtogroup usb_defines
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA USB.H
+ * The order of header inclusion is important. usart.h includes the device
+ * specific memorymap.h header before including this header file.*/
+
+/** @cond */
+#ifdef LIBOPENCM3_USB_H
+/** @endcond */
+#ifndef LIBOPENCM3_USB_COMMON_V2_H
+#define LIBOPENCM3_USB_COMMON_V2_H
+
+#include <libopencm3/stm32/common/usb_common_all.h>
+
+/*****************************************************************************/
+/* Module definitions                                                        */
+/*****************************************************************************/
+
+/*****************************************************************************/
+/* Register definitions                                                      */
+/*****************************************************************************/
+
+#define USB_LPMCSR		MMIO32(USB_DEV_FS_BASE + 0x54)
+#define USB_BDCR		MMIO32(USB_DEV_FS_BASE + 0x58)
+
+/*****************************************************************************/
+/* Register values                                                           */
+/*****************************************************************************/
+
+/* USB_CNTR Values ----------------------------------------------------------*/
+
+#define USB_CNTR_L1REQM		(1 << 7)
+#define USB_CNTR_L1RESUME	(1 << 5)
+
+/* USB_ISTR Values ----------------------------------------------------------*/
+
+#define USB_ISTR_L1REQ		(1 << 5)
+
+/* USB_LPMCSR Values --------------------------------------------------------*/
+
+#define USB_LPMCSR_BESL_SHIFT	4
+#define USB_LPMCSR_BESL		(15 << USB_LPMCSR_BESL_SHIFT)
+
+#define USB_LPMCSR_REMWAKE	(1 << 3)
+#define USB_LPMCSR_LPMACK	(1 << 1)
+#define USB_LPMCSR_LPMEN	(1 << 0)
+
+/* USB_BDCR Values ----------------------------------------------------------*/
+
+#define USB_BDCR_DPPU		(1 << 15)
+#define USB_BDCR_PS2DET		(1 << 7)
+#define USB_BDCR_SDET		(1 << 6)
+#define USB_BDCR_PDET		(1 << 5)
+#define USB_BDCR_DCDET		(1 << 4)
+#define USB_BDCR_SDEN		(1 << 3)
+#define USB_BDCR_PDEN		(1 << 2)
+#define USB_BDCR_DCDEN		(1 << 1)
+#define USB_BDCR_BCDEN		(1 << 0)
+
+/* --- USB BTABLE registers ------------------------------------------------ */
+
+#define USB_EP_TX_ADDR(ep) \
+	((uint16_t *)(USB_PMA_BASE + (USB_GET_BTABLE + (ep) * 8 + 0) * 1))
+
+#define USB_EP_TX_COUNT(ep) \
+	((uint16_t *)(USB_PMA_BASE + (USB_GET_BTABLE + (ep) * 8 + 2) * 1))
+
+#define USB_EP_RX_ADDR(ep) \
+	((uint16_t *)(USB_PMA_BASE + (USB_GET_BTABLE + (ep) * 8 + 4) * 1))
+
+#define USB_EP_RX_COUNT(ep) \
+	((uint16_t *)(USB_PMA_BASE + (USB_GET_BTABLE + (ep) * 8 + 6) * 1))
+
+/* --- USB BTABLE manipulators --------------------------------------------- */
+
+#define USB_GET_EP_TX_BUFF(ep) \
+	(USB_PMA_BASE + (uint8_t *)(USB_GET_EP_TX_ADDR(ep) * 1))
+
+#define USB_GET_EP_RX_BUFF(ep) \
+	(USB_PMA_BASE + (uint8_t *)(USB_GET_EP_RX_ADDR(ep) * 1))
+
+#endif
+/** @cond */
+#else
+#warning "usb_common_v2.h should not be included directly, only via usb.h"
+#endif
+/** @endcond */
+

--- a/include/libopencm3/stm32/f0/usb.h
+++ b/include/libopencm3/stm32/f0/usb.h
@@ -18,6 +18,6 @@
 #ifndef LIBOPENCM3_USB_H
 #define LIBOPENCM3_USB_H
 
-#include <libopencm3/stm32/common/usb_common_v1.h>
+#include <libopencm3/stm32/common/usb_common_v2.h>
 
 #endif

--- a/include/libopencm3/stm32/f1/usb.h
+++ b/include/libopencm3/stm32/f1/usb.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over STM32F subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -17,18 +15,9 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_USB_H
+#define LIBOPENCM3_USB_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/usb.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/usb.h>
-#elif defined(STM32F3)
-#       include <libopencm3/stm32/f3/usb.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/usb.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/usb_common_all.h>
+
 #endif
-

--- a/include/libopencm3/stm32/f3/usb.h
+++ b/include/libopencm3/stm32/f3/usb.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over STM32F subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -17,18 +15,9 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_USB_H
+#define LIBOPENCM3_USB_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/usb.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/usb.h>
-#elif defined(STM32F3)
-#       include <libopencm3/stm32/f3/usb.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/usb.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/usb_common_all.h>
+
 #endif
-

--- a/include/libopencm3/stm32/f3/usb.h
+++ b/include/libopencm3/stm32/f3/usb.h
@@ -18,6 +18,6 @@
 #ifndef LIBOPENCM3_USB_H
 #define LIBOPENCM3_USB_H
 
-#include <libopencm3/stm32/common/usb_common_all.h>
+#include <libopencm3/stm32/common/usb_common_v1.h>
 
 #endif

--- a/include/libopencm3/stm32/l0/usb.h
+++ b/include/libopencm3/stm32/l0/usb.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over STM32F subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -17,20 +15,9 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_USB_H
+#define LIBOPENCM3_USB_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/usb.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/usb.h>
-#elif defined(STM32F3)
-#       include <libopencm3/stm32/f3/usb.h>
-#elif defined(STM32L0)
-#       include <libopencm3/stm32/l0/usb.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/usb.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/usb_common_v2.h>
+
 #endif
-

--- a/include/libopencm3/stm32/l1/usb.h
+++ b/include/libopencm3/stm32/l1/usb.h
@@ -1,5 +1,3 @@
-/* This provides unification of code over STM32F subfamilies */
-
 /*
  * This file is part of the libopencm3 project.
  *
@@ -17,18 +15,9 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_USB_H
+#define LIBOPENCM3_USB_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/usb.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/usb.h>
-#elif defined(STM32F3)
-#       include <libopencm3/stm32/f3/usb.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/usb.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/usb_common_all.h>
+
 #endif
-

--- a/include/libopencm3/stm32/l1/usb.h
+++ b/include/libopencm3/stm32/l1/usb.h
@@ -18,6 +18,6 @@
 #ifndef LIBOPENCM3_USB_H
 #define LIBOPENCM3_USB_H
 
-#include <libopencm3/stm32/common/usb_common_all.h>
+#include <libopencm3/stm32/common/usb_common_v1.h>
 
 #endif

--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -55,6 +55,7 @@ typedef struct _usbd_device usbd_device;
 extern const usbd_driver stm32f103_usb_driver;
 extern const usbd_driver stm32f107_usb_driver;
 extern const usbd_driver stm32f207_usb_driver;
+extern const usbd_driver stm32f0x2_usb_driver;
 #define otgfs_usb_driver stm32f107_usb_driver
 #define otghs_usb_driver stm32f207_usb_driver
 

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -44,6 +44,8 @@ OBJS            += gpio_common_all.o gpio_common_f0234.o crc_common_all.o \
 		   spi_common_f03.o flash_common_f01.o dac_common_all.o \
 		   timer_common_all.o rcc_common_all.o crs.o
 
+OBJS		+= usb.o usb_control.o usb_standard.o usb_f0x2.o
+
 VPATH += ../../usb:../:../../cm3:../common
 
 include ../../Makefile.include

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -44,7 +44,7 @@ OBJS            += gpio_common_all.o gpio_common_f0234.o crc_common_all.o \
 		   spi_common_f03.o flash_common_f01.o dac_common_all.o \
 		   timer_common_all.o rcc_common_all.o crs.o
 
-OBJS		+= usb.o usb_control.o usb_standard.o usb_f0x2.o
+OBJS		+= usb.o usb_control.o usb_standard.o stm32_usbfs_common.o usb_f0x2.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -47,7 +47,7 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_l1f013.o \
                    flash_common_f01.o
 
 OBJS            += usb.o usb_control.o usb_standard.o usb_f103.o usb_f107.o \
-                   usb_fx07_common.o usb_msc.o
+                   usb_fx07_common.o stm32_usbfs_common.o usb_msc.o
 
 VPATH += ../../usb:../:../../cm3:../common:../../ethernet
 

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -39,7 +39,7 @@ OBJS		= gpio.o rcc.o
 
 OBJS            += gpio_common_all.o gpio_common_f0234.o rcc_common_all.o
 
-OBJS		+= usb.o usb_control.o usb_standard.o usb_f0x2.o
+OBJS		+= usb.o usb_control.o usb_standard.o stm32_usbfs_common.o usb_f0x2.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -39,6 +39,8 @@ OBJS		= gpio.o rcc.o
 
 OBJS            += gpio_common_all.o gpio_common_f0234.o rcc_common_all.o
 
+OBJS		+= usb.o usb_control.o usb_standard.o usb_f0x2.o
+
 VPATH += ../../usb:../:../../cm3:../common
 
 include ../../Makefile.include

--- a/lib/usb/stm32_usbfs_common.c
+++ b/lib/usb/stm32_usbfs_common.c
@@ -1,0 +1,272 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Robin Kreis <r.kreis@uni-bremen.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/tools.h>
+#include <libopencm3/stm32/usb.h>
+#include <libopencm3/usb/usbd.h>
+#include "usb_private.h"
+#include "stm32_usbfs_common.h"
+
+uint8_t stm32_usbfs_force_nak[8];
+struct _usbd_device stm32_usbfs_dev;
+
+void stm32_usbfs_set_address(usbd_device *dev, uint8_t addr)
+{
+	(void)dev;
+	/* Set device address and enable. */
+	SET_REG(USB_DADDR_REG, (addr & USB_DADDR_ADDR) | USB_DADDR_EF);
+}
+
+/**
+ * Set the receive buffer size for a given USB endpoint.
+ *
+ * @param ep Index of endpoint to configure.
+ * @param size Size in bytes of the RX buffer.
+ */
+void stm32_usbfs_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size)
+{
+	(void)dev;
+	if (size > 62) {
+		if (size & 0x1f) {
+			size -= 32;
+		}
+		USB_SET_EP_RX_COUNT(ep, (size << 5) | 0x8000);
+	} else {
+		if (size & 1) {
+			size++;
+		}
+		USB_SET_EP_RX_COUNT(ep, size << 10);
+	}
+}
+
+void stm32_usbfs_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
+		uint16_t max_size,
+		void (*callback) (usbd_device *usbd_dev,
+		uint8_t ep))
+{
+	/* Translate USB standard type codes to STM32. */
+	const uint16_t typelookup[] = {
+		[USB_ENDPOINT_ATTR_CONTROL] = USB_EP_TYPE_CONTROL,
+		[USB_ENDPOINT_ATTR_ISOCHRONOUS] = USB_EP_TYPE_ISO,
+		[USB_ENDPOINT_ATTR_BULK] = USB_EP_TYPE_BULK,
+		[USB_ENDPOINT_ATTR_INTERRUPT] = USB_EP_TYPE_INTERRUPT,
+	};
+	uint8_t dir = addr & 0x80;
+	addr &= 0x7f;
+
+	/* Assign address. */
+	USB_SET_EP_ADDR(addr, addr);
+	USB_SET_EP_TYPE(addr, typelookup[type]);
+
+	if (dir || (addr == 0)) {
+		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
+		if (callback) {
+			dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
+			    (void *)callback;
+		}
+		USB_CLR_EP_TX_DTOG(addr);
+		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
+		dev->pm_top += max_size;
+	}
+
+	if (!dir) {
+		USB_SET_EP_RX_ADDR(addr, dev->pm_top);
+		stm32_usbfs_set_ep_rx_bufsize(dev, addr, max_size);
+		if (callback) {
+			dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
+			    (void *)callback;
+		}
+		USB_CLR_EP_RX_DTOG(addr);
+		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
+		dev->pm_top += max_size;
+	}
+}
+
+void stm32_usbfs_endpoints_reset(usbd_device *dev)
+{
+	int i;
+
+	/* Reset all endpoints. */
+	for (i = 1; i < 8; i++) {
+		USB_SET_EP_TX_STAT(i, USB_EP_TX_STAT_DISABLED);
+		USB_SET_EP_RX_STAT(i, USB_EP_RX_STAT_DISABLED);
+	}
+	dev->pm_top = USBD_PM_TOP + (2 * dev->desc->bMaxPacketSize0);
+}
+
+void stm32_usbfs_ep_stall_set(usbd_device *dev, uint8_t addr,
+				   uint8_t stall)
+{
+	(void)dev;
+	if (addr == 0) {
+		USB_SET_EP_TX_STAT(addr, stall ? USB_EP_TX_STAT_STALL :
+				   USB_EP_TX_STAT_NAK);
+	}
+
+	if (addr & 0x80) {
+		addr &= 0x7F;
+
+		USB_SET_EP_TX_STAT(addr, stall ? USB_EP_TX_STAT_STALL :
+				   USB_EP_TX_STAT_NAK);
+
+		/* Reset to DATA0 if clearing stall condition. */
+		if (!stall) {
+			USB_CLR_EP_TX_DTOG(addr);
+		}
+	} else {
+		/* Reset to DATA0 if clearing stall condition. */
+		if (!stall) {
+			USB_CLR_EP_RX_DTOG(addr);
+		}
+
+		USB_SET_EP_RX_STAT(addr, stall ? USB_EP_RX_STAT_STALL :
+				   USB_EP_RX_STAT_VALID);
+	}
+}
+
+uint8_t stm32_usbfs_ep_stall_get(usbd_device *dev, uint8_t addr)
+{
+	(void)dev;
+	if (addr & 0x80) {
+		if ((*USB_EP_REG(addr & 0x7F) & USB_EP_TX_STAT) ==
+		    USB_EP_TX_STAT_STALL) {
+			return 1;
+		}
+	} else {
+		if ((*USB_EP_REG(addr) & USB_EP_RX_STAT) ==
+		    USB_EP_RX_STAT_STALL) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+void stm32_usbfs_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
+{
+	(void)dev;
+	/* It does not make sence to force NAK on IN endpoints. */
+	if (addr & 0x80) {
+		return;
+	}
+
+	stm32_usbfs_force_nak[addr] = nak;
+
+	if (nak) {
+		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_NAK);
+	} else {
+		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
+	}
+}
+
+uint16_t stm32_usbfs_ep_write_packet(usbd_device *dev, uint8_t addr,
+				     const void *buf, uint16_t len)
+{
+	(void)dev;
+	addr &= 0x7F;
+
+	if ((*USB_EP_REG(addr) & USB_EP_TX_STAT) == USB_EP_TX_STAT_VALID) {
+		return 0;
+	}
+
+	stm32_usbfs_copy_to_pm(USB_GET_EP_TX_BUFF(addr), buf, len);
+	USB_SET_EP_TX_COUNT(addr, len);
+	USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_VALID);
+
+	return len;
+}
+
+uint16_t stm32_usbfs_ep_read_packet(usbd_device *dev, uint8_t addr,
+					 void *buf, uint16_t len)
+{
+	(void)dev;
+	if ((*USB_EP_REG(addr) & USB_EP_RX_STAT) == USB_EP_RX_STAT_VALID) {
+		return 0;
+	}
+
+	len = MIN(USB_GET_EP_RX_COUNT(addr) & 0x3ff, len);
+	stm32_usbfs_copy_from_pm(buf, USB_GET_EP_RX_BUFF(addr), len);
+	USB_CLR_EP_RX_CTR(addr);
+
+	if (!stm32_usbfs_force_nak[addr]) {
+		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
+	}
+
+	return len;
+}
+
+void stm32_usbfs_poll(usbd_device *dev)
+{
+	uint16_t istr = *USB_ISTR_REG;
+
+	if (istr & USB_ISTR_RESET) {
+		USB_CLR_ISTR_RESET();
+		dev->pm_top = USBD_PM_TOP;
+		_usbd_reset(dev);
+		return;
+	}
+
+	if (istr & USB_ISTR_CTR) {
+		uint8_t ep = istr & USB_ISTR_EP_ID;
+		uint8_t type;
+
+		if (istr & USB_ISTR_DIR) {
+			/* OUT or SETUP? */
+			if (*USB_EP_REG(ep) & USB_EP_SETUP) {
+				type = USB_TRANSACTION_SETUP;
+			} else {
+				type = USB_TRANSACTION_OUT;
+			}
+		} else {
+			type = USB_TRANSACTION_IN;
+			USB_CLR_EP_TX_CTR(ep);
+		}
+
+		if (dev->user_callback_ctr[ep][type]) {
+			dev->user_callback_ctr[ep][type] (dev, ep);
+		}
+
+		if(istr & USB_ISTR_DIR) {
+			USB_CLR_EP_RX_CTR(ep);
+		}
+	}
+
+	if (istr & USB_ISTR_SUSP) {
+		USB_CLR_ISTR_SUSP();
+		if (dev->user_callback_suspend) {
+			dev->user_callback_suspend();
+		}
+	}
+
+	if (istr & USB_ISTR_WKUP) {
+		USB_CLR_ISTR_WKUP();
+		if (dev->user_callback_resume) {
+			dev->user_callback_resume();
+		}
+	}
+
+	if (istr & USB_ISTR_SOF) {
+		USB_CLR_ISTR_SOF();
+		if (dev->user_callback_sof) {
+			dev->user_callback_sof();
+		}
+	}
+}

--- a/lib/usb/stm32_usbfs_common.h
+++ b/lib/usb/stm32_usbfs_common.h
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Robin Kreis <r.kreis@uni-bremen.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef STM32_USBFS_COMMON_H
+#define STM32_USBFS_COMMON_H
+
+#include <libopencm3/stm32/usb.h>
+#include <libopencm3/usb/usbd.h>
+
+#define USBD_PM_TOP 0x40
+
+void stm32_usbfs_set_address(usbd_device *dev, uint8_t addr);
+void stm32_usbfs_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size);
+
+void stm32_usbfs_ep_setup(usbd_device *usbd_dev, uint8_t addr,
+		uint8_t type, uint16_t max_size,
+		void (*callback) (usbd_device *usbd_dev,
+		uint8_t ep));
+
+void stm32_usbfs_endpoints_reset(usbd_device *usbd_dev);
+void stm32_usbfs_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall);
+uint8_t stm32_usbfs_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);
+void stm32_usbfs_ep_nak_set(usbd_device *usbd_dev, uint8_t addr, uint8_t nak);
+uint16_t stm32_usbfs_ep_write_packet(usbd_device *usbd_dev, uint8_t addr, const void *buf, uint16_t len);
+uint16_t stm32_usbfs_ep_read_packet(usbd_device *usbd_dev, uint8_t addr, void *buf, uint16_t len);
+void stm32_usbfs_poll(usbd_device *usbd_dev);
+
+/* These must be implemented by the device specific driver */
+
+/**
+ * Copy a data buffer to packet memory.
+ *
+ * @param vPM Destination pointer into packet memory.
+ * @param buf Source pointer to data buffer.
+ * @param len Number of bytes to copy.
+ */
+void stm32_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len);
+
+/**
+ * Copy a data buffer from packet memory.
+ *
+ * @param buf Source pointer to data buffer.
+ * @param vPM Destination pointer into packet memory.
+ * @param len Number of bytes to copy.
+ */
+void stm32_usbfs_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len);
+
+extern uint8_t stm32_usbfs_force_nak[8];
+extern struct _usbd_device stm32_usbfs_dev;
+
+#endif

--- a/lib/usb/usb_f0x2.c
+++ b/lib/usb/usb_f0x2.c
@@ -46,6 +46,8 @@ static void stm32f0x2_poll(usbd_device *usbd_dev);
 static uint8_t force_nak[8];
 static struct _usbd_device usbd_dev;
 
+#define USBD_PM_TOP 0x40
+
 const struct _usbd_driver stm32f0x2_usb_driver = {
 	.init = stm32f0x2_usbd_init,
 	.set_address = stm32f0x2_set_address,
@@ -155,7 +157,7 @@ static void stm32f0x2_endpoints_reset(usbd_device *dev)
 		USB_SET_EP_TX_STAT(i, USB_EP_TX_STAT_DISABLED);
 		USB_SET_EP_RX_STAT(i, USB_EP_RX_STAT_DISABLED);
 	}
-	dev->pm_top = 0x40 + (2 * dev->desc->bMaxPacketSize0);
+	dev->pm_top = USBD_PM_TOP + (2 * dev->desc->bMaxPacketSize0);
 }
 
 static void stm32f0x2_ep_stall_set(usbd_device *dev, uint8_t addr,
@@ -302,7 +304,7 @@ static void stm32f0x2_poll(usbd_device *dev)
 	uint16_t istr = *USB_ISTR_REG;
 
 	if (istr & USB_ISTR_RESET) {
-		dev->pm_top = 0x40;
+		dev->pm_top = USBD_PM_TOP;
 		_usbd_reset(dev);
 		USB_CLR_ISTR_RESET();
 		return;

--- a/lib/usb/usb_f0x2.c
+++ b/lib/usb/usb_f0x2.c
@@ -27,6 +27,7 @@
 #include "stm32_usbfs_common.h"
 
 static usbd_device *stm32f0x2_usbd_init(void);
+static void stm32f0x2_usbd_disconnect(usbd_device *usbd_dev, bool disconnected);
 
 const struct _usbd_driver stm32f0x2_usb_driver = {
 	.init = stm32f0x2_usbd_init,
@@ -39,6 +40,7 @@ const struct _usbd_driver stm32f0x2_usb_driver = {
 	.ep_write_packet = stm32_usbfs_ep_write_packet,
 	.ep_read_packet = stm32_usbfs_ep_read_packet,
 	.poll = stm32_usbfs_poll,
+	.disconnect = stm32f0x2_usbd_disconnect
 };
 
 /** Initialize the USB device controller hardware of the STM32. */
@@ -92,5 +94,18 @@ void stm32_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 
 	if (odd) {
 		*(uint8_t *) lbuf = *(uint8_t *) PM;
+	}
+}
+
+static void stm32f0x2_usbd_disconnect(usbd_device *usbd_dev, bool disconnected)
+{
+	(void) usbd_dev;
+	
+	if(disconnected) {
+		USB_CNTR |= USB_CNTR_PWDN;
+		USB_BDCR &= ~USB_BDCR_DPPU;
+	} else {
+		USB_CNTR &= ~USB_CNTR_PWDN;
+		USB_BDCR |= USB_BDCR_DPPU;
 	}
 }

--- a/lib/usb/usb_f0x2.c
+++ b/lib/usb/usb_f0x2.c
@@ -24,41 +24,21 @@
 #include <libopencm3/stm32/usb.h>
 #include <libopencm3/usb/usbd.h>
 #include "usb_private.h"
+#include "stm32_usbfs_common.h"
 
 static usbd_device *stm32f0x2_usbd_init(void);
-static void stm32f0x2_set_address(usbd_device *usbd_dev, uint8_t addr);
-static void stm32f0x2_ep_setup(usbd_device *usbd_dev, uint8_t addr,
-			       uint8_t type, uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep));
-static void stm32f0x2_endpoints_reset(usbd_device *usbd_dev);
-static void stm32f0x2_ep_stall_set(usbd_device *usbd_dev, uint8_t addr,
-				   uint8_t stall);
-static uint8_t stm32f0x2_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);
-static void stm32f0x2_ep_nak_set(usbd_device *usbd_dev, uint8_t addr,
-				 uint8_t nak);
-static uint16_t stm32f0x2_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
-					  const void *buf, uint16_t len);
-static uint16_t stm32f0x2_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
-					 void *buf, uint16_t len);
-static void stm32f0x2_poll(usbd_device *usbd_dev);
-
-static uint8_t force_nak[8];
-static struct _usbd_device usbd_dev;
-
-#define USBD_PM_TOP 0x40
 
 const struct _usbd_driver stm32f0x2_usb_driver = {
 	.init = stm32f0x2_usbd_init,
-	.set_address = stm32f0x2_set_address,
-	.ep_setup = stm32f0x2_ep_setup,
-	.ep_reset = stm32f0x2_endpoints_reset,
-	.ep_stall_set = stm32f0x2_ep_stall_set,
-	.ep_stall_get = stm32f0x2_ep_stall_get,
-	.ep_nak_set = stm32f0x2_ep_nak_set,
-	.ep_write_packet = stm32f0x2_ep_write_packet,
-	.ep_read_packet = stm32f0x2_ep_read_packet,
-	.poll = stm32f0x2_poll,
+	.set_address = stm32_usbfs_set_address,
+	.ep_setup = stm32_usbfs_ep_setup,
+	.ep_reset = stm32_usbfs_endpoints_reset,
+	.ep_stall_set = stm32_usbfs_ep_stall_set,
+	.ep_stall_get = stm32_usbfs_ep_stall_get,
+	.ep_nak_set = stm32_usbfs_ep_nak_set,
+	.ep_write_packet = stm32_usbfs_ep_write_packet,
+	.ep_read_packet = stm32_usbfs_ep_read_packet,
+	.poll = stm32_usbfs_poll,
 };
 
 /** Initialize the USB device controller hardware of the STM32. */
@@ -73,155 +53,7 @@ static usbd_device *stm32f0x2_usbd_init(void)
 	SET_REG(USB_CNTR_REG, USB_CNTR_RESETM | USB_CNTR_CTRM |
 		USB_CNTR_SUSPM | USB_CNTR_WKUPM);
 	USB_BDCR = USB_BDCR_DPPU;
-	return &usbd_dev;
-}
-
-static void stm32f0x2_set_address(usbd_device *dev, uint8_t addr)
-{
-	(void)dev;
-	/* Set device address and enable. */
-	USB_DADDR = (addr & USB_DADDR_ADDR) | USB_DADDR_EF;
-}
-
-/**
- * Set the receive buffer size for a given USB endpoint.
- *
- * @param ep Index of endpoint to configure.
- * @param size Size in bytes of the RX buffer.
- */
-static void usb_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size)
-{
-	(void)dev;
-	if (size > 62) {
-		if (size & 0x1f) {
-			size -= 32;
-		}
-		USB_SET_EP_RX_COUNT(ep, (size << 5) | 0x8000);
-	} else {
-		if (size & 1) {
-			size++;
-		}
-		USB_SET_EP_RX_COUNT(ep, size << 10);
-	}
-}
-
-static void stm32f0x2_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
-			       uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep))
-{
-	/* Translate USB standard type codes to STM32. */
-	const uint16_t typelookup[] = {
-		[USB_ENDPOINT_ATTR_CONTROL] = USB_EP_TYPE_CONTROL,
-		[USB_ENDPOINT_ATTR_ISOCHRONOUS] = USB_EP_TYPE_ISO,
-		[USB_ENDPOINT_ATTR_BULK] = USB_EP_TYPE_BULK,
-		[USB_ENDPOINT_ATTR_INTERRUPT] = USB_EP_TYPE_INTERRUPT,
-	};
-	uint8_t dir = addr & 0x80;
-	addr &= 0x7f;
-
-	/* Assign address. */
-	USB_SET_EP_ADDR(addr, addr);
-	USB_SET_EP_TYPE(addr, typelookup[type]);
-
-	if (dir || (addr == 0)) {
-		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
-		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
-		}
-		USB_CLR_EP_TX_DTOG(addr);
-		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
-		dev->pm_top += max_size;
-	}
-
-	if (!dir) {
-		USB_SET_EP_RX_ADDR(addr, dev->pm_top);
-		usb_set_ep_rx_bufsize(dev, addr, max_size);
-		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
-		}
-		USB_CLR_EP_RX_DTOG(addr);
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
-		dev->pm_top += max_size;
-	}
-}
-
-static void stm32f0x2_endpoints_reset(usbd_device *dev)
-{
-	int i;
-
-	/* Reset all endpoints. */
-	for (i = 1; i < 8; i++) {
-		USB_SET_EP_TX_STAT(i, USB_EP_TX_STAT_DISABLED);
-		USB_SET_EP_RX_STAT(i, USB_EP_RX_STAT_DISABLED);
-	}
-	dev->pm_top = USBD_PM_TOP + (2 * dev->desc->bMaxPacketSize0);
-}
-
-static void stm32f0x2_ep_stall_set(usbd_device *dev, uint8_t addr,
-				   uint8_t stall)
-{
-	(void)dev;
-	if (addr == 0) {
-		USB_SET_EP_TX_STAT(addr, stall ? USB_EP_TX_STAT_STALL :
-				   USB_EP_TX_STAT_NAK);
-	}
-
-	if (addr & 0x80) {
-		addr &= 0x7F;
-
-		USB_SET_EP_TX_STAT(addr, stall ? USB_EP_TX_STAT_STALL :
-				   USB_EP_TX_STAT_NAK);
-
-		/* Reset to DATA0 if clearing stall condition. */
-		if (!stall) {
-			USB_CLR_EP_TX_DTOG(addr);
-		}
-	} else {
-		/* Reset to DATA0 if clearing stall condition. */
-		if (!stall) {
-			USB_CLR_EP_RX_DTOG(addr);
-		}
-
-		USB_SET_EP_RX_STAT(addr, stall ? USB_EP_RX_STAT_STALL :
-				   USB_EP_RX_STAT_VALID);
-	}
-}
-
-static uint8_t stm32f0x2_ep_stall_get(usbd_device *dev, uint8_t addr)
-{
-	(void)dev;
-	if (addr & 0x80) {
-		if ((*USB_EP_REG(addr & 0x7F) & USB_EP_TX_STAT) ==
-		    USB_EP_TX_STAT_STALL) {
-			return 1;
-		}
-	} else {
-		if ((*USB_EP_REG(addr) & USB_EP_RX_STAT) ==
-		    USB_EP_RX_STAT_STALL) {
-			return 1;
-		}
-	}
-	return 0;
-}
-
-static void stm32f0x2_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
-{
-	(void)dev;
-	/* It does not make sence to force NAK on IN endpoints. */
-	if (addr & 0x80) {
-		return;
-	}
-
-	force_nak[addr] = nak;
-
-	if (nak) {
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_NAK);
-	} else {
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
-	}
+	return &stm32_usbfs_dev;
 }
 
 /**
@@ -231,7 +63,7 @@ static void stm32f0x2_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
  * @param buf Source pointer to data buffer.
  * @param len Number of bytes to copy.
  */
-static void usb_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
+void stm32_usbfs_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
 {
 	const uint16_t *lbuf = buf;
 	volatile uint16_t *PM = vPM;
@@ -241,23 +73,6 @@ static void usb_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
 	}
 }
 
-static uint16_t stm32f0x2_ep_write_packet(usbd_device *dev, uint8_t addr,
-				     const void *buf, uint16_t len)
-{
-	(void)dev;
-	addr &= 0x7F;
-
-	if ((*USB_EP_REG(addr) & USB_EP_TX_STAT) == USB_EP_TX_STAT_VALID) {
-		return 0;
-	}
-
-	usb_copy_to_pm(USB_GET_EP_TX_BUFF(addr), buf, len);
-	USB_SET_EP_TX_COUNT(addr, len);
-	USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_VALID);
-
-	return len;
-}
-
 /**
  * Copy a data buffer from packet memory.
  *
@@ -265,7 +80,7 @@ static uint16_t stm32f0x2_ep_write_packet(usbd_device *dev, uint8_t addr,
  * @param vPM Destination pointer into packet memory.
  * @param len Number of bytes to copy.
  */
-static void usb_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
+void stm32_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 {
 	uint16_t *lbuf = buf;
 	const volatile uint16_t *PM = vPM;
@@ -277,82 +92,5 @@ static void usb_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 
 	if (odd) {
 		*(uint8_t *) lbuf = *(uint8_t *) PM;
-	}
-}
-
-static uint16_t stm32f0x2_ep_read_packet(usbd_device *dev, uint8_t addr,
-					 void *buf, uint16_t len)
-{
-	(void)dev;
-	if ((*USB_EP_REG(addr) & USB_EP_RX_STAT) == USB_EP_RX_STAT_VALID) {
-		return 0;
-	}
-
-	len = MIN(USB_GET_EP_RX_COUNT(addr) & 0x3ff, len);
-	usb_copy_from_pm(buf, USB_GET_EP_RX_BUFF(addr), len);
-	USB_CLR_EP_RX_CTR(addr);
-
-	if (!force_nak[addr]) {
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
-	}
-
-	return len;
-}
-
-static void stm32f0x2_poll(usbd_device *dev)
-{
-	uint16_t istr = *USB_ISTR_REG;
-
-	if (istr & USB_ISTR_RESET) {
-		dev->pm_top = USBD_PM_TOP;
-		_usbd_reset(dev);
-		USB_CLR_ISTR_RESET();
-		return;
-	}
-
-	if (istr & USB_ISTR_CTR) {
-		uint8_t ep = istr & USB_ISTR_EP_ID;
-		uint8_t type;
-
-		if (istr & USB_ISTR_DIR) {
-			/* OUT or SETUP? */
-			if (*USB_EP_REG(ep) & USB_EP_SETUP) {
-				type = USB_TRANSACTION_SETUP;
-			} else {
-				type = USB_TRANSACTION_OUT;
-			}
-		} else {
-			type = USB_TRANSACTION_IN;
-			USB_CLR_EP_TX_CTR(ep);
-		}
-
-		if (dev->user_callback_ctr[ep][type]) {
-			dev->user_callback_ctr[ep][type] (dev, ep);
-		}
-
-		if(istr & USB_ISTR_DIR) {
-			USB_CLR_EP_RX_CTR(ep);
-		}
-	}
-
-	if (istr & USB_ISTR_SUSP) {
-		USB_CLR_ISTR_SUSP();
-		if (dev->user_callback_suspend) {
-			dev->user_callback_suspend();
-		}
-	}
-
-	if (istr & USB_ISTR_WKUP) {
-		USB_CLR_ISTR_WKUP();
-		if (dev->user_callback_resume) {
-			dev->user_callback_resume();
-		}
-	}
-
-	if (istr & USB_ISTR_SOF) {
-		if (dev->user_callback_sof) {
-			dev->user_callback_sof();
-		}
-		USB_CLR_ISTR_SOF();
 	}
 }

--- a/lib/usb/usb_f0x2.c
+++ b/lib/usb/usb_f0x2.c
@@ -2,6 +2,7 @@
  * This file is part of the libopencm3 project.
  *
  * Copyright (C) 2010 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2014 Kuldeep Singh Dhaka <kuldeepdhaka9@gmail.com>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -24,44 +25,44 @@
 #include <libopencm3/usb/usbd.h>
 #include "usb_private.h"
 
-static usbd_device *stm32f103_usbd_init(void);
-static void stm32f103_set_address(usbd_device *usbd_dev, uint8_t addr);
-static void stm32f103_ep_setup(usbd_device *usbd_dev, uint8_t addr,
+static usbd_device *stm32f0x2_usbd_init(void);
+static void stm32f0x2_set_address(usbd_device *usbd_dev, uint8_t addr);
+static void stm32f0x2_ep_setup(usbd_device *usbd_dev, uint8_t addr,
 			       uint8_t type, uint16_t max_size,
 			       void (*callback) (usbd_device *usbd_dev,
 						 uint8_t ep));
-static void stm32f103_endpoints_reset(usbd_device *usbd_dev);
-static void stm32f103_ep_stall_set(usbd_device *usbd_dev, uint8_t addr,
+static void stm32f0x2_endpoints_reset(usbd_device *usbd_dev);
+static void stm32f0x2_ep_stall_set(usbd_device *usbd_dev, uint8_t addr,
 				   uint8_t stall);
-static uint8_t stm32f103_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);
-static void stm32f103_ep_nak_set(usbd_device *usbd_dev, uint8_t addr,
+static uint8_t stm32f0x2_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);
+static void stm32f0x2_ep_nak_set(usbd_device *usbd_dev, uint8_t addr,
 				 uint8_t nak);
-static uint16_t stm32f103_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
+static uint16_t stm32f0x2_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
 					  const void *buf, uint16_t len);
-static uint16_t stm32f103_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
+static uint16_t stm32f0x2_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
 					 void *buf, uint16_t len);
-static void stm32f103_poll(usbd_device *usbd_dev);
+static void stm32f0x2_poll(usbd_device *usbd_dev);
 
 static uint8_t force_nak[8];
 static struct _usbd_device usbd_dev;
 
-const struct _usbd_driver stm32f103_usb_driver = {
-	.init = stm32f103_usbd_init,
-	.set_address = stm32f103_set_address,
-	.ep_setup = stm32f103_ep_setup,
-	.ep_reset = stm32f103_endpoints_reset,
-	.ep_stall_set = stm32f103_ep_stall_set,
-	.ep_stall_get = stm32f103_ep_stall_get,
-	.ep_nak_set = stm32f103_ep_nak_set,
-	.ep_write_packet = stm32f103_ep_write_packet,
-	.ep_read_packet = stm32f103_ep_read_packet,
-	.poll = stm32f103_poll,
+const struct _usbd_driver stm32f0x2_usb_driver = {
+	.init = stm32f0x2_usbd_init,
+	.set_address = stm32f0x2_set_address,
+	.ep_setup = stm32f0x2_ep_setup,
+	.ep_reset = stm32f0x2_endpoints_reset,
+	.ep_stall_set = stm32f0x2_ep_stall_set,
+	.ep_stall_get = stm32f0x2_ep_stall_get,
+	.ep_nak_set = stm32f0x2_ep_nak_set,
+	.ep_write_packet = stm32f0x2_ep_write_packet,
+	.ep_read_packet = stm32f0x2_ep_read_packet,
+	.poll = stm32f0x2_poll,
 };
 
 /** Initialize the USB device controller hardware of the STM32. */
-static usbd_device *stm32f103_usbd_init(void)
+static usbd_device *stm32f0x2_usbd_init(void)
 {
-	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USBEN);
+	rcc_periph_clock_enable(RCC_USB);
 	SET_REG(USB_CNTR_REG, 0);
 	SET_REG(USB_BTABLE_REG, 0);
 	SET_REG(USB_ISTR_REG, 0);
@@ -69,14 +70,15 @@ static usbd_device *stm32f103_usbd_init(void)
 	/* Enable RESET, SUSPEND, RESUME and CTR interrupts. */
 	SET_REG(USB_CNTR_REG, USB_CNTR_RESETM | USB_CNTR_CTRM |
 		USB_CNTR_SUSPM | USB_CNTR_WKUPM);
+	USB_BDCR = USB_BDCR_DPPU;
 	return &usbd_dev;
 }
 
-static void stm32f103_set_address(usbd_device *dev, uint8_t addr)
+static void stm32f0x2_set_address(usbd_device *dev, uint8_t addr)
 {
 	(void)dev;
 	/* Set device address and enable. */
-	SET_REG(USB_DADDR_REG, (addr & USB_DADDR_ADDR) | USB_DADDR_EF);
+	USB_DADDR = (addr & USB_DADDR_ADDR) | USB_DADDR_EF;
 }
 
 /**
@@ -101,7 +103,7 @@ static void usb_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size)
 	}
 }
 
-static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
+static void stm32f0x2_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 			       uint16_t max_size,
 			       void (*callback) (usbd_device *usbd_dev,
 						 uint8_t ep))
@@ -144,7 +146,7 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 	}
 }
 
-static void stm32f103_endpoints_reset(usbd_device *dev)
+static void stm32f0x2_endpoints_reset(usbd_device *dev)
 {
 	int i;
 
@@ -156,7 +158,7 @@ static void stm32f103_endpoints_reset(usbd_device *dev)
 	dev->pm_top = 0x40 + (2 * dev->desc->bMaxPacketSize0);
 }
 
-static void stm32f103_ep_stall_set(usbd_device *dev, uint8_t addr,
+static void stm32f0x2_ep_stall_set(usbd_device *dev, uint8_t addr,
 				   uint8_t stall)
 {
 	(void)dev;
@@ -186,7 +188,7 @@ static void stm32f103_ep_stall_set(usbd_device *dev, uint8_t addr,
 	}
 }
 
-static uint8_t stm32f103_ep_stall_get(usbd_device *dev, uint8_t addr)
+static uint8_t stm32f0x2_ep_stall_get(usbd_device *dev, uint8_t addr)
 {
 	(void)dev;
 	if (addr & 0x80) {
@@ -203,7 +205,7 @@ static uint8_t stm32f103_ep_stall_get(usbd_device *dev, uint8_t addr)
 	return 0;
 }
 
-static void stm32f103_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
+static void stm32f0x2_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
 {
 	(void)dev;
 	/* It does not make sence to force NAK on IN endpoints. */
@@ -232,12 +234,12 @@ static void usb_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
 	const uint16_t *lbuf = buf;
 	volatile uint16_t *PM = vPM;
 
-	for (len = (len + 1) >> 1; len; PM += 2, lbuf++, len--) {
+	for (len = (len + 1) >> 1; len; PM++, lbuf++, len--) {
 		*PM = *lbuf;
 	}
 }
 
-static uint16_t stm32f103_ep_write_packet(usbd_device *dev, uint8_t addr,
+static uint16_t stm32f0x2_ep_write_packet(usbd_device *dev, uint8_t addr,
 				     const void *buf, uint16_t len)
 {
 	(void)dev;
@@ -267,7 +269,7 @@ static void usb_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 	const volatile uint16_t *PM = vPM;
 	uint8_t odd = len & 1;
 
-	for (len >>= 1; len; PM += 2, lbuf++, len--) {
+	for (len >>= 1; len; PM++, lbuf++, len--) {
 		*lbuf = *PM;
 	}
 
@@ -276,7 +278,7 @@ static void usb_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 	}
 }
 
-static uint16_t stm32f103_ep_read_packet(usbd_device *dev, uint8_t addr,
+static uint16_t stm32f0x2_ep_read_packet(usbd_device *dev, uint8_t addr,
 					 void *buf, uint16_t len)
 {
 	(void)dev;
@@ -295,7 +297,7 @@ static uint16_t stm32f103_ep_read_packet(usbd_device *dev, uint8_t addr,
 	return len;
 }
 
-static void stm32f103_poll(usbd_device *dev)
+static void stm32f0x2_poll(usbd_device *dev)
 {
 	uint16_t istr = *USB_ISTR_REG;
 

--- a/lib/usb/usb_f103.c
+++ b/lib/usb/usb_f103.c
@@ -23,39 +23,21 @@
 #include <libopencm3/stm32/usb.h>
 #include <libopencm3/usb/usbd.h>
 #include "usb_private.h"
+#include "stm32_usbfs_common.h"
 
 static usbd_device *stm32f103_usbd_init(void);
-static void stm32f103_set_address(usbd_device *usbd_dev, uint8_t addr);
-static void stm32f103_ep_setup(usbd_device *usbd_dev, uint8_t addr,
-			       uint8_t type, uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep));
-static void stm32f103_endpoints_reset(usbd_device *usbd_dev);
-static void stm32f103_ep_stall_set(usbd_device *usbd_dev, uint8_t addr,
-				   uint8_t stall);
-static uint8_t stm32f103_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);
-static void stm32f103_ep_nak_set(usbd_device *usbd_dev, uint8_t addr,
-				 uint8_t nak);
-static uint16_t stm32f103_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
-					  const void *buf, uint16_t len);
-static uint16_t stm32f103_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
-					 void *buf, uint16_t len);
-static void stm32f103_poll(usbd_device *usbd_dev);
-
-static uint8_t force_nak[8];
-static struct _usbd_device usbd_dev;
 
 const struct _usbd_driver stm32f103_usb_driver = {
 	.init = stm32f103_usbd_init,
-	.set_address = stm32f103_set_address,
-	.ep_setup = stm32f103_ep_setup,
-	.ep_reset = stm32f103_endpoints_reset,
-	.ep_stall_set = stm32f103_ep_stall_set,
-	.ep_stall_get = stm32f103_ep_stall_get,
-	.ep_nak_set = stm32f103_ep_nak_set,
-	.ep_write_packet = stm32f103_ep_write_packet,
-	.ep_read_packet = stm32f103_ep_read_packet,
-	.poll = stm32f103_poll,
+	.set_address = stm32_usbfs_set_address,
+	.ep_setup = stm32_usbfs_ep_setup,
+	.ep_reset = stm32_usbfs_endpoints_reset,
+	.ep_stall_set = stm32_usbfs_ep_stall_set,
+	.ep_stall_get = stm32_usbfs_ep_stall_get,
+	.ep_nak_set = stm32_usbfs_ep_nak_set,
+	.ep_write_packet = stm32_usbfs_ep_write_packet,
+	.ep_read_packet = stm32_usbfs_ep_read_packet,
+	.poll = stm32_usbfs_poll,
 };
 
 /** Initialize the USB device controller hardware of the STM32. */
@@ -69,155 +51,7 @@ static usbd_device *stm32f103_usbd_init(void)
 	/* Enable RESET, SUSPEND, RESUME and CTR interrupts. */
 	SET_REG(USB_CNTR_REG, USB_CNTR_RESETM | USB_CNTR_CTRM |
 		USB_CNTR_SUSPM | USB_CNTR_WKUPM);
-	return &usbd_dev;
-}
-
-static void stm32f103_set_address(usbd_device *dev, uint8_t addr)
-{
-	(void)dev;
-	/* Set device address and enable. */
-	SET_REG(USB_DADDR_REG, (addr & USB_DADDR_ADDR) | USB_DADDR_EF);
-}
-
-/**
- * Set the receive buffer size for a given USB endpoint.
- *
- * @param ep Index of endpoint to configure.
- * @param size Size in bytes of the RX buffer.
- */
-static void usb_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size)
-{
-	(void)dev;
-	if (size > 62) {
-		if (size & 0x1f) {
-			size -= 32;
-		}
-		USB_SET_EP_RX_COUNT(ep, (size << 5) | 0x8000);
-	} else {
-		if (size & 1) {
-			size++;
-		}
-		USB_SET_EP_RX_COUNT(ep, size << 10);
-	}
-}
-
-static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
-			       uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep))
-{
-	/* Translate USB standard type codes to STM32. */
-	const uint16_t typelookup[] = {
-		[USB_ENDPOINT_ATTR_CONTROL] = USB_EP_TYPE_CONTROL,
-		[USB_ENDPOINT_ATTR_ISOCHRONOUS] = USB_EP_TYPE_ISO,
-		[USB_ENDPOINT_ATTR_BULK] = USB_EP_TYPE_BULK,
-		[USB_ENDPOINT_ATTR_INTERRUPT] = USB_EP_TYPE_INTERRUPT,
-	};
-	uint8_t dir = addr & 0x80;
-	addr &= 0x7f;
-
-	/* Assign address. */
-	USB_SET_EP_ADDR(addr, addr);
-	USB_SET_EP_TYPE(addr, typelookup[type]);
-
-	if (dir || (addr == 0)) {
-		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
-		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
-		}
-		USB_CLR_EP_TX_DTOG(addr);
-		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
-		dev->pm_top += max_size;
-	}
-
-	if (!dir) {
-		USB_SET_EP_RX_ADDR(addr, dev->pm_top);
-		usb_set_ep_rx_bufsize(dev, addr, max_size);
-		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
-		}
-		USB_CLR_EP_RX_DTOG(addr);
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
-		dev->pm_top += max_size;
-	}
-}
-
-static void stm32f103_endpoints_reset(usbd_device *dev)
-{
-	int i;
-
-	/* Reset all endpoints. */
-	for (i = 1; i < 8; i++) {
-		USB_SET_EP_TX_STAT(i, USB_EP_TX_STAT_DISABLED);
-		USB_SET_EP_RX_STAT(i, USB_EP_RX_STAT_DISABLED);
-	}
-	dev->pm_top = 0x40 + (2 * dev->desc->bMaxPacketSize0);
-}
-
-static void stm32f103_ep_stall_set(usbd_device *dev, uint8_t addr,
-				   uint8_t stall)
-{
-	(void)dev;
-	if (addr == 0) {
-		USB_SET_EP_TX_STAT(addr, stall ? USB_EP_TX_STAT_STALL :
-				   USB_EP_TX_STAT_NAK);
-	}
-
-	if (addr & 0x80) {
-		addr &= 0x7F;
-
-		USB_SET_EP_TX_STAT(addr, stall ? USB_EP_TX_STAT_STALL :
-				   USB_EP_TX_STAT_NAK);
-
-		/* Reset to DATA0 if clearing stall condition. */
-		if (!stall) {
-			USB_CLR_EP_TX_DTOG(addr);
-		}
-	} else {
-		/* Reset to DATA0 if clearing stall condition. */
-		if (!stall) {
-			USB_CLR_EP_RX_DTOG(addr);
-		}
-
-		USB_SET_EP_RX_STAT(addr, stall ? USB_EP_RX_STAT_STALL :
-				   USB_EP_RX_STAT_VALID);
-	}
-}
-
-static uint8_t stm32f103_ep_stall_get(usbd_device *dev, uint8_t addr)
-{
-	(void)dev;
-	if (addr & 0x80) {
-		if ((*USB_EP_REG(addr & 0x7F) & USB_EP_TX_STAT) ==
-		    USB_EP_TX_STAT_STALL) {
-			return 1;
-		}
-	} else {
-		if ((*USB_EP_REG(addr) & USB_EP_RX_STAT) ==
-		    USB_EP_RX_STAT_STALL) {
-			return 1;
-		}
-	}
-	return 0;
-}
-
-static void stm32f103_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
-{
-	(void)dev;
-	/* It does not make sence to force NAK on IN endpoints. */
-	if (addr & 0x80) {
-		return;
-	}
-
-	force_nak[addr] = nak;
-
-	if (nak) {
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_NAK);
-	} else {
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
-	}
+	return &stm32_usbfs_dev;
 }
 
 /**
@@ -227,7 +61,7 @@ static void stm32f103_ep_nak_set(usbd_device *dev, uint8_t addr, uint8_t nak)
  * @param buf Source pointer to data buffer.
  * @param len Number of bytes to copy.
  */
-static void usb_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
+void stm32_usbfs_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
 {
 	const uint16_t *lbuf = buf;
 	volatile uint16_t *PM = vPM;
@@ -237,23 +71,6 @@ static void usb_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
 	}
 }
 
-static uint16_t stm32f103_ep_write_packet(usbd_device *dev, uint8_t addr,
-				     const void *buf, uint16_t len)
-{
-	(void)dev;
-	addr &= 0x7F;
-
-	if ((*USB_EP_REG(addr) & USB_EP_TX_STAT) == USB_EP_TX_STAT_VALID) {
-		return 0;
-	}
-
-	usb_copy_to_pm(USB_GET_EP_TX_BUFF(addr), buf, len);
-	USB_SET_EP_TX_COUNT(addr, len);
-	USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_VALID);
-
-	return len;
-}
-
 /**
  * Copy a data buffer from packet memory.
  *
@@ -261,7 +78,7 @@ static uint16_t stm32f103_ep_write_packet(usbd_device *dev, uint8_t addr,
  * @param vPM Destination pointer into packet memory.
  * @param len Number of bytes to copy.
  */
-static void usb_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
+void stm32_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 {
 	uint16_t *lbuf = buf;
 	const volatile uint16_t *PM = vPM;
@@ -273,74 +90,5 @@ static void usb_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 
 	if (odd) {
 		*(uint8_t *) lbuf = *(uint8_t *) PM;
-	}
-}
-
-static uint16_t stm32f103_ep_read_packet(usbd_device *dev, uint8_t addr,
-					 void *buf, uint16_t len)
-{
-	(void)dev;
-	if ((*USB_EP_REG(addr) & USB_EP_RX_STAT) == USB_EP_RX_STAT_VALID) {
-		return 0;
-	}
-
-	len = MIN(USB_GET_EP_RX_COUNT(addr) & 0x3ff, len);
-	usb_copy_from_pm(buf, USB_GET_EP_RX_BUFF(addr), len);
-	USB_CLR_EP_RX_CTR(addr);
-
-	if (!force_nak[addr]) {
-		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
-	}
-
-	return len;
-}
-
-static void stm32f103_poll(usbd_device *dev)
-{
-	uint16_t istr = *USB_ISTR_REG;
-
-	if (istr & USB_ISTR_RESET) {
-		dev->pm_top = 0x40;
-		_usbd_reset(dev);
-		USB_CLR_ISTR_RESET();
-		return;
-	}
-
-	if (istr & USB_ISTR_CTR) {
-		uint8_t ep = istr & USB_ISTR_EP_ID;
-		uint8_t type = (istr & USB_ISTR_DIR) ? 1 : 0;
-
-		if (type) { /* OUT or SETUP transaction */
-			type += (*USB_EP_REG(ep) & USB_EP_SETUP) ? 1 : 0;
-		} else { /* IN transaction */
-			USB_CLR_EP_TX_CTR(ep);
-		}
-
-		if (dev->user_callback_ctr[ep][type]) {
-			dev->user_callback_ctr[ep][type] (dev, ep);
-		} else {
-			USB_CLR_EP_RX_CTR(ep);
-		}
-	}
-
-	if (istr & USB_ISTR_SUSP) {
-		USB_CLR_ISTR_SUSP();
-		if (dev->user_callback_suspend) {
-			dev->user_callback_suspend();
-		}
-	}
-
-	if (istr & USB_ISTR_WKUP) {
-		USB_CLR_ISTR_WKUP();
-		if (dev->user_callback_resume) {
-			dev->user_callback_resume();
-		}
-	}
-
-	if (istr & USB_ISTR_SOF) {
-		if (dev->user_callback_sof) {
-			dev->user_callback_sof();
-		}
-		USB_CLR_ISTR_SOF();
 	}
 }


### PR DESCRIPTION
This pr include.
* stm32l0 usb support
* stm32f0x2 usb support
* stm32f103 and stm32f0x2 commonized code.
* fix for endpoint callback that do not read the data on time (earlier it cause infinite loop)
* pm-top configurable value
* included changes of @UweBonnes #274 and #388 for stm32f103
* disconnect support (only for stm32f0x2)

some of the fix were only meant for stm32f0x2 but since f103 was pulled in, it made the change more broad.
most of the code is old. new code is low (mostly bug fix)