### PR TITLE
partially fixed #454 adc power off

### DIFF
--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -870,7 +870,7 @@
 BEGIN_DECLS
 
 void adc_power_on(uint32_t adc);
-void adc_off(uint32_t adc);
+void adc_power_off(uint32_t adc);
 void adc_enable_analog_watchdog_regular(uint32_t adc);
 void adc_disable_analog_watchdog_regular(uint32_t adc);
 void adc_enable_analog_watchdog_injected(uint32_t adc);

--- a/lib/stm32/f0/adc.c
+++ b/lib/stm32/f0/adc.c
@@ -471,7 +471,7 @@ void adc_disable_eoc_interrupt(uint32_t adc)
 
 void adc_power_off(uint32_t adc)
 {
-	ADC_CR(adc) &= ~ADC_CR_ADEN;
+	ADC_CR(adc) |= ADC_CR_ADDIS;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -99,7 +99,7 @@
 
 void adc_off(uint32_t adc)
 {
-	ADC_CR(adc) &= ~ADC_CR_ADEN;
+	ADC_CR(adc) |= ADC_CR_ADDIS;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -97,7 +97,7 @@
  * adc_reg_base
 */
 
-void adc_off(uint32_t adc)
+void adc_power_off(uint32_t adc)
 {
 	ADC_CR(adc) |= ADC_CR_ADDIS;
 }


### PR DESCRIPTION
This is the correct way to disable the ADC according to the reference manual. Note that this is asynchronous, the ADC will not stop immediatly, you need to check the ADEN flag to ensure its actually down.
Smoke-tested.