### PR TITLE
Use type defined usbd_endpoint_callback callback

### DIFF
--- a/lib/lm4f/usb_lm4f.c
+++ b/lib/lm4f/usb_lm4f.c
@@ -263,7 +263,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_TXFIFOSZ = reg8;
 		USB_TXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_IN] =
+			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_IN] =
 			(void *)callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
@@ -276,7 +276,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_RXFIFOSZ = reg8;
 		USB_RXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_OUT] =
+			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_OUT] =
 			(void *)callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
@@ -504,14 +504,14 @@ static void lm4f_poll(usbd_device *usbd_dev)
 				? USB_TRANSACTION_SETUP :
 				  USB_TRANSACTION_OUT;
 
-			if (usbd_dev->user_callback_ctr[0][type]) {
+			if (usbd_dev->user_endpoint_callback[0][type]) {
 				usbd_dev->
-					user_callback_ctr[0][type](usbd_dev, 0);
+					user_endpoint_callback[0][type](usbd_dev, 0);
 			}
 
 
 		} else {
-			tx_cb = usbd_dev->user_callback_ctr[0]
+			tx_cb = usbd_dev->user_endpoint_callback[0]
 							   [USB_TRANSACTION_IN];
 
 			/*
@@ -542,8 +542,8 @@ static void lm4f_poll(usbd_device *usbd_dev)
 
 	/* See which interrupt occurred */
 	for (i = 1; i < 8; i++) {
-		tx_cb = usbd_dev->user_callback_ctr[i][USB_TRANSACTION_IN];
-		rx_cb = usbd_dev->user_callback_ctr[i][USB_TRANSACTION_OUT];
+		tx_cb = usbd_dev->user_endpoint_callback[i][USB_TRANSACTION_IN];
+		rx_cb = usbd_dev->user_endpoint_callback[i][USB_TRANSACTION_OUT];
 
 		if ((usb_txis & (1 << i)) && tx_cb) {
 			tx_cb(usbd_dev, i);

--- a/lib/lm4f/usb_lm4f.c
+++ b/lib/lm4f/usb_lm4f.c
@@ -186,7 +186,7 @@ static void lm4f_set_address(usbd_device *usbd_dev, uint8_t addr)
 
 static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 			  uint16_t max_size,
-			  void (*callback) (usbd_device *usbd_dev, uint8_t ep))
+			  usbd_endpoint_callback callback)
 {
 	(void)usbd_dev;
 	(void)type;
@@ -264,7 +264,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_TXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
 			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_IN] =
-			(void *)callback;
+				callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
 			USB_TXCSRH(ep) |= USB_TXCSRH_ISO;
@@ -277,7 +277,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_RXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
 			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_OUT] =
-			(void *)callback;
+				callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
 			USB_RXCSRH(ep) |= USB_RXCSRH_ISO;

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -79,11 +79,11 @@ usbd_device *usbd_init(const usbd_driver *driver,
 	usbd_dev->ctrl_buf = control_buffer;
 	usbd_dev->ctrl_buf_len = control_buffer_size;
 
-	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_SETUP] =
+	usbd_dev->user_endpoint_callback[0][USB_TRANSACTION_SETUP] =
 	    _usbd_control_setup;
-	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_OUT] =
+	usbd_dev->user_endpoint_callback[0][USB_TRANSACTION_OUT] =
 	    _usbd_control_out;
-	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_IN] =
+	usbd_dev->user_endpoint_callback[0][USB_TRANSACTION_IN] =
 	    _usbd_control_in;
 
 	int i;

--- a/lib/usb/usb_f103.c
+++ b/lib/usb/usb_f103.c
@@ -123,7 +123,7 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 	if (dir || (addr == 0)) {
 		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
 		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
+			dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
 			    (void *)callback;
 		}
 		USB_CLR_EP_TX_DTOG(addr);
@@ -135,7 +135,7 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 		USB_SET_EP_RX_ADDR(addr, dev->pm_top);
 		usb_set_ep_rx_bufsize(dev, addr, max_size);
 		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
+			dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
 			    (void *)callback;
 		}
 		USB_CLR_EP_RX_DTOG(addr);
@@ -316,8 +316,8 @@ static void stm32f103_poll(usbd_device *dev)
 			USB_CLR_EP_TX_CTR(ep);
 		}
 
-		if (dev->user_callback_ctr[ep][type]) {
-			dev->user_callback_ctr[ep][type] (dev, ep);
+		if (dev->user_endpoint_callback[ep][type]) {
+			dev->user_endpoint_callback[ep][type] (dev, ep);
 		} else {
 			USB_CLR_EP_RX_CTR(ep);
 		}

--- a/lib/usb/usb_f103.c
+++ b/lib/usb/usb_f103.c
@@ -28,8 +28,7 @@ static usbd_device *stm32f103_usbd_init(void);
 static void stm32f103_set_address(usbd_device *usbd_dev, uint8_t addr);
 static void stm32f103_ep_setup(usbd_device *usbd_dev, uint8_t addr,
 			       uint8_t type, uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep));
+			       usbd_endpoint_callback callback);
 static void stm32f103_endpoints_reset(usbd_device *usbd_dev);
 static void stm32f103_ep_stall_set(usbd_device *usbd_dev, uint8_t addr,
 				   uint8_t stall);
@@ -103,8 +102,7 @@ static void usb_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size)
 
 static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 			       uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep))
+			       usbd_endpoint_callback callback)
 {
 	/* Translate USB standard type codes to STM32. */
 	const uint16_t typelookup[] = {
@@ -124,7 +122,7 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
 		if (callback) {
 			dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
+			    callback;
 		}
 		USB_CLR_EP_TX_DTOG(addr);
 		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
@@ -136,7 +134,7 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 		usb_set_ep_rx_bufsize(dev, addr, max_size);
 		if (callback) {
 			dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
+			    callback;
 		}
 		USB_CLR_EP_RX_DTOG(addr);
 		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -95,7 +95,7 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		    | (addr << 22) | max_size;
 
 		if (callback) {
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
+			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
 			    (void *)callback;
 		}
 	}
@@ -109,7 +109,7 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		    OTG_FS_DOEPCTLX_SD0PID | (type << 18) | max_size;
 
 		if (callback) {
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
+			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
 			    (void *)callback;
 		}
 	}
@@ -277,8 +277,8 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 			__asm__("nop");
 		}
 
-		if (usbd_dev->user_callback_ctr[ep][type]) {
-			usbd_dev->user_callback_ctr[ep][type] (usbd_dev, ep);
+		if (usbd_dev->user_endpoint_callback[ep][type]) {
+			usbd_dev->user_endpoint_callback[ep][type] (usbd_dev, ep);
 		}
 
 		/* Discard unread packet data. */
@@ -296,9 +296,9 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 	for (i = 0; i < 4; i++) { /* Iterate over endpoints. */
 		if (REBASE(OTG_DIEPINT(i)) & OTG_FS_DIEPINTX_XFRC) {
 			/* Transfer complete. */
-			if (usbd_dev->user_callback_ctr[i]
+			if (usbd_dev->user_endpoint_callback[i]
 						       [USB_TRANSACTION_IN]) {
-				usbd_dev->user_callback_ctr[i]
+				usbd_dev->user_endpoint_callback[i]
 					[USB_TRANSACTION_IN](usbd_dev, i);
 			}
 

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -39,8 +39,7 @@ void stm32fx07_set_address(usbd_device *usbd_dev, uint8_t addr)
 }
 
 void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
-			uint16_t max_size,
-			void (*callback) (usbd_device *usbd_dev, uint8_t ep))
+			uint16_t max_size, usbd_endpoint_callback callback)
 {
 	/*
 	 * Configure endpoint address and type. Allocate FIFO memory for
@@ -96,7 +95,7 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 
 		if (callback) {
 			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
+			    callback;
 		}
 	}
 
@@ -110,7 +109,7 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 
 		if (callback) {
 			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
+			    callback;
 		}
 	}
 }

--- a/lib/usb/usb_fx07_common.h
+++ b/lib/usb/usb_fx07_common.h
@@ -22,8 +22,7 @@
 
 void stm32fx07_set_address(usbd_device *usbd_dev, uint8_t addr);
 void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
-			uint16_t max_size,
-			void (*callback)(usbd_device *usbd_dev, uint8_t ep));
+			uint16_t max_size, usbd_endpoint_callback callback);
 void stm32fx07_endpoints_reset(usbd_device *usbd_dev);
 void stm32fx07_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall);
 uint8_t stm32fx07_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -82,7 +82,7 @@ struct _usbd_device {
 		uint8_t type_mask;
 	} user_control_callback[MAX_USER_CONTROL_CALLBACK];
 
-	usbd_endpoint_callback user_callback_ctr[8][3];
+	usbd_endpoint_callback user_endpoint_callback[8][3];
 
 	/* User callback function for some standard USB function hooks */
 	usbd_set_config_callback user_callback_set_config[MAX_USER_SET_CONFIG_CALLBACK];


### PR DESCRIPTION
Use type defined usbd_endpoint_callback callback for callback instead of
 void (*callback)(usbd_device *usbd_dev, uint8_t ep) in source

preq: #483