### PR TITLE
Send ZLP if app send less data than host expecting and send length is multiple of bMaxPacketSize0

### DIFF
--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -74,6 +74,7 @@ struct _usbd_device {
 		uint8_t *ctrl_buf;
 		uint16_t ctrl_len;
 		usbd_control_complete_callback complete;
+		bool send_zlp_at_end;
 	} control_state;
 
 	struct user_control_callback {


### PR DESCRIPTION
[USB] If the application
 - send smaller length data than the host requested and
 - the send data is multiple of bMaxPacketSize0.
If the condition occur, a ZLP (Zero Length Packet) need to be send to the host to tell that
 the device is out of data and will not further send anymore data.

This fix only apply to Control IN Request

(if the second condition do not occur, a packet of length less than bMaxPacketSize0 is send to host. using that host can automatically infer that device is out of data)

use the firmware and python script to test the patch provided
https://github.com/kuldeepdhaka/libopencm3-examples/tree/usb-stack-tester

reference: #194 