### PR TITLE
commonize ep setup code

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -120,6 +120,9 @@ extern uint8_t usbd_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);
 
 extern void usbd_ep_nak_set(usbd_device *usbd_dev, uint8_t addr, uint8_t nak);
 
+extern void usbd_ep_callback_set(usbd_device *usbd_dev, uint8_t addr,
+			usbd_endpoint_callback callback);
+
 /* Optional */
 extern void usbd_cable_connect(usbd_device *usbd_dev, uint8_t on);
 

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -145,7 +145,8 @@ void usbd_disconnect(usbd_device *usbd_dev, bool disconnected)
 void usbd_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		   uint16_t max_size, usbd_endpoint_callback callback)
 {
-	usbd_dev->driver->ep_setup(usbd_dev, addr, type, max_size, callback);
+	usbd_dev->driver->ep_setup(usbd_dev, addr, type, max_size);
+	usbd_ep_callback_set(usbd_dev, addr, callback);
 }
 
 uint16_t usbd_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
@@ -182,7 +183,7 @@ void usbd_ep_callback_set(usbd_device *usbd_dev, uint8_t addr,
 		USB_TRANSACTION_IN : USB_TRANSACTION_OUT;
 	addr &= 0x7F;
 
-	if(addr) {
+	if (addr) {
 		usbd_dev->user_endpoint_callback[addr][dir] = callback;
 	}
 }

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -79,11 +79,11 @@ usbd_device *usbd_init(const usbd_driver *driver,
 	usbd_dev->ctrl_buf = control_buffer;
 	usbd_dev->ctrl_buf_len = control_buffer_size;
 
-	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_SETUP] =
+	usbd_dev->user_endpoint_callback[0][USB_TRANSACTION_SETUP] =
 	    _usbd_control_setup;
-	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_OUT] =
+	usbd_dev->user_endpoint_callback[0][USB_TRANSACTION_OUT] =
 	    _usbd_control_out;
-	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_IN] =
+	usbd_dev->user_endpoint_callback[0][USB_TRANSACTION_IN] =
 	    _usbd_control_in;
 
 	int i;

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -175,5 +175,17 @@ void usbd_ep_nak_set(usbd_device *usbd_dev, uint8_t addr, uint8_t nak)
 	usbd_dev->driver->ep_nak_set(usbd_dev, addr, nak);
 }
 
+void usbd_ep_callback_set(usbd_device *usbd_dev, uint8_t addr,
+			usbd_endpoint_callback callback)
+{
+	enum _usbd_transaction dir = (addr & 0x80) ?
+		USB_TRANSACTION_IN : USB_TRANSACTION_OUT;
+	addr &= 0x7F;
+
+	if(addr) {
+		usbd_dev->user_endpoint_callback[addr][dir] = callback;
+	}
+}
+
 /**@}*/
 

--- a/lib/usb/usb_f103.c
+++ b/lib/usb/usb_f103.c
@@ -123,7 +123,7 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 	if (dir || (addr == 0)) {
 		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
 		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
+			dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
 			    (void *)callback;
 		}
 		USB_CLR_EP_TX_DTOG(addr);
@@ -135,7 +135,7 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 		USB_SET_EP_RX_ADDR(addr, dev->pm_top);
 		usb_set_ep_rx_bufsize(dev, addr, max_size);
 		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
+			dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
 			    (void *)callback;
 		}
 		USB_CLR_EP_RX_DTOG(addr);
@@ -316,8 +316,8 @@ static void stm32f103_poll(usbd_device *dev)
 			USB_CLR_EP_TX_CTR(ep);
 		}
 
-		if (dev->user_callback_ctr[ep][type]) {
-			dev->user_callback_ctr[ep][type] (dev, ep);
+		if (dev->user_endpoint_callback[ep][type]) {
+			dev->user_endpoint_callback[ep][type] (dev, ep);
 		} else {
 			USB_CLR_EP_RX_CTR(ep);
 		}

--- a/lib/usb/usb_f103.c
+++ b/lib/usb/usb_f103.c
@@ -27,9 +27,7 @@
 static usbd_device *stm32f103_usbd_init(void);
 static void stm32f103_set_address(usbd_device *usbd_dev, uint8_t addr);
 static void stm32f103_ep_setup(usbd_device *usbd_dev, uint8_t addr,
-			       uint8_t type, uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep));
+			       uint8_t type, uint16_t max_size);
 static void stm32f103_endpoints_reset(usbd_device *usbd_dev);
 static void stm32f103_ep_stall_set(usbd_device *usbd_dev, uint8_t addr,
 				   uint8_t stall);
@@ -102,9 +100,7 @@ static void usb_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size)
 }
 
 static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
-			       uint16_t max_size,
-			       void (*callback) (usbd_device *usbd_dev,
-						 uint8_t ep))
+			       uint16_t max_size)
 {
 	/* Translate USB standard type codes to STM32. */
 	const uint16_t typelookup[] = {
@@ -122,10 +118,6 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 
 	if (dir || (addr == 0)) {
 		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
-		if (callback) {
-			dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
-		}
 		USB_CLR_EP_TX_DTOG(addr);
 		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
 		dev->pm_top += max_size;
@@ -134,10 +126,6 @@ static void stm32f103_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 	if (!dir) {
 		USB_SET_EP_RX_ADDR(addr, dev->pm_top);
 		usb_set_ep_rx_bufsize(dev, addr, max_size);
-		if (callback) {
-			dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
-		}
 		USB_CLR_EP_RX_DTOG(addr);
 		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
 		dev->pm_top += max_size;

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -95,7 +95,7 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		    | (addr << 22) | max_size;
 
 		if (callback) {
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
+			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
 			    (void *)callback;
 		}
 	}
@@ -109,7 +109,7 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		    OTG_DOEPCTLX_SD0PID | (type << 18) | max_size;
 
 		if (callback) {
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
+			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
 			    (void *)callback;
 		}
 	}
@@ -277,8 +277,8 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 			__asm__("nop");
 		}
 
-		if (usbd_dev->user_callback_ctr[ep][type]) {
-			usbd_dev->user_callback_ctr[ep][type] (usbd_dev, ep);
+		if (usbd_dev->user_endpoint_callback[ep][type]) {
+			usbd_dev->user_endpoint_callback[ep][type] (usbd_dev, ep);
 		}
 
 		/* Discard unread packet data. */
@@ -296,9 +296,9 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 	for (i = 0; i < 4; i++) { /* Iterate over endpoints. */
 		if (REBASE(OTG_DIEPINT(i)) & OTG_DIEPINTX_XFRC) {
 			/* Transfer complete. */
-			if (usbd_dev->user_callback_ctr[i]
+			if (usbd_dev->user_endpoint_callback[i]
 						       [USB_TRANSACTION_IN]) {
-				usbd_dev->user_callback_ctr[i]
+				usbd_dev->user_endpoint_callback[i]
 					[USB_TRANSACTION_IN](usbd_dev, i);
 			}
 

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -39,8 +39,7 @@ void stm32fx07_set_address(usbd_device *usbd_dev, uint8_t addr)
 }
 
 void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
-			uint16_t max_size,
-			void (*callback) (usbd_device *usbd_dev, uint8_t ep))
+			uint16_t max_size)
 {
 	/*
 	 * Configure endpoint address and type. Allocate FIFO memory for
@@ -93,11 +92,6 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		    OTG_DIEPCTL0_EPENA | OTG_DIEPCTL0_SNAK | (type << 18)
 		    | OTG_DIEPCTL0_USBAEP | OTG_DIEPCTLX_SD0PID
 		    | (addr << 22) | max_size;
-
-		if (callback) {
-			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
-		}
 	}
 
 	if (!dir) {
@@ -107,11 +101,6 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		REBASE(OTG_DOEPCTL(addr)) |= OTG_DOEPCTL0_EPENA |
 		    OTG_DOEPCTL0_USBAEP | OTG_DIEPCTL0_CNAK |
 		    OTG_DOEPCTLX_SD0PID | (type << 18) | max_size;
-
-		if (callback) {
-			usbd_dev->user_endpoint_callback[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
-		}
 	}
 }
 

--- a/lib/usb/usb_fx07_common.h
+++ b/lib/usb/usb_fx07_common.h
@@ -22,8 +22,7 @@
 
 void stm32fx07_set_address(usbd_device *usbd_dev, uint8_t addr);
 void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
-			uint16_t max_size,
-			void (*callback)(usbd_device *usbd_dev, uint8_t ep));
+			uint16_t max_size);
 void stm32fx07_endpoints_reset(usbd_device *usbd_dev);
 void stm32fx07_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall);
 uint8_t stm32fx07_ep_stall_get(usbd_device *usbd_dev, uint8_t addr);

--- a/lib/usb/usb_lm4f.c
+++ b/lib/usb/usb_lm4f.c
@@ -263,7 +263,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_TXFIFOSZ = reg8;
 		USB_TXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_IN] =
+			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_IN] =
 			(void *)callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
@@ -276,7 +276,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_RXFIFOSZ = reg8;
 		USB_RXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_OUT] =
+			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_OUT] =
 			(void *)callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
@@ -504,14 +504,14 @@ static void lm4f_poll(usbd_device *usbd_dev)
 				? USB_TRANSACTION_SETUP :
 				  USB_TRANSACTION_OUT;
 
-			if (usbd_dev->user_callback_ctr[0][type]) {
+			if (usbd_dev->user_endpoint_callback[0][type]) {
 				usbd_dev->
-					user_callback_ctr[0][type](usbd_dev, 0);
+					user_endpoint_callback[0][type](usbd_dev, 0);
 			}
 
 
 		} else {
-			tx_cb = usbd_dev->user_callback_ctr[0]
+			tx_cb = usbd_dev->user_endpoint_callback[0]
 							   [USB_TRANSACTION_IN];
 
 			/*
@@ -542,8 +542,8 @@ static void lm4f_poll(usbd_device *usbd_dev)
 
 	/* See which interrupt occurred */
 	for (i = 1; i < 8; i++) {
-		tx_cb = usbd_dev->user_callback_ctr[i][USB_TRANSACTION_IN];
-		rx_cb = usbd_dev->user_callback_ctr[i][USB_TRANSACTION_OUT];
+		tx_cb = usbd_dev->user_endpoint_callback[i][USB_TRANSACTION_IN];
+		rx_cb = usbd_dev->user_endpoint_callback[i][USB_TRANSACTION_OUT];
 
 		if ((usb_txis & (1 << i)) && tx_cb) {
 			tx_cb(usbd_dev, i);

--- a/lib/usb/usb_lm4f.c
+++ b/lib/usb/usb_lm4f.c
@@ -185,8 +185,7 @@ static void lm4f_set_address(usbd_device *usbd_dev, uint8_t addr)
 }
 
 static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
-			  uint16_t max_size,
-			  void (*callback) (usbd_device *usbd_dev, uint8_t ep))
+			  uint16_t max_size)
 {
 	(void)usbd_dev;
 	(void)type;
@@ -262,10 +261,6 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_TXMAXP(ep) = max_size;
 		USB_TXFIFOSZ = reg8;
 		USB_TXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
-		if (callback) {
-			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_IN] =
-			(void *)callback;
-		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
 			USB_TXCSRH(ep) |= USB_TXCSRH_ISO;
 		} else {
@@ -275,10 +270,6 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_RXMAXP(ep) = max_size;
 		USB_RXFIFOSZ = reg8;
 		USB_RXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
-		if (callback) {
-			usbd_dev->user_endpoint_callback[ep][USB_TRANSACTION_OUT] =
-			(void *)callback;
-		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
 			USB_RXCSRH(ep) |= USB_RXCSRH_ISO;
 		} else {

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -82,7 +82,7 @@ struct _usbd_device {
 		uint8_t type_mask;
 	} user_control_callback[MAX_USER_CONTROL_CALLBACK];
 
-	usbd_endpoint_callback user_callback_ctr[8][3];
+	usbd_endpoint_callback user_endpoint_callback[8][3];
 
 	/* User callback function for some standard USB function hooks */
 	usbd_set_config_callback user_callback_set_config[MAX_USER_SET_CONFIG_CALLBACK];

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -141,7 +141,7 @@ struct _usbd_driver {
 	usbd_device *(*init)(void);
 	void (*set_address)(usbd_device *usbd_dev, uint8_t addr);
 	void (*ep_setup)(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
-			 uint16_t max_size, usbd_endpoint_callback cb);
+			 uint16_t max_size);
 	void (*ep_reset)(usbd_device *usbd_dev);
 	void (*ep_stall_set)(usbd_device *usbd_dev, uint8_t addr,
 			     uint8_t stall);


### PR DESCRIPTION
 [USB] Commonize the storage of reference of endpoint callback.

Seperate usbd_ep_setup() frontend into two calls.
 - backend->usbd_ep_setup()
 - usbd_ep_callback_set()

since earlier, all the backend ep_setup() are doing the same thing over and over.

preq: #420
if  this commit is merged, {#501, #488} can be closed without merge (what they where trying to change is removed by this commit).