### PR TITLE
Fix typo : USB_BDCR* -> USB_BCDR*

### DIFF
--- a/include/libopencm3/stm32/usb.h
+++ b/include/libopencm3/stm32/usb.h
@@ -60,7 +60,7 @@ LGPL License Terms @ref lgpl_license
 #define USB_BTABLE_REG		(&MMIO32(USB_DEV_FS_BASE + 0x50))
 
 #define USB_LPMCSR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x54))
-#define USB_BDCR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x58))
+#define USB_BCDR_REG		(&MMIO32(USB_DEV_FS_BASE + 0x58))
 
 /* USB EP register */
 #define USB_EP_REG(EP)		(&MMIO32(USB_DEV_FS_BASE) + (EP))
@@ -123,15 +123,15 @@ LGPL License Terms @ref lgpl_license
 #define USB_LPMCSR_LPMACK	(1 << 1)
 #define USB_LPMCSR_LPMEN	(1 << 0)
 
-#define USB_BDCR_DPPU		(1 << 15)
-#define USB_BDCR_PS2DET		(1 << 7)
-#define USB_BDCR_SDET		(1 << 6)
-#define USB_BDCR_PDET		(1 << 5)
-#define USB_BDCR_DCDET		(1 << 4)
-#define USB_BDCR_SDEN		(1 << 3)
-#define USB_BDCR_PDEN		(1 << 2)
-#define USB_BDCR_DCDEN		(1 << 1)
-#define USB_BDCR_BCDEN		(1 << 0)
+#define USB_BCDR_DPPU		(1 << 15)
+#define USB_BCDR_PS2DET		(1 << 7)
+#define USB_BCDR_SDET		(1 << 6)
+#define USB_BCDR_PDET		(1 << 5)
+#define USB_BCDR_DCDET		(1 << 4)
+#define USB_BCDR_SDEN		(1 << 3)
+#define USB_BCDR_PDEN		(1 << 2)
+#define USB_BCDR_DCDEN		(1 << 1)
+#define USB_BCDR_BCDEN		(1 << 0)
 
 /* --- USB device address register manipulators ---------------------------- */
 


### PR DESCRIPTION
ref: https://github.com/fenugrec/libopencm3/commit/c31d152e1b36e33c37964e479ef3a243b560d0b0
credit: @fenugrec