### PR TITLE
Pass usbd reference to {sof, reset, resume, suspend} callback.

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -66,14 +66,16 @@ extern usbd_device * usbd_init(const usbd_driver *driver,
 			       uint8_t *control_buffer,
 			       uint16_t control_buffer_size);
 
+typedef void (* usbd_generic_callback)(usbd_device *usbd_dev);
+
 extern void usbd_register_reset_callback(usbd_device *usbd_dev,
-					 void (*callback)(void));
+					usbd_generic_callback callback);
 extern void usbd_register_suspend_callback(usbd_device *usbd_dev,
-					   void (*callback)(void));
+					usbd_generic_callback callback);
 extern void usbd_register_resume_callback(usbd_device *usbd_dev,
-					  void (*callback)(void));
+					usbd_generic_callback callback);
 extern void usbd_register_sof_callback(usbd_device *usbd_dev,
-				       void (*callback)(void));
+				    usbd_generic_callback callback);
 
 typedef int (*usbd_control_complete_callback)(usbd_device *usbd_dev,
 		struct usb_setup_data *req);

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -94,24 +94,26 @@ usbd_device *usbd_init(const usbd_driver *driver,
 	return usbd_dev;
 }
 
-void usbd_register_reset_callback(usbd_device *usbd_dev, void (*callback)(void))
+void usbd_register_reset_callback(usbd_device *usbd_dev,
+			usbd_generic_callback callback)
 {
 	usbd_dev->user_callback_reset = callback;
 }
 
 void usbd_register_suspend_callback(usbd_device *usbd_dev,
-				    void (*callback)(void))
+			usbd_generic_callback callback)
 {
 	usbd_dev->user_callback_suspend = callback;
 }
 
 void usbd_register_resume_callback(usbd_device *usbd_dev,
-				   void (*callback)(void))
+			usbd_generic_callback callback)
 {
 	usbd_dev->user_callback_resume = callback;
 }
 
-void usbd_register_sof_callback(usbd_device *usbd_dev, void (*callback)(void))
+void usbd_register_sof_callback(usbd_device *usbd_dev,
+			usbd_generic_callback callback)
 {
 	usbd_dev->user_callback_sof = callback;
 }
@@ -124,7 +126,7 @@ void _usbd_reset(usbd_device *usbd_dev)
 	usbd_dev->driver->set_address(usbd_dev, 0);
 
 	if (usbd_dev->user_callback_reset) {
-		usbd_dev->user_callback_reset();
+		usbd_dev->user_callback_reset(usbd_dev);
 	}
 }
 

--- a/lib/usb/usb_f103.c
+++ b/lib/usb/usb_f103.c
@@ -326,21 +326,21 @@ static void stm32f103_poll(usbd_device *dev)
 	if (istr & USB_ISTR_SUSP) {
 		USB_CLR_ISTR_SUSP();
 		if (dev->user_callback_suspend) {
-			dev->user_callback_suspend();
+			dev->user_callback_suspend(dev);
 		}
 	}
 
 	if (istr & USB_ISTR_WKUP) {
 		USB_CLR_ISTR_WKUP();
 		if (dev->user_callback_resume) {
-			dev->user_callback_resume();
+			dev->user_callback_resume(dev);
 		}
 	}
 
 	if (istr & USB_ISTR_SOF) {
 		USB_CLR_ISTR_SOF();
 		if (dev->user_callback_sof) {
-			dev->user_callback_sof();
+			dev->user_callback_sof(dev);
 		}
 	}
 

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -308,21 +308,21 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 
 	if (intsts & OTG_GINTSTS_USBSUSP) {
 		if (usbd_dev->user_callback_suspend) {
-			usbd_dev->user_callback_suspend();
+			usbd_dev->user_callback_suspend(usbd_dev);
 		}
 		REBASE(OTG_GINTSTS) = OTG_GINTSTS_USBSUSP;
 	}
 
 	if (intsts & OTG_GINTSTS_WKUPINT) {
 		if (usbd_dev->user_callback_resume) {
-			usbd_dev->user_callback_resume();
+			usbd_dev->user_callback_resume(usbd_dev);
 		}
 		REBASE(OTG_GINTSTS) = OTG_GINTSTS_WKUPINT;
 	}
 
 	if (intsts & OTG_GINTSTS_SOF) {
 		if (usbd_dev->user_callback_sof) {
-			usbd_dev->user_callback_sof();
+			usbd_dev->user_callback_sof(usbd_dev);
 		}
 		REBASE(OTG_GINTSTS) = OTG_GINTSTS_SOF;
 	}

--- a/lib/usb/usb_lm4f.c
+++ b/lib/usb/usb_lm4f.c
@@ -472,11 +472,11 @@ static void lm4f_poll(usbd_device *usbd_dev)
 	const uint8_t usb_csrl0 = USB_CSRL0;
 
 	if ((usb_is & USB_IM_SUSPEND) && (usbd_dev->user_callback_suspend)) {
-		usbd_dev->user_callback_suspend();
+		usbd_dev->user_callback_suspend(usbd_dev);
 	}
 
 	if ((usb_is & USB_IM_RESUME) && (usbd_dev->user_callback_resume)) {
-		usbd_dev->user_callback_resume();
+		usbd_dev->user_callback_resume(usbd_dev);
 	}
 
 	if (usb_is & USB_IM_RESET) {
@@ -484,7 +484,7 @@ static void lm4f_poll(usbd_device *usbd_dev)
 	}
 
 	if ((usb_is & USB_IM_SOF) && (usbd_dev->user_callback_sof)) {
-		usbd_dev->user_callback_sof();
+		usbd_dev->user_callback_sof(usbd_dev);
 	}
 
 	if (usb_txis & USB_EP0) {

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -59,10 +59,10 @@ struct _usbd_device {
 	uint16_t pm_top;    /**< Top of allocated endpoint buffer memory */
 
 	/* User callback functions for various USB events */
-	void (*user_callback_reset)(void);
-	void (*user_callback_suspend)(void);
-	void (*user_callback_resume)(void);
-	void (*user_callback_sof)(void);
+	usbd_generic_callback user_callback_reset;
+	usbd_generic_callback user_callback_suspend;
+	usbd_generic_callback user_callback_resume;
+	usbd_generic_callback user_callback_sof;
 
 	struct usb_control_state {
 		enum {


### PR DESCRIPTION
without this, application code has to mantain a global reference in its code.
this pr have little similarity with #482. (but are completly independent) 