### PR TITLE
stm32: gpio: add gpio_get_mode()

### DIFF
--- a/include/libopencm3/stm32/f1/gpio.h
+++ b/include/libopencm3/stm32/f1/gpio.h
@@ -968,6 +968,8 @@ BEGIN_DECLS
 
 void gpio_set_mode(uint32_t gpioport, uint8_t mode, uint8_t cnf,
 		   uint16_t gpios);
+void gpio_get_mode(uint32_t gpioport, uint8_t *mode, uint8_t *cnf,
+	           uint16_t gpio);
 void gpio_set_eventout(uint8_t evoutport, uint8_t evoutpin);
 void gpio_primary_remap(uint32_t swjenable, uint32_t maps);
 void gpio_secondary_remap(uint32_t maps);

--- a/lib/stm32/f1/gpio.c
+++ b/lib/stm32/f1/gpio.c
@@ -131,6 +131,33 @@ void gpio_set_mode(uint32_t gpioport, uint8_t mode, uint8_t cnf, uint16_t gpios)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief Get GPIO Pin Mode
+
+Gets the mode (input/output) and configuration (analog/digitial and
+open drain/push pull), for a given GPIO pin on a given GPIO port.
+
+@param[in] gpioport Unsigned int32. Port identifier @ref gpio_port_id
+@param[out] mode Unsigned *int8. Pin mode @ref gpio_mode
+@param[out] cnf Unsigned *int8. Pin configuration @ref gpio_cnf
+@param[in] gpio Unsigned int16. Pin identifier @ref gpio_pin_id
+*/
+void gpio_get_mode(uint32_t gpioport, uint8_t *mode, uint8_t *cnf, uint16_t gpio)
+{
+	uint16_t offset = 0;
+	uint32_t tmp32 = 0;
+	int pin = __builtin_ctz(gpio);
+
+	/* Calculate bit offset. */
+	offset = (pin < 8) ? (pin * 4) : ((pin - 8) * 4);
+
+	/* Use tmp32 to either read crl or crh. */
+	tmp32 = (pin < 8) ? GPIO_CRL(gpioport) : GPIO_CRH(gpioport);
+
+	*mode = (tmp32 >> offset) & 3;
+	*cnf = (tmp32 >> (offset + 2)) & 3;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief Map the EVENTOUT signal
 
 Enable the EVENTOUT signal and select the port and pin to be used.


### PR DESCRIPTION
As the name suggests, this function is the reciprocal for gpio_set_mode().

I kept the function signature/parameters-type as much similar as all the other functions in gpio.c. Nevertheless, since this function works on only one pin at a time, passing an integer to identify the pin could probably also be considered. Any opinion on this ?

To extract the pin index from the bitfield I'm using GCC __builtin_ctz(). This maps to one single ASM instruction in CM3 MCUs. I assumed libopencm3 is intended to be compiled only on GCC. Is this true ?

Signed-off-by: Andrea Merello <andrea.merello@gmail.com>