### PR TITLE
usb: Use enumerated return codes

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -78,7 +78,8 @@ extern void usbd_register_sof_callback(usbd_device *usbd_dev,
 typedef int (*usbd_control_complete_callback)(usbd_device *usbd_dev,
 		struct usb_setup_data *req);
 
-typedef int (*usbd_control_callback)(usbd_device *usbd_dev,
+typedef enum usbd_request_return_codes (*usbd_control_callback)(
+		usbd_device *usbd_dev,
 		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
 		usbd_control_complete_callback *complete);
 

--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -115,8 +115,9 @@ static int usb_control_recv_chunk(usbd_device *usbd_dev)
 	return packetsize;
 }
 
-static int usb_control_request_dispatch(usbd_device *usbd_dev,
-					struct usb_setup_data *req)
+static enum usbd_request_return_codes
+usb_control_request_dispatch(usbd_device *usbd_dev,
+			     struct usb_setup_data *req)
 {
 	int i, result = 0;
 	struct user_control_callback *cb = usbd_dev->user_control_callback;

--- a/lib/usb/usb_msc.c
+++ b/lib/usb/usb_msc.c
@@ -706,9 +706,10 @@ static void msc_data_tx_cb(usbd_device *usbd_dev, uint8_t ep)
 /** @brief Handle various control requests related to the msc storage
  *	   interface.
  */
-static int msc_control_request(usbd_device *usbd_dev,
-				struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-				usbd_control_complete_callback *complete)
+static enum usbd_request_return_codes
+msc_control_request(usbd_device *usbd_dev,
+		    struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		    usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)usbd_dev;

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -122,16 +122,16 @@ void _usbd_control_in(usbd_device *usbd_dev, uint8_t ea);
 void _usbd_control_out(usbd_device *usbd_dev, uint8_t ea);
 void _usbd_control_setup(usbd_device *usbd_dev, uint8_t ea);
 
-int _usbd_standard_request_device(usbd_device *usbd_dev,
+enum usbd_request_return_codes _usbd_standard_request_device(usbd_device *usbd_dev,
 				  struct usb_setup_data *req, uint8_t **buf,
 				  uint16_t *len);
-int _usbd_standard_request_interface(usbd_device *usbd_dev,
+enum usbd_request_return_codes _usbd_standard_request_interface(usbd_device *usbd_dev,
 				     struct usb_setup_data *req, uint8_t **buf,
 				     uint16_t *len);
-int _usbd_standard_request_endpoint(usbd_device *usbd_dev,
+enum usbd_request_return_codes _usbd_standard_request_endpoint(usbd_device *usbd_dev,
 				    struct usb_setup_data *req, uint8_t **buf,
 				    uint16_t *len);
-int _usbd_standard_request(usbd_device *usbd_dev, struct usb_setup_data *req,
+enum usbd_request_return_codes _usbd_standard_request(usbd_device *usbd_dev, struct usb_setup_data *req,
 			   uint8_t **buf, uint16_t *len);
 
 void _usbd_reset(usbd_device *usbd_dev);

--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -144,9 +144,10 @@ static int usb_descriptor_index(uint16_t wValue)
 	return wValue & 0xFF;
 }
 
-static int usb_standard_get_descriptor(usbd_device *usbd_dev,
-				       struct usb_setup_data *req,
-				       uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_get_descriptor(usbd_device *usbd_dev,
+			    struct usb_setup_data *req,
+			    uint8_t **buf, uint16_t *len)
 {
 	int i, array_idx, descr_idx;
 	struct usb_string_descriptor *sd;
@@ -215,9 +216,10 @@ static int usb_standard_get_descriptor(usbd_device *usbd_dev,
 	return USBD_REQ_NOTSUPP;
 }
 
-static int usb_standard_set_address(usbd_device *usbd_dev,
-				    struct usb_setup_data *req, uint8_t **buf,
-				    uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_set_address(usbd_device *usbd_dev,
+			 struct usb_setup_data *req, uint8_t **buf,
+			 uint16_t *len)
 {
 	(void)req;
 	(void)buf;
@@ -225,7 +227,7 @@ static int usb_standard_set_address(usbd_device *usbd_dev,
 
 	/* The actual address is only latched at the STATUS IN stage. */
 	if ((req->bmRequestType != 0) || (req->wValue >= 128)) {
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 
 	usbd_dev->current_address = req->wValue;
@@ -238,12 +240,13 @@ static int usb_standard_set_address(usbd_device *usbd_dev,
 		usbd_dev->driver->set_address(usbd_dev, req->wValue);
 	}
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_set_configuration(usbd_device *usbd_dev,
-					  struct usb_setup_data *req,
-					  uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_set_configuration(usbd_device *usbd_dev,
+			       struct usb_setup_data *req,
+			       uint8_t **buf, uint16_t *len)
 {
 	int i;
 
@@ -253,7 +256,7 @@ static int usb_standard_set_configuration(usbd_device *usbd_dev,
 
 	/* Is this correct, or should we reset alternate settings. */
 	if (req->wValue == usbd_dev->current_config) {
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
 
 	usbd_dev->current_config = req->wValue;
@@ -278,12 +281,13 @@ static int usb_standard_set_configuration(usbd_device *usbd_dev,
 		}
 	}
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_get_configuration(usbd_device *usbd_dev,
-					  struct usb_setup_data *req,
-					  uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_get_configuration(usbd_device *usbd_dev,
+			       struct usb_setup_data *req,
+			       uint8_t **buf, uint16_t *len)
 {
 	(void)req;
 
@@ -292,12 +296,13 @@ static int usb_standard_get_configuration(usbd_device *usbd_dev,
 	}
 	(*buf)[0] = usbd_dev->current_config;
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_set_interface(usbd_device *usbd_dev,
-				      struct usb_setup_data *req,
-				      uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_set_interface(usbd_device *usbd_dev,
+			   struct usb_setup_data *req,
+			   uint8_t **buf, uint16_t *len)
 {
 	const struct usb_config_descriptor *cfx = &usbd_dev->config[usbd_dev->current_config - 1];
 	const struct usb_interface *iface;
@@ -330,9 +335,10 @@ static int usb_standard_set_interface(usbd_device *usbd_dev,
 	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_get_interface(usbd_device *usbd_dev,
-				      struct usb_setup_data *req,
-				      uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_get_interface(usbd_device *usbd_dev,
+			   struct usb_setup_data *req,
+			   uint8_t **buf, uint16_t *len)
 {
 	uint8_t *cur_altsetting;
 	const struct usb_config_descriptor *cfx = &usbd_dev->config[usbd_dev->current_config - 1];
@@ -348,9 +354,10 @@ static int usb_standard_get_interface(usbd_device *usbd_dev,
 	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_device_get_status(usbd_device *usbd_dev,
-					  struct usb_setup_data *req,
-					  uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_device_get_status(usbd_device *usbd_dev,
+			       struct usb_setup_data *req,
+			       uint8_t **buf, uint16_t *len)
 {
 	(void)usbd_dev;
 	(void)req;
@@ -363,12 +370,13 @@ static int usb_standard_device_get_status(usbd_device *usbd_dev,
 	(*buf)[0] = 0;
 	(*buf)[1] = 0;
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_interface_get_status(usbd_device *usbd_dev,
-					     struct usb_setup_data *req,
-					     uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_interface_get_status(usbd_device *usbd_dev,
+				  struct usb_setup_data *req,
+				  uint8_t **buf, uint16_t *len)
 {
 	(void)usbd_dev;
 	(void)req;
@@ -380,12 +388,13 @@ static int usb_standard_interface_get_status(usbd_device *usbd_dev,
 	(*buf)[0] = 0;
 	(*buf)[1] = 0;
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_endpoint_get_status(usbd_device *usbd_dev,
-					    struct usb_setup_data *req,
-					    uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_endpoint_get_status(usbd_device *usbd_dev,
+				 struct usb_setup_data *req,
+				 uint8_t **buf, uint16_t *len)
 {
 	(void)req;
 
@@ -395,42 +404,46 @@ static int usb_standard_endpoint_get_status(usbd_device *usbd_dev,
 	(*buf)[0] = usbd_ep_stall_get(usbd_dev, req->wIndex) ? 1 : 0;
 	(*buf)[1] = 0;
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_endpoint_stall(usbd_device *usbd_dev,
-				       struct usb_setup_data *req,
-				       uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_endpoint_stall(usbd_device *usbd_dev,
+			    struct usb_setup_data *req,
+			    uint8_t **buf, uint16_t *len)
 {
 	(void)buf;
 	(void)len;
 
 	usbd_ep_stall_set(usbd_dev, req->wIndex, 1);
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
-static int usb_standard_endpoint_unstall(usbd_device *usbd_dev,
-					 struct usb_setup_data *req,
-					 uint8_t **buf, uint16_t *len)
+static enum usbd_request_return_codes
+usb_standard_endpoint_unstall(usbd_device *usbd_dev,
+			      struct usb_setup_data *req,
+			      uint8_t **buf, uint16_t *len)
 {
 	(void)buf;
 	(void)len;
 
 	usbd_ep_stall_set(usbd_dev, req->wIndex, 0);
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
 /* Do not appear to belong to the API, so are omitted from docs */
 /**@}*/
 
-int _usbd_standard_request_device(usbd_device *usbd_dev,
-				  struct usb_setup_data *req, uint8_t **buf,
-				  uint16_t *len)
+enum usbd_request_return_codes
+_usbd_standard_request_device(usbd_device *usbd_dev,
+			      struct usb_setup_data *req, uint8_t **buf,
+			      uint16_t *len)
 {
-	int (*command)(usbd_device *usbd_dev, struct usb_setup_data *req,
-		       uint8_t **buf, uint16_t *len) = NULL;
+	enum usbd_request_return_codes (*command)(usbd_device *usbd_dev,
+		struct usb_setup_data *req,
+		uint8_t **buf, uint16_t *len) = NULL;
 
 	switch (req->bRequest) {
 	case USB_REQ_CLEAR_FEATURE:
@@ -473,18 +486,20 @@ int _usbd_standard_request_device(usbd_device *usbd_dev,
 	}
 
 	if (!command) {
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 
 	return command(usbd_dev, req, buf, len);
 }
 
-int _usbd_standard_request_interface(usbd_device *usbd_dev,
-				     struct usb_setup_data *req, uint8_t **buf,
-				     uint16_t *len)
+enum usbd_request_return_codes
+_usbd_standard_request_interface(usbd_device *usbd_dev,
+				 struct usb_setup_data *req, uint8_t **buf,
+				 uint16_t *len)
 {
-	int (*command)(usbd_device *usbd_dev, struct usb_setup_data *req,
-		       uint8_t **buf, uint16_t *len) = NULL;
+	enum usbd_request_return_codes (*command)(usbd_device *usbd_dev,
+		struct usb_setup_data *req,
+		uint8_t **buf, uint16_t *len) = NULL;
 
 	switch (req->bRequest) {
 	case USB_REQ_CLEAR_FEATURE:
@@ -503,18 +518,20 @@ int _usbd_standard_request_interface(usbd_device *usbd_dev,
 	}
 
 	if (!command) {
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 
 	return command(usbd_dev, req, buf, len);
 }
 
-int _usbd_standard_request_endpoint(usbd_device *usbd_dev,
-				    struct usb_setup_data *req, uint8_t **buf,
-				    uint16_t *len)
+enum usbd_request_return_codes
+_usbd_standard_request_endpoint(usbd_device *usbd_dev,
+				struct usb_setup_data *req, uint8_t **buf,
+				uint16_t *len)
 {
-	int (*command) (usbd_device *usbd_dev, struct usb_setup_data *req,
-			uint8_t **buf, uint16_t *len) = NULL;
+	enum usbd_request_return_codes (*command) (usbd_device *usbd_dev,
+		struct usb_setup_data *req,
+		uint8_t **buf, uint16_t *len) = NULL;
 
 	switch (req->bRequest) {
 	case USB_REQ_CLEAR_FEATURE:
@@ -540,18 +557,19 @@ int _usbd_standard_request_endpoint(usbd_device *usbd_dev,
 	}
 
 	if (!command) {
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 
 	return command(usbd_dev, req, buf, len);
 }
 
-int _usbd_standard_request(usbd_device *usbd_dev, struct usb_setup_data *req,
-			   uint8_t **buf, uint16_t *len)
+enum usbd_request_return_codes
+_usbd_standard_request(usbd_device *usbd_dev, struct usb_setup_data *req,
+		       uint8_t **buf, uint16_t *len)
 {
 	/* FIXME: Have class/vendor requests as well. */
 	if ((req->bmRequestType & USB_REQ_TYPE_TYPE) != USB_REQ_TYPE_STANDARD) {
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 
 	switch (req->bmRequestType & USB_REQ_TYPE_RECIPIENT) {
@@ -563,7 +581,7 @@ int _usbd_standard_request(usbd_device *usbd_dev, struct usb_setup_data *req,
 	case USB_REQ_TYPE_ENDPOINT:
 		return _usbd_standard_request_endpoint(usbd_dev, req, buf, len);
 	default:
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 }
 


### PR DESCRIPTION
The enum usbd_request_return_codes has been available for some time.  It
should be used internally, not just by users of this code.

Note: this is a superset of #481 (it completely replaces that pull request, by expanding it to not just use the return defines, but also fixes the signatures of those methods.
