### PR TITLE
validate SET_INTERFACE control requests

### DIFF
--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -18,6 +18,7 @@ LGPL License Terms @ref lgpl_license
  * This file is part of the libopencm3 project.
  *
  * Copyright (C) 2010 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2015 Kuldeep Singh Dhaka <kuldeepdhaka9@gmail.com>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -245,18 +246,31 @@ static int usb_standard_set_configuration(usbd_device *usbd_dev,
 					  struct usb_setup_data *req,
 					  uint8_t **buf, uint16_t *len)
 {
-	int i;
+	unsigned i;
+	const struct usb_config_descriptor *cfg;
 
 	(void)req;
 	(void)buf;
 	(void)len;
 
-	/* Is this correct, or should we reset alternate settings. */
-	if (req->wValue == usbd_dev->current_config) {
-		return 1;
+	if(req->wValue > 0) {
+		if (req->wValue > usbd_dev->desc->bNumConfigurations) {
+			return USBD_REQ_NOTSUPP;
+		}
 	}
 
 	usbd_dev->current_config = req->wValue;
+
+	if (usbd_dev->current_config > 0) {
+		cfg = &usbd_dev->config[usbd_dev->current_config - 1];
+
+		/* reset all alternate settings configuration */
+		for (i = 0; i < cfg->bNumInterfaces; i++) {
+			if (cfg->interface[i].cur_altsetting) {
+				*cfg->interface[i].cur_altsetting = 0;
+			}
+		}
+	}
 
 	/* Reset all endpoints. */
 	usbd_dev->driver->ep_reset(usbd_dev);
@@ -299,10 +313,16 @@ static int usb_standard_set_interface(usbd_device *usbd_dev,
 				      struct usb_setup_data *req,
 				      uint8_t **buf, uint16_t *len)
 {
-	const struct usb_config_descriptor *cfx = &usbd_dev->config[usbd_dev->current_config - 1];
+	const struct usb_config_descriptor *cfx;
 	const struct usb_interface *iface;
 
 	(void)buf;
+
+	if (!usbd_dev->current_config) {
+		return USBD_REQ_NOTSUPP;
+	}
+
+	cfx = &usbd_dev->config[usbd_dev->current_config - 1];
 
 	if (req->wIndex >= cfx->bNumInterfaces) {
 		return USBD_REQ_NOTSUPP;
@@ -335,7 +355,13 @@ static int usb_standard_get_interface(usbd_device *usbd_dev,
 				      uint8_t **buf, uint16_t *len)
 {
 	uint8_t *cur_altsetting;
-	const struct usb_config_descriptor *cfx = &usbd_dev->config[usbd_dev->current_config - 1];
+	const struct usb_config_descriptor *cfx;
+
+	if (!usbd_dev->current_config) {
+		return USBD_REQ_NOTSUPP;
+	}
+
+	cfx = &usbd_dev->config[usbd_dev->current_config - 1];
 
 	if (req->wIndex >= cfx->bNumInterfaces) {
 		return USBD_REQ_NOTSUPP;


### PR DESCRIPTION
Transaction will fail if host try to pass invalid configuration,
interface number or interface alternate setting.

Validate set-configuration wValue,
if wValue > 0, confirm that device have the configuration.
and do the reset, init part for alternate settings.

fixes #302