### PR TITLE
STM32 timers : avoid R-M-W operation when clearing interrupt flags in TIM_SR

### DIFF
--- a/lib/stm32/common/timer_common_all.c
+++ b/lib/stm32/common/timer_common_all.c
@@ -280,7 +280,12 @@ tim_reg_base
 
 void timer_clear_flag(uint32_t timer_peripheral, uint32_t flag)
 {
-	TIM_SR(timer_peripheral) &= ~flag;
+	/* Avoid R-M-W operation !*/
+	TIM_SR(timer_peripheral) = ~flag;
+	/* Paranoid version : set reserved bits to "Reset value" (0)
+	 * by masking out undefined flags :
+	 * TIM_SR(timer_peripheral) = ~flag & (TIM_SR_ALL_FLAGS);
+	 */
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Fixes #392 : previous code did a read-modify-write operation on the TIMx_SR register, which could result in missed interrupts.
This code now only writes 0 to the specified flag, and 1 to the other bits.
The paranoid version of this would write 0 to the reserved bits (0 is the "reset value"), but this would require knowing which flags are valid on the actual platform, and adding the corresponding macros.