### PR TITLE
Add a helper function for i2c clock setup

### DIFF
--- a/include/libopencm3/stm32/common/i2c_common_all.h
+++ b/include/libopencm3/stm32/common/i2c_common_all.h
@@ -160,6 +160,8 @@ specific memorymap.h header before including this header file.*/
 /* ITERREN: Error interrupt enable */
 #define I2C_CR2_ITERREN			(1 << 8)
 
+#define I2C_CR2_FREQ_MASK		0x3ff
+
 /* Note: Bits [7:6] are reserved, and forced to 0 by hardware. */
 
 /* FREQ[5:0]: Peripheral clock frequency (valid values: 2-36 MHz, 2-42 MHz for
@@ -267,9 +269,11 @@ specific memorymap.h header before including this header file.*/
 
 /* TxE: Data register empty (transmitters) */
 #define I2C_SR1_TxE			(1 << 7)
+#define I2C_SR1_TXE			(1 << 7)
 
 /* RxNE: Data register not empty (receivers) */
 #define I2C_SR1_RxNE			(1 << 6)
+#define I2C_SR1_RXNE			(1 << 6)
 
 /* Note: Bit 5 is reserved, and forced to 0 by hardware. */
 
@@ -320,6 +324,8 @@ specific memorymap.h header before including this header file.*/
 /* F/S: I2C Master mode selection (fast / standard) */
 #define I2C_CCR_FS			(1 << 15)
 
+#define I2C_CCR_CCRMASK			0xfff
+
 /* DUTY: Fast Mode Duty Cycle */
 /** @defgroup i2c_duty_cycle I2C peripheral clock duty cycles
 @ingroup i2c_defines
@@ -345,6 +351,7 @@ specific memorymap.h header before including this header file.*/
  * Bits [5:0]:
  * TRISE[5:0]: Maximum rise time in Fast/Standard mode (master mode)
  */
+#define I2C_TRISE_MASK			0x3f
 
 /* --- I2C constant definitions -------------------------------------------- */
 
@@ -391,6 +398,7 @@ void i2c_enable_dma(uint32_t i2c);
 void i2c_disable_dma(uint32_t i2c);
 void i2c_set_dma_last_transfer(uint32_t i2c);
 void i2c_clear_dma_last_transfer(uint32_t i2c);
+void i2c_set_speed(uint32_t i2c, uint8_t fastmode);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/common/i2c_common_all.h
+++ b/include/libopencm3/stm32/common/i2c_common_all.h
@@ -269,11 +269,9 @@ specific memorymap.h header before including this header file.*/
 
 /* TxE: Data register empty (transmitters) */
 #define I2C_SR1_TxE			(1 << 7)
-#define I2C_SR1_TXE			(1 << 7)
 
 /* RxNE: Data register not empty (receivers) */
 #define I2C_SR1_RxNE			(1 << 6)
-#define I2C_SR1_RXNE			(1 << 6)
 
 /* Note: Bit 5 is reserved, and forced to 0 by hardware. */
 

--- a/lib/stm32/common/i2c_common_all.c
+++ b/lib/stm32/common/i2c_common_all.c
@@ -468,6 +468,11 @@ Note: this function has to disable the device while setting clock speeds
 and so it may lose other settings you've made. Please call it first,
 then make any addition changes to the settings to complete your setup
 such as enabling interrupts, dma, etc.
+
+Also when you set "fast" mode you get the common 1:2 clock duty cycle,
+if you want the more complext 9:16 duty cycle that the chip does support
+then you will need to program the FREQ and CCR registers directly
+with the @ref i2c_set_ccr and @ref i2c_set_clock_frequency calls.
 */
 void i2c_set_speed(uint32_t i2c, uint8_t fast)
 {
@@ -482,7 +487,6 @@ void i2c_set_speed(uint32_t i2c, uint8_t fast)
 	reg = (I2C_CR2(i2c) & ~(I2C_CR2_FREQ_MASK)) | (freq & I2C_CR2_FREQ_MASK);
 	I2C_CR2(i2c) = reg;
 
-	/* Note supports the two 'simple' versions not the 9:16 ratio version */
 	if (fast) {
 		I2C_CCR(i2c) = I2C_CCR_FS | (((freq * 5) / 6) & I2C_CCR_CCRMASK);
 	} else {


### PR DESCRIPTION
The code lets you set up the i2c channel as slow (100Khz) or
fast (400Khz) taking care of setting up CR2/CCR/TRISE registers
for you. If you aren't doing interrupts or DMA you can start
sending data right after that.
