### PR TITLE
[USB] Commonize the OTG {FS, HS} with proper defination.

### DIFF
--- a/include/libopencm3/stm32/common/otg_common_all.h
+++ b/include/libopencm3/stm32/common/otg_common_all.h
@@ -1,0 +1,332 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_OTG_COMMON_ALL_H
+#define LIBOPENCM3_OTG_COMMON_ALL_H
+
+/* Core Global Control and Status Registers */
+#define OTG_GOTGCTL(base)		MMIO32(base + 0x000)
+#define OTG_GOTGIN(base)		MMIO32(base + 0x004)
+#define OTG_GAHBCFG(base)		MMIO32(base + 0x008)
+#define OTG_GUSBCFG(base)		MMIO32(base + 0x00C)
+#define OTG_GRSTCTL(base)		MMIO32(base + 0x010)
+#define OTG_GINTSTS(base)		MMIO32(base + 0x014)
+#define OTG_GINTMSK(base)		MMIO32(base + 0x018)
+#define OTG_GRXSTSR(base)		MMIO32(base + 0x01C)
+#define OTG_GRXSTSP(base)		MMIO32(base + 0x020)
+#define OTG_GRXFSIZ(base)		MMIO32(base + 0x024)
+#define OTG_GNPTXFSIZ(base)		MMIO32(base + 0x028)
+#define OTG_GNPTXSTS(base)		MMIO32(base + 0x02C)
+#define OTG_GCCFG(base)			MMIO32(base + 0x038)
+#define OTG_CID(base)			MMIO32(base + 0x03C)
+#define OTG_HPTXFSIZ(base)		MMIO32(base + 0x100)
+#define OTG_DIEPTXF(base, x)	MMIO32(base + (0x104 + 4*(x-1)))
+
+/* Host-mode Control and Status Registers */
+#define OTG_HCFG(base)			MMIO32(base + 0x400)
+#define OTG_HFIR(base)			MMIO32(base + 0x404)
+#define OTG_HFNUM(base)			MMIO32(base + 0x408)
+#define OTG_HPTXSTS(base)		MMIO32(base + 0x410)
+#define OTG_HAINT(base)			MMIO32(base + 0x414)
+#define OTG_HAINTMSK(base)		MMIO32(base + 0x418)
+#define OTG_HPRT(base)			MMIO32(base + 0x440)
+#define OTG_HCCHARx(base)		MMIO32(base + 0x500)
+#define OTG_HCINTx(base)		MMIO32(base + 0x508)
+#define OTG_HCINTMSKx(base)		MMIO32(base + 0x50C)
+#define OTG_HCTSIZx(base)		MMIO32(base + 0x510)
+
+/* Device-mode Control and Status Registers */
+#define OTG_DCFG(base)			MMIO32(base + 0x800)
+#define OTG_DCTL(base)			MMIO32(base + 0x804)
+#define OTG_DSTS(base)			MMIO32(base + 0x808)
+#define OTG_DIEPMSK(base)		MMIO32(base + 0x810)
+#define OTG_DOEPMSK(base)		MMIO32(base + 0x814)
+#define OTG_DAINT(base)			MMIO32(base + 0x818)
+#define OTG_DAINTMSK(base)		MMIO32(base + 0x81C)
+#define OTG_DVBUSDIS(base)		MMIO32(base + 0x828)
+#define OTG_DVBUSPULSE(base)	MMIO32(base + 0x82C)
+#define OTG_DIEPEMPMSK(base)	MMIO32(base + 0x834)
+#define OTG_DIEPCTL0(base)		MMIO32(base + 0x900)
+#define OTG_DIEPCTL(base, x)	MMIO32(base + (0x900 + 0x20*(x)))
+#define OTG_DOEPCTL0(base)		MMIO32(base + 0xB00)
+#define OTG_DOEPCTL(base, x)	MMIO32(base + (0xB00 + 0x20*(x)))
+#define OTG_DIEPINT(base, x)	MMIO32(base + (0x908 + 0x20*(x)))
+#define OTG_DOEPINT(base, x)	MMIO32(base + (0xB08 + 0x20*(x)))
+#define OTG_DIEPTSIZ0(base)		MMIO32(base + 0x910)
+#define OTG_DOEPTSIZ0(base)		MMIO32(base + 0xB10)
+#define OTG_DIEPTSIZ(base, x)	MMIO32(base + (0x910 + 0x20*(x)))
+#define OTG_DTXFSTS(base, x)	MMIO32(base + (0x918 + 0x20*(x)))
+#define OTG_DOEPTSIZ(base, x)	MMIO32(base + (0xB10 + 0x20*(x)))
+
+/* Power and clock gating control and status register */
+#define OTG_PCGCCTL(base)		MMIO32(base + 0xE00)
+
+/* Data FIFO */
+#define OTG_FIFO(base, x)			(&MMIO32(base + (((x) + 1) << 12)))
+
+/* Global CSRs */
+/* OTG_FS USB control registers (OTG_HS_GOTGCTL) */
+#define OTG_GOTGCTL_BSVLD		(1 << 19)
+#define OTG_GOTGCTL_ASVLD		(1 << 18)
+#define OTG_GOTGCTL_DBCT		(1 << 17)
+#define OTG_GOTGCTL_CIDSTS		(1 << 16)
+#define OTG_GOTGCTL_DHNPEN		(1 << 11)
+#define OTG_GOTGCTL_HSHNPEN		(1 << 10)
+#define OTG_GOTGCTL_HNPRQ		(1 << 9)
+#define OTG_GOTGCTL_HNGSCS		(1 << 8)
+#define OTG_GOTGCTL_SRQ			(1 << 1)
+#define OTG_GOTGCTL_SRQSCS		(1 << 0)
+
+/* OTG_FS AHB configuration register (OTG_GAHBCFG) */
+#define OTG_GAHBCFG_GINT		0x0001
+#define OTG_GAHBCFG_TXFELVL		0x0080
+#define OTG_GAHBCFG_PTXFELVL	0x0100
+
+/* OTG_FS USB configuration register (OTG_GUSBCFG) */
+#define OTG_GUSBCFG_TOCAL		0x00000003
+#define OTG_GUSBCFG_SRPCAP		0x00000100
+#define OTG_GUSBCFG_HNPCAP		0x00000200
+#define OTG_GUSBCFG_TRDT_MASK	(0xf << 10)
+#define OTG_GUSBCFG_TRDT_16BIT	(0x5 << 10)
+#define OTG_GUSBCFG_TRDT_8BIT	(0x9 << 10)
+#define OTG_GUSBCFG_NPTXRWEN	0x00004000
+#define OTG_GUSBCFG_FHMOD		0x20000000
+#define OTG_GUSBCFG_FDMOD		0x40000000
+#define OTG_GUSBCFG_CTXPKT		0x80000000
+#define OTG_GUSBCFG_PHYSEL		(1 << 7)
+
+/* OTG_FS reset register (OTG_GRSTCTL) */
+#define OTG_GRSTCTL_AHBIDL		(1 << 31)
+/* Bits 30:11 - Reserved */
+#define OTG_GRSTCTL_TXFNUM_MASK	(0x1f << 6)
+#define OTG_GRSTCTL_TXFFLSH		(1 << 5)
+#define OTG_GRSTCTL_RXFFLSH		(1 << 4)
+/* Bit 3 - Reserved */
+#define OTG_GRSTCTL_FCRST		(1 << 2)
+#define OTG_GRSTCTL_HSRST		(1 << 1)
+#define OTG_GRSTCTL_CSRST		(1 << 0)
+
+/* OTG_FS interrupt status register (OTG_GINTSTS) */
+#define OTG_GINTSTS_WKUPINT		(1 << 31)
+#define OTG_GINTSTS_SRQINT		(1 << 30)
+#define OTG_GINTSTS_DISCINT		(1 << 29)
+#define OTG_GINTSTS_CIDSCHG		(1 << 28)
+/* Bit 27 - Reserved */
+#define OTG_GINTSTS_PTXFE		(1 << 26)
+#define OTG_GINTSTS_HCINT		(1 << 25)
+#define OTG_GINTSTS_HPRTINT		(1 << 24)
+/* Bits 23:22 - Reserved */
+#define OTG_GINTSTS_IPXFR		(1 << 21)
+#define OTG_GINTSTS_INCOMPISOOUT	(1 << 21)
+#define OTG_GINTSTS_IISOIXFR		(1 << 20)
+#define OTG_GINTSTS_OEPINT		(1 << 19)
+#define OTG_GINTSTS_IEPINT		(1 << 18)
+/* Bits 17:16 - Reserved */
+#define OTG_GINTSTS_EOPF		(1 << 15)
+#define OTG_GINTSTS_ISOODRP		(1 << 14)
+#define OTG_GINTSTS_ENUMDNE		(1 << 13)
+#define OTG_GINTSTS_USBRST		(1 << 12)
+#define OTG_GINTSTS_USBSUSP		(1 << 11)
+#define OTG_GINTSTS_ESUSP		(1 << 10)
+/* Bits 9:8 - Reserved */
+#define OTG_GINTSTS_GONAKEFF	(1 << 7)
+#define OTG_GINTSTS_GINAKEFF	(1 << 6)
+#define OTG_GINTSTS_NPTXFE		(1 << 5)
+#define OTG_GINTSTS_RXFLVL		(1 << 4)
+#define OTG_GINTSTS_SOF			(1 << 3)
+#define OTG_GINTSTS_OTGINT		(1 << 2)
+#define OTG_GINTSTS_MMIS		(1 << 1)
+#define OTG_GINTSTS_CMOD		(1 << 0)
+
+/* OTG_FS interrupt mask register (OTG_GINTMSK) */
+#define OTG_GINTMSK_MMISM		0x00000002
+#define OTG_GINTMSK_OTGINT		0x00000004
+#define OTG_GINTMSK_SOFM		0x00000008
+#define OTG_GINTMSK_RXFLVLM		0x00000010
+#define OTG_GINTMSK_NPTXFEM		0x00000020
+#define OTG_GINTMSK_GINAKEFFM	0x00000040
+#define OTG_GINTMSK_GONAKEFFM	0x00000080
+#define OTG_GINTMSK_ESUSPM		0x00000400
+#define OTG_GINTMSK_USBSUSPM	0x00000800
+#define OTG_GINTMSK_USBRST		0x00001000
+#define OTG_GINTMSK_ENUMDNEM	0x00002000
+#define OTG_GINTMSK_ISOODRPM	0x00004000
+#define OTG_GINTMSK_EOPFM		0x00008000
+#define OTG_GINTMSK_EPMISM		0x00020000
+#define OTG_GINTMSK_IEPINT		0x00040000
+#define OTG_GINTMSK_OEPINT		0x00080000
+#define OTG_GINTMSK_IISOIXFRM	0x00100000
+#define OTG_GINTMSK_IISOOXFRM	0x00200000
+#define OTG_GINTMSK_IPXFRM		0x00200000
+#define OTG_GINTMSK_PRTIM		0x01000000
+#define OTG_GINTMSK_HCIM		0x02000000
+#define OTG_GINTMSK_PTXFEM		0x04000000
+#define OTG_GINTMSK_CIDSCHGM	0x10000000
+#define OTG_GINTMSK_DISCINT		0x20000000
+#define OTG_GINTMSK_SRQIM		0x40000000
+#define OTG_GINTMSK_WUIM		0x80000000
+
+/* OTG_FS Receive Status Pop Register (OTG_GRXSTSP) */
+/* Bits 31:25 - Reserved */
+#define OTG_GRXSTSP_FRMNUM_MASK		(0xf << 21)
+#define OTG_GRXSTSP_PKTSTS_MASK		(0xf << 17)
+#define OTG_GRXSTSP_PKTSTS_GOUTNAK	(0x1 << 17)
+#define OTG_GRXSTSP_PKTSTS_OUT		(0x2 << 17)
+#define OTG_GRXSTSP_PKTSTS_OUT_COMP		(0x3 << 17)
+#define OTG_GRXSTSP_PKTSTS_SETUP_COMP	(0x4 << 17)
+#define OTG_GRXSTSP_PKTSTS_SETUP		(0x6 << 17)
+#define OTG_GRXSTSP_DPID_MASK		(0x3 << 15)
+#define OTG_GRXSTSP_DPID_DATA0		(0x0 << 15)
+#define OTG_GRXSTSP_DPID_DATA1		(0x2 << 15)
+#define OTG_GRXSTSP_DPID_DATA2		(0x1 << 15)
+#define OTG_GRXSTSP_DPID_MDATA		(0x3 << 15)
+#define OTG_GRXSTSP_BCNT_MASK		(0x7ff << 4)
+#define OTG_GRXSTSP_EPNUM_MASK		(0xf << 0)
+
+/* OTG_FS general core configuration register (OTG_GCCFG) */
+/* Bits 31:22 - Reserved */
+#define OTG_GCCFG_NOVBUSSENS	(1 << 21)
+#define OTG_GCCFG_SOFOUTEN		(1 << 20)
+#define OTG_GCCFG_VBUSBSEN		(1 << 19)
+#define OTG_GCCFG_VBUSASEN		(1 << 18)
+/* Bit 17 - Reserved */
+#define OTG_GCCFG_PWRDWN		(1 << 16)
+/* Bits 15:0 - Reserved */
+
+
+/* Device-mode CSRs */
+/* OTG_FS device control register (OTG_DCTL) */
+/* Bits 31:12 - Reserved */
+#define OTG_DCTL_POPRGDNE		(1 << 11)
+#define OTG_DCTL_CGONAK		(1 << 10)
+#define OTG_DCTL_SGONAK		(1 << 9)
+#define OTG_DCTL_SGINAK		(1 << 8)
+#define OTG_DCTL_TCTL_MASK		(7 << 4)
+#define OTG_DCTL_GONSTS		(1 << 3)
+#define OTG_DCTL_GINSTS		(1 << 2)
+#define OTG_DCTL_SDIS		(1 << 1)
+#define OTG_DCTL_RWUSIG		(1 << 0)
+
+/* OTG_FS device configuration register (OTG_DCFG) */
+#define OTG_DCFG_DSPD		0x0003
+#define OTG_DCFG_NZLSOHSK	0x0004
+#define OTG_DCFG_DAD		0x07F0
+#define OTG_DCFG_PFIVL		0x1800
+
+/* OTG_FS Device IN Endpoint Common Interrupt Mask Register (OTG_DIEPMSK) */
+/* Bits 31:10 - Reserved */
+#define OTG_DIEPMSK_BIM			(1 << 9)
+#define OTG_DIEPMSK_TXFURM		(1 << 8)
+/* Bit 7 - Reserved */
+#define OTG_DIEPMSK_INEPNEM		(1 << 6)
+#define OTG_DIEPMSK_INEPNMM		(1 << 5)
+#define OTG_DIEPMSK_ITTXFEMSK	(1 << 4)
+#define OTG_DIEPMSK_TOM			(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DIEPMSK_EPDM		(1 << 1)
+#define OTG_DIEPMSK_XFRCM		(1 << 0)
+
+/* OTG_FS Device OUT Endpoint Common Interrupt Mask Register (OTG_DOEPMSK) */
+/* Bits 31:10 - Reserved */
+#define OTG_DOEPMSK_BOIM		(1 << 9)
+#define OTG_DOEPMSK_OPEM		(1 << 8)
+/* Bit 7 - Reserved */
+#define OTG_DOEPMSK_B2BSTUP		(1 << 6)
+/* Bit 5 - Reserved */
+#define OTG_DOEPMSK_OTEPDM		(1 << 4)
+#define OTG_DOEPMSK_STUPM		(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DOEPMSK_EPDM		(1 << 1)
+#define OTG_DOEPMSK_XFRCM		(1 << 0)
+
+/* OTG_FS Device Control IN Endpoint 0 Control Register (OTG_DIEPCTL0) */
+#define OTG_DIEPCTL0_EPENA		(1 << 31)
+#define OTG_DIEPCTL0_EPDIS		(1 << 30)
+/* Bits 29:28 - Reserved */
+#define OTG_DIEPCTLX_SD0PID		(1 << 28)
+#define OTG_DIEPCTL0_SNAK		(1 << 27)
+#define OTG_DIEPCTL0_CNAK		(1 << 26)
+#define OTG_DIEPCTL0_TXFNUM_MASK	(0xf << 22)
+#define OTG_DIEPCTL0_STALL		(1 << 21)
+/* Bit 20 - Reserved */
+#define OTG_DIEPCTL0_EPTYP_MASK	(0x3 << 18)
+#define OTG_DIEPCTL0_NAKSTS		(1 << 17)
+/* Bit 16 - Reserved */
+#define OTG_DIEPCTL0_USBAEP		(1 << 15)
+/* Bits 14:2 - Reserved */
+#define OTG_DIEPCTL0_MPSIZ_MASK	(0x3 << 0)
+#define OTG_DIEPCTL0_MPSIZ_64	(0x0 << 0)
+#define OTG_DIEPCTL0_MPSIZ_32	(0x1 << 0)
+#define OTG_DIEPCTL0_MPSIZ_16	(0x2 << 0)
+#define OTG_DIEPCTL0_MPSIZ_8		(0x3 << 0)
+
+/* OTG_FS Device Control OUT Endpoint 0 Control Register (OTG_DOEPCTL0) */
+#define OTG_DOEPCTL0_EPENA		(1 << 31)
+#define OTG_DOEPCTL0_EPDIS		(1 << 30)
+/* Bits 29:28 - Reserved */
+#define OTG_DOEPCTLX_SD0PID		(1 << 28)
+#define OTG_DOEPCTL0_SNAK		(1 << 27)
+#define OTG_DOEPCTL0_CNAK		(1 << 26)
+/* Bits 25:22 - Reserved */
+#define OTG_DOEPCTL0_STALL		(1 << 21)
+#define OTG_DOEPCTL0_SNPM		(1 << 20)
+#define OTG_DOEPCTL0_EPTYP_MASK	(0x3 << 18)
+#define OTG_DOEPCTL0_NAKSTS		(1 << 17)
+/* Bit 16 - Reserved */
+#define OTG_DOEPCTL0_USBAEP		(1 << 15)
+/* Bits 14:2 - Reserved */
+#define OTG_DOEPCTL0_MPSIZ_MASK	(0x3 << 0)
+#define OTG_DOEPCTL0_MPSIZ_64	(0x0 << 0)
+#define OTG_DOEPCTL0_MPSIZ_32	(0x1 << 0)
+#define OTG_DOEPCTL0_MPSIZ_16	(0x2 << 0)
+#define OTG_DOEPCTL0_MPSIZ_8	(0x3 << 0)
+
+/* OTG_FS Device IN Endpoint Interrupt Register (OTG_DIEPINTx) */
+/* Bits 31:8 - Reserved */
+#define OTG_DIEPINTX_TXFE		(1 << 7)
+#define OTG_DIEPINTX_INEPNE		(1 << 6)
+/* Bit 5 - Reserved */
+#define OTG_DIEPINTX_ITTXFE		(1 << 4)
+#define OTG_DIEPINTX_TOC		(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DIEPINTX_EPDISD		(1 << 1)
+#define OTG_DIEPINTX_XFRC		(1 << 0)
+
+/* OTG_FS Device IN Endpoint Interrupt Register (OTG_DOEPINTx) */
+/* Bits 31:7 - Reserved */
+#define OTG_DOEPINTX_B2BSTUP	(1 << 6)
+/* Bit 5 - Reserved */
+#define OTG_DOEPINTX_OTEPDIS	(1 << 4)
+#define OTG_DOEPINTX_STUP		(1 << 3)
+/* Bit 2 - Reserved */
+#define OTG_DOEPINTX_EPDISD		(1 << 1)
+#define OTG_DOEPINTX_XFRC		(1 << 0)
+
+/* OTG_FS Device OUT Endpoint 0 Transfer Size Register (OTG_DOEPTSIZ0) */
+/* Bit 31 - Reserved */
+#define OTG_DIEPSIZ0_STUPCNT_1	(0x1 << 29)
+#define OTG_DIEPSIZ0_STUPCNT_2	(0x2 << 29)
+#define OTG_DIEPSIZ0_STUPCNT_3	(0x3 << 29)
+#define OTG_DIEPSIZ0_STUPCNT_MASK	(0x3 << 29)
+/* Bits 28:20 - Reserved */
+#define OTG_DIEPSIZ0_PKTCNT		(1 << 19)
+/* Bits 18:7 - Reserved */
+#define OTG_DIEPSIZ0_XFRSIZ_MASK	(0x7f << 0)
+
+#endif

--- a/include/libopencm3/stm32/otg_fs.h
+++ b/include/libopencm3/stm32/otg_fs.h
@@ -27,324 +27,66 @@
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/common/otg_common_all.h>
 
 /* Core Global Control and Status Registers */
-#define OTG_FS_GOTGCTL			MMIO32(USB_OTG_FS_BASE + 0x000)
-#define OTG_FS_GOTGINT			MMIO32(USB_OTG_FS_BASE + 0x004)
-#define OTG_FS_GAHBCFG			MMIO32(USB_OTG_FS_BASE + 0x008)
-#define OTG_FS_GUSBCFG			MMIO32(USB_OTG_FS_BASE + 0x00C)
-#define OTG_FS_GRSTCTL			MMIO32(USB_OTG_FS_BASE + 0x010)
-#define OTG_FS_GINTSTS			MMIO32(USB_OTG_FS_BASE + 0x014)
-#define OTG_FS_GINTMSK			MMIO32(USB_OTG_FS_BASE + 0x018)
-#define OTG_FS_GRXSTSR			MMIO32(USB_OTG_FS_BASE + 0x01C)
-#define OTG_FS_GRXSTSP			MMIO32(USB_OTG_FS_BASE + 0x020)
-#define OTG_FS_GRXFSIZ			MMIO32(USB_OTG_FS_BASE + 0x024)
-#define OTG_FS_GNPTXFSIZ		MMIO32(USB_OTG_FS_BASE + 0x028)
-#define OTG_FS_GNPTXSTS			MMIO32(USB_OTG_FS_BASE + 0x02C)
-#define OTG_FS_GCCFG			MMIO32(USB_OTG_FS_BASE + 0x038)
-#define OTG_FS_CID			MMIO32(USB_OTG_FS_BASE + 0x03C)
-#define OTG_FS_HPTXFSIZ			MMIO32(USB_OTG_FS_BASE + 0x100)
-#define OTG_FS_DIEPTXF(x)		MMIO32(USB_OTG_FS_BASE + 0x104 \
-					       + 4*(x-1))
+#define OTG_FS_GOTGCTL			OTG_GOTGCTL(USB_OTG_FS_BASE)
+#define OTG_FS_GOTGINT			OTG_GOTGINT(USB_OTG_FS_BASE)
+#define OTG_FS_GAHBCFG			OTG_GAHBCFG(USB_OTG_FS_BASE)
+#define OTG_FS_GUSBCFG			OTG_GUSBCFG(USB_OTG_FS_BASE)
+#define OTG_FS_GRSTCTL			OTG_GRSTCTL(USB_OTG_FS_BASE)
+#define OTG_FS_GINTSTS			OTG_GINTSTS(USB_OTG_FS_BASE)
+#define OTG_FS_GINTMSK			OTG_GINTMSK(USB_OTG_FS_BASE)
+#define OTG_FS_GRXSTSR			OTG_GRXSTSR(USB_OTG_FS_BASE)
+#define OTG_FS_GRXSTSP			OTG_GRXSTSP(USB_OTG_FS_BASE)
+#define OTG_FS_GRXFSIZ			OTG_GRXFSIZ(USB_OTG_FS_BASE)
+#define OTG_FS_GNPTXFSIZ		OTG_GNPTXFSIZ(USB_OTG_FS_BASE)
+#define OTG_FS_GNPTXSTS			OTG_GNPTXSTS(USB_OTG_FS_BASE)
+#define OTG_FS_GCCFG			OTG_GCCFG(USB_OTG_FS_BASE)
+#define OTG_FS_CID				OTG_CID(USB_OTG_FS_BASE)
+#define OTG_FS_HPTXFSIZ			OTG_HPTXFSIZ(USB_OTG_FS_BASE)
+#define OTG_FS_DIEPTXF(x)		OTG_DIEPTXF(USB_OTG_FS_BASE, x)
 
 /* Host-mode Control and Status Registers */
-#define OTG_FS_HCFG			MMIO32(USB_OTG_FS_BASE + 0x400)
-#define OTG_FS_HFIR			MMIO32(USB_OTG_FS_BASE + 0x404)
-#define OTG_FS_HFNUM			MMIO32(USB_OTG_FS_BASE + 0x408)
-#define OTG_FS_HPTXSTS			MMIO32(USB_OTG_FS_BASE + 0x410)
-#define OTG_FS_HAINT			MMIO32(USB_OTG_FS_BASE + 0x414)
-#define OTG_FS_HAINTMSK			MMIO32(USB_OTG_FS_BASE + 0x418)
-#define OTG_FS_HPRT			MMIO32(USB_OTG_FS_BASE + 0x440)
-#define OTG_FS_HCCHARx			MMIO32(USB_OTG_FS_BASE + 0x500)
-#define OTG_FS_HCINTx			MMIO32(USB_OTG_FS_BASE + 0x508)
-#define OTG_FS_HCINTMSKx		MMIO32(USB_OTG_FS_BASE + 0x50C)
-#define OTG_FS_HCTSIZx			MMIO32(USB_OTG_FS_BASE + 0x510)
+#define OTG_FS_HCFG			OTG_HCFG(USB_OTG_FS_BASE)
+#define OTG_FS_HFIR			OTG_HFIR(USB_OTG_FS_BASE)
+#define OTG_FS_HFNUM		OTG_HFNUM(USB_OTG_FS_BASE)
+#define OTG_FS_HPTXSTS		OTG_HPTXSTS(USB_OTG_FS_BASE)
+#define OTG_FS_HAINT		OTG_HAINT(USB_OTG_FS_BASE)
+#define OTG_FS_HAINTMSK		OTG_HAINTMSK(USB_OTG_FS_BASE)
+#define OTG_FS_HPRT			OTG_HPRT(USB_OTG_FS_BASE)
+#define OTG_FS_HCCHARx(x)	OTG_HCCHARx(USB_OTG_FS_BASE, x)
+#define OTG_FS_HCINTx(x)	OTG_HCINTx(USB_OTG_FS_BASE, x)
+#define OTG_FS_HCINTMSKx(x)	OTG_HCINTMSKx(USB_OTG_FS_BASE, x)
+#define OTG_FS_HCTSIZx(x)	OTG_HCTSIZx(USB_OTG_FS_BASE, x)
 
 /* Device-mode Control and Status Registers */
-#define OTG_FS_DCFG			MMIO32(USB_OTG_FS_BASE + 0x800)
-#define OTG_FS_DCTL			MMIO32(USB_OTG_FS_BASE + 0x804)
-#define OTG_FS_DSTS			MMIO32(USB_OTG_FS_BASE + 0x808)
-#define OTG_FS_DIEPMSK			MMIO32(USB_OTG_FS_BASE + 0x810)
-#define OTG_FS_DOEPMSK			MMIO32(USB_OTG_FS_BASE + 0x814)
-#define OTG_FS_DAINT			MMIO32(USB_OTG_FS_BASE + 0x818)
-#define OTG_FS_DAINTMSK			MMIO32(USB_OTG_FS_BASE + 0x81C)
-#define OTG_FS_DVBUSDIS			MMIO32(USB_OTG_FS_BASE + 0x828)
-#define OTG_FS_DVBUSPULSE		MMIO32(USB_OTG_FS_BASE + 0x82C)
-#define OTG_FS_DIEPEMPMSK		MMIO32(USB_OTG_FS_BASE + 0x834)
-#define OTG_FS_DIEPCTL0			MMIO32(USB_OTG_FS_BASE + 0x900)
-#define OTG_FS_DIEPCTL(x)		MMIO32(USB_OTG_FS_BASE + 0x900 + \
-						0x20*(x))
-#define OTG_FS_DOEPCTL0			MMIO32(USB_OTG_FS_BASE + 0xB00)
-#define OTG_FS_DOEPCTL(x)		MMIO32(USB_OTG_FS_BASE + 0xB00 + \
-						0x20*(x))
-#define OTG_FS_DIEPINT(x)		MMIO32(USB_OTG_FS_BASE + 0x908 + \
-						0x20*(x))
-#define OTG_FS_DOEPINT(x)		MMIO32(USB_OTG_FS_BASE + 0xB08 + \
-						0x20*(x))
-#define OTG_FS_DIEPTSIZ0		MMIO32(USB_OTG_FS_BASE + 0x910)
-#define OTG_FS_DOEPTSIZ0		MMIO32(USB_OTG_FS_BASE + 0xB10)
-#define OTG_FS_DIEPTSIZ(x)		MMIO32(USB_OTG_FS_BASE + 0x910 + \
-						0x20*(x))
-#define OTG_FS_DTXFSTS(x)		MMIO32(USB_OTG_FS_BASE + 0x918 + \
-						0x20*(x))
-#define OTG_FS_DOEPTSIZ(x)		MMIO32(USB_OTG_FS_BASE + 0xB10 + \
-						0x20*(x))
+#define OTG_FS_DCFG				OTG_DCFG(USB_OTG_FS_BASE)
+#define OTG_FS_DCTL				OTG_DCTL(USB_OTG_FS_BASE)
+#define OTG_FS_DSTS				OTG_DSTS(USB_OTG_FS_BASE)
+#define OTG_FS_DIEPMSK			OTG_DIEPMSK(USB_OTG_FS_BASE)
+#define OTG_FS_DOEPMSK			OTG_DOEPMSK(USB_OTG_FS_BASE)
+#define OTG_FS_DAINT			OTG_DAINT(USB_OTG_FS_BASE)
+#define OTG_FS_DAINTMSK			OTG_DAINTMSK(USB_OTG_FS_BASE)
+#define OTG_FS_DVBUSDIS			OTG_DVBUSDIS(USB_OTG_FS_BASE)
+#define OTG_FS_DVBUSPULSE		OTG_DVBUSPULSE(USB_OTG_FS_BASE)
+#define OTG_FS_DIEPEMPMSK		OTG_DIEPEMPMSK(USB_OTG_FS_BASE)
+#define OTG_FS_DIEPCTL0			OTG_DIEPCTL0(USB_OTG_FS_BASE)
+#define OTG_FS_DIEPCTL(x)		OTG_DIEPCTL(USB_OTG_FS_BASE, x)
+#define OTG_FS_DOEPCTL0			OTG_DOEPCTL0(USB_OTG_FS_BASE, x)
+#define OTG_FS_DOEPCTL(x)		OTG_DOEPCTL(USB_OTG_FS_BASE, x)
+#define OTG_FS_DIEPINT(x)		OTG_DIEPINT(USB_OTG_FS_BASE, x)
+#define OTG_FS_DOEPINT(x)		OTG_DOEPINT(USB_OTG_FS_BASE , x)
+#define OTG_FS_DIEPTSIZ0		OTG_DIEPTSIZ0(USB_OTG_FS_BASE)
+#define OTG_FS_DOEPTSIZ0		OTG_DOEPTSIZ0(USB_OTG_FS_BASE)
+#define OTG_FS_DIEPTSIZ(x)		OTG_DIEPTSIZ(USB_OTG_FS_BASE, x)
+#define OTG_FS_DTXFSTS(x)		OTG_DTXFSTS(USB_OTG_FS_BASE, x)
+#define OTG_FS_DOEPTSIZ(x)		OTG_DOEPTSIZ(USB_OTG_FS_BASE, x)
 
 /* Power and clock gating control and status register */
-#define OTG_FS_PCGCCTL			MMIO32(USB_OTG_FS_BASE + 0xE00)
+#define OTG_FS_PCGCCTL			OTG_PCGCCTL(USB_OTG_FS_BASE)
 
 /* Data FIFO */
-#define OTG_FS_FIFO(x)			(&MMIO32(USB_OTG_FS_BASE \
-							      + (((x) + 1) \
-								 << 12)))
-
-/* Global CSRs */
-/* OTG_FS USB control registers (OTG_HS_GOTGCTL) */
-#define OTG_FS_GOTGCTL_BSVLD		(1 << 19)
-#define OTG_FS_GOTGCTL_ASVLD		(1 << 18)
-#define OTG_FS_GOTGCTL_DBCT		(1 << 17)
-#define OTG_FS_GOTGCTL_CIDSTS		(1 << 16)
-#define OTG_FS_GOTGCTL_DHNPEN		(1 << 11)
-#define OTG_FS_GOTGCTL_HSHNPEN		(1 << 10)
-#define OTG_FS_GOTGCTL_HNPRQ		(1 << 9)
-#define OTG_FS_GOTGCTL_HNGSCS		(1 << 8)
-#define OTG_FS_GOTGCTL_SRQ		(1 << 1)
-#define OTG_FS_GOTGCTL_SRQSCS		(1 << 0)
-
-/* OTG_FS AHB configuration register (OTG_FS_GAHBCFG) */
-#define OTG_FS_GAHBCFG_GINT		0x0001
-#define OTG_FS_GAHBCFG_TXFELVL		0x0080
-#define OTG_FS_GAHBCFG_PTXFELVL		0x0100
-
-/* OTG_FS USB configuration register (OTG_FS_GUSBCFG) */
-#define OTG_FS_GUSBCFG_TOCAL		0x00000003
-#define OTG_FS_GUSBCFG_SRPCAP		0x00000100
-#define OTG_FS_GUSBCFG_HNPCAP		0x00000200
-#define OTG_FS_GUSBCFG_TRDT_MASK	(0xf << 10)
-#define OTG_FS_GUSBCFG_TRDT_16BIT	(0x5 << 10)
-#define OTG_FS_GUSBCFG_TRDT_8BIT	(0x9 << 10)
-#define OTG_FS_GUSBCFG_NPTXRWEN		0x00004000
-#define OTG_FS_GUSBCFG_FHMOD		0x20000000
-#define OTG_FS_GUSBCFG_FDMOD		0x40000000
-#define OTG_FS_GUSBCFG_CTXPKT		0x80000000
-#define OTG_FS_GUSBCFG_PHYSEL		(1 << 7)
-
-/* OTG_FS reset register (OTG_FS_GRSTCTL) */
-#define OTG_FS_GRSTCTL_AHBIDL		(1 << 31)
-/* Bits 30:11 - Reserved */
-#define OTG_FS_GRSTCTL_TXFNUM_MASK	(0x1f << 6)
-#define OTG_FS_GRSTCTL_TXFFLSH		(1 << 5)
-#define OTG_FS_GRSTCTL_RXFFLSH		(1 << 4)
-/* Bit 3 - Reserved */
-#define OTG_FS_GRSTCTL_FCRST		(1 << 2)
-#define OTG_FS_GRSTCTL_HSRST		(1 << 1)
-#define OTG_FS_GRSTCTL_CSRST		(1 << 0)
-
-/* OTG_FS interrupt status register (OTG_FS_GINTSTS) */
-#define OTG_FS_GINTSTS_WKUPINT		(1 << 31)
-#define OTG_FS_GINTSTS_SRQINT		(1 << 30)
-#define OTG_FS_GINTSTS_DISCINT		(1 << 29)
-#define OTG_FS_GINTSTS_CIDSCHG		(1 << 28)
-/* Bit 27 - Reserved */
-#define OTG_FS_GINTSTS_PTXFE		(1 << 26)
-#define OTG_FS_GINTSTS_HCINT		(1 << 25)
-#define OTG_FS_GINTSTS_HPRTINT		(1 << 24)
-/* Bits 23:22 - Reserved */
-#define OTG_FS_GINTSTS_IPXFR		(1 << 21)
-#define OTG_FS_GINTSTS_INCOMPISOOUT	(1 << 21)
-#define OTG_FS_GINTSTS_IISOIXFR		(1 << 20)
-#define OTG_FS_GINTSTS_OEPINT		(1 << 19)
-#define OTG_FS_GINTSTS_IEPINT		(1 << 18)
-/* Bits 17:16 - Reserved */
-#define OTG_FS_GINTSTS_EOPF		(1 << 15)
-#define OTG_FS_GINTSTS_ISOODRP		(1 << 14)
-#define OTG_FS_GINTSTS_ENUMDNE		(1 << 13)
-#define OTG_FS_GINTSTS_USBRST		(1 << 12)
-#define OTG_FS_GINTSTS_USBSUSP		(1 << 11)
-#define OTG_FS_GINTSTS_ESUSP		(1 << 10)
-/* Bits 9:8 - Reserved */
-#define OTG_FS_GINTSTS_GONAKEFF		(1 << 7)
-#define OTG_FS_GINTSTS_GINAKEFF		(1 << 6)
-#define OTG_FS_GINTSTS_NPTXFE		(1 << 5)
-#define OTG_FS_GINTSTS_RXFLVL		(1 << 4)
-#define OTG_FS_GINTSTS_SOF		(1 << 3)
-#define OTG_FS_GINTSTS_OTGINT		(1 << 2)
-#define OTG_FS_GINTSTS_MMIS		(1 << 1)
-#define OTG_FS_GINTSTS_CMOD		(1 << 0)
-
-/* OTG_FS interrupt mask register (OTG_FS_GINTMSK) */
-#define OTG_FS_GINTMSK_MMISM		0x00000002
-#define OTG_FS_GINTMSK_OTGINT		0x00000004
-#define OTG_FS_GINTMSK_SOFM		0x00000008
-#define OTG_FS_GINTMSK_RXFLVLM		0x00000010
-#define OTG_FS_GINTMSK_NPTXFEM		0x00000020
-#define OTG_FS_GINTMSK_GINAKEFFM	0x00000040
-#define OTG_FS_GINTMSK_GONAKEFFM	0x00000080
-#define OTG_FS_GINTMSK_ESUSPM		0x00000400
-#define OTG_FS_GINTMSK_USBSUSPM		0x00000800
-#define OTG_FS_GINTMSK_USBRST		0x00001000
-#define OTG_FS_GINTMSK_ENUMDNEM		0x00002000
-#define OTG_FS_GINTMSK_ISOODRPM		0x00004000
-#define OTG_FS_GINTMSK_EOPFM		0x00008000
-#define OTG_FS_GINTMSK_EPMISM		0x00020000
-#define OTG_FS_GINTMSK_IEPINT		0x00040000
-#define OTG_FS_GINTMSK_OEPINT		0x00080000
-#define OTG_FS_GINTMSK_IISOIXFRM	0x00100000
-#define OTG_FS_GINTMSK_IISOOXFRM	0x00200000
-#define OTG_FS_GINTMSK_IPXFRM		0x00200000
-#define OTG_FS_GINTMSK_PRTIM		0x01000000
-#define OTG_FS_GINTMSK_HCIM		0x02000000
-#define OTG_FS_GINTMSK_PTXFEM		0x04000000
-#define OTG_FS_GINTMSK_CIDSCHGM		0x10000000
-#define OTG_FS_GINTMSK_DISCINT		0x20000000
-#define OTG_FS_GINTMSK_SRQIM		0x40000000
-#define OTG_FS_GINTMSK_WUIM		0x80000000
-
-/* OTG_FS Receive Status Pop Register (OTG_FS_GRXSTSP) */
-/* Bits 31:25 - Reserved */
-#define OTG_FS_GRXSTSP_FRMNUM_MASK		(0xf << 21)
-#define OTG_FS_GRXSTSP_PKTSTS_MASK		(0xf << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_GOUTNAK		(0x1 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_OUT		(0x2 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_OUT_COMP		(0x3 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_SETUP_COMP	(0x4 << 17)
-#define OTG_FS_GRXSTSP_PKTSTS_SETUP		(0x6 << 17)
-#define OTG_FS_GRXSTSP_DPID_MASK		(0x3 << 15)
-#define OTG_FS_GRXSTSP_DPID_DATA0		(0x0 << 15)
-#define OTG_FS_GRXSTSP_DPID_DATA1		(0x2 << 15)
-#define OTG_FS_GRXSTSP_DPID_DATA2		(0x1 << 15)
-#define OTG_FS_GRXSTSP_DPID_MDATA		(0x3 << 15)
-#define OTG_FS_GRXSTSP_BCNT_MASK		(0x7ff << 4)
-#define OTG_FS_GRXSTSP_EPNUM_MASK		(0xf << 0)
-
-/* OTG_FS general core configuration register (OTG_FS_GCCFG) */
-/* Bits 31:22 - Reserved */
-#define OTG_FS_GCCFG_NOVBUSSENS		(1 << 21)
-#define OTG_FS_GCCFG_SOFOUTEN		(1 << 20)
-#define OTG_FS_GCCFG_VBUSBSEN		(1 << 19)
-#define OTG_FS_GCCFG_VBUSASEN		(1 << 18)
-/* Bit 17 - Reserved */
-#define OTG_FS_GCCFG_PWRDWN		(1 << 16)
-/* Bits 15:0 - Reserved */
-
-
-/* Device-mode CSRs */
-/* OTG_FS device control register (OTG_FS_DCTL) */
-/* Bits 31:12 - Reserved */
-#define OTG_FS_DCTL_POPRGDNE		(1 << 11)
-#define OTG_FS_DCTL_CGONAK		(1 << 10)
-#define OTG_FS_DCTL_SGONAK		(1 << 9)
-#define OTG_FS_DCTL_SGINAK		(1 << 8)
-#define OTG_FS_DCTL_TCTL_MASK		(7 << 4)
-#define OTG_FS_DCTL_GONSTS		(1 << 3)
-#define OTG_FS_DCTL_GINSTS		(1 << 2)
-#define OTG_FS_DCTL_SDIS		(1 << 1)
-#define OTG_FS_DCTL_RWUSIG		(1 << 0)
-
-/* OTG_FS device configuration register (OTG_FS_DCFG) */
-#define OTG_FS_DCFG_DSPD		0x0003
-#define OTG_FS_DCFG_NZLSOHSK		0x0004
-#define OTG_FS_DCFG_DAD			0x07F0
-#define OTG_FS_DCFG_PFIVL		0x1800
-
-/* OTG_FS Device IN Endpoint Common Interrupt Mask Register (OTG_FS_DIEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_FS_DIEPMSK_BIM		(1 << 9)
-#define OTG_FS_DIEPMSK_TXFURM		(1 << 8)
-/* Bit 7 - Reserved */
-#define OTG_FS_DIEPMSK_INEPNEM		(1 << 6)
-#define OTG_FS_DIEPMSK_INEPNMM		(1 << 5)
-#define OTG_FS_DIEPMSK_ITTXFEMSK	(1 << 4)
-#define OTG_FS_DIEPMSK_TOM		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DIEPMSK_EPDM		(1 << 1)
-#define OTG_FS_DIEPMSK_XFRCM		(1 << 0)
-
-/* OTG_FS Device OUT Endpoint Common Interrupt Mask Register (OTG_FS_DOEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_FS_DOEPMSK_BOIM		(1 << 9)
-#define OTG_FS_DOEPMSK_OPEM		(1 << 8)
-/* Bit 7 - Reserved */
-#define OTG_FS_DOEPMSK_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_FS_DOEPMSK_OTEPDM		(1 << 4)
-#define OTG_FS_DOEPMSK_STUPM		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DOEPMSK_EPDM		(1 << 1)
-#define OTG_FS_DOEPMSK_XFRCM		(1 << 0)
-
-/* OTG_FS Device Control IN Endpoint 0 Control Register (OTG_FS_DIEPCTL0) */
-#define OTG_FS_DIEPCTL0_EPENA		(1 << 31)
-#define OTG_FS_DIEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_FS_DIEPCTLX_SD0PID		(1 << 28)
-#define OTG_FS_DIEPCTL0_SNAK		(1 << 27)
-#define OTG_FS_DIEPCTL0_CNAK		(1 << 26)
-#define OTG_FS_DIEPCTL0_TXFNUM_MASK	(0xf << 22)
-#define OTG_FS_DIEPCTL0_STALL		(1 << 21)
-/* Bit 20 - Reserved */
-#define OTG_FS_DIEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_FS_DIEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_FS_DIEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_FS_DIEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_FS_DIEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device Control OUT Endpoint 0 Control Register (OTG_FS_DOEPCTL0) */
-#define OTG_FS_DOEPCTL0_EPENA		(1 << 31)
-#define OTG_FS_DOEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_FS_DOEPCTLX_SD0PID		(1 << 28)
-#define OTG_FS_DOEPCTL0_SNAK		(1 << 27)
-#define OTG_FS_DOEPCTL0_CNAK		(1 << 26)
-/* Bits 25:22 - Reserved */
-#define OTG_FS_DOEPCTL0_STALL		(1 << 21)
-#define OTG_FS_DOEPCTL0_SNPM		(1 << 20)
-#define OTG_FS_DOEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_FS_DOEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_FS_DOEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_FS_DOEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_FS_DOEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_FS_DIEPINTx) */
-/* Bits 31:8 - Reserved */
-#define OTG_FS_DIEPINTX_TXFE		(1 << 7)
-#define OTG_FS_DIEPINTX_INEPNE		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_FS_DIEPINTX_ITTXFE		(1 << 4)
-#define OTG_FS_DIEPINTX_TOC		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DIEPINTX_EPDISD		(1 << 1)
-#define OTG_FS_DIEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_FS_DOEPINTx) */
-/* Bits 31:7 - Reserved */
-#define OTG_FS_DOEPINTX_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_FS_DOEPINTX_OTEPDIS		(1 << 4)
-#define OTG_FS_DOEPINTX_STUP		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_FS_DOEPINTX_EPDISD		(1 << 1)
-#define OTG_FS_DOEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device OUT Endpoint 0 Transfer Size Register (OTG_FS_DOEPTSIZ0) */
-/* Bit 31 - Reserved */
-#define OTG_FS_DIEPSIZ0_STUPCNT_1	(0x1 << 29)
-#define OTG_FS_DIEPSIZ0_STUPCNT_2	(0x2 << 29)
-#define OTG_FS_DIEPSIZ0_STUPCNT_3	(0x3 << 29)
-#define OTG_FS_DIEPSIZ0_STUPCNT_MASK	(0x3 << 29)
-/* Bits 28:20 - Reserved */
-#define OTG_FS_DIEPSIZ0_PKTCNT		(1 << 19)
-/* Bits 18:7 - Reserved */
-#define OTG_FS_DIEPSIZ0_XFRSIZ_MASK	(0x7f << 0)
+#define OTG_FS_FIFO(x)			OTG_FIFO(USB_OTG_FS_BASE, x)
 
 #endif

--- a/include/libopencm3/stm32/otg_hs.h
+++ b/include/libopencm3/stm32/otg_hs.h
@@ -22,377 +22,66 @@
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/memorymap.h>
+#include <libopencm3/stm32/common/otg_common_all.h>
 
 /* Core Global Control and Status Registers */
-#define OTG_GOTGCTL			0x000
-#define OTG_GOTGIN			0x004
-#define OTG_GAHBCFG			0x008
-#define OTG_GUSBCFG			0x00C
-#define OTG_GRSTCTL			0x010
-#define OTG_GINTSTS			0x014
-#define OTG_GINTMSK			0x018
-#define OTG_GRXSTSR			0x01C
-#define OTG_GRXSTSP			0x020
-#define OTG_GRXFSIZ			0x024
-#define OTG_GNPTXFSIZ			0x028
-#define OTG_GNPTXSTS			0x02C
-#define OTG_GCCFG			0x038
-#define OTG_CID				0x03C
-#define OTG_HPTXFSIZ			0x100
-#define OTG_DIEPTXF(x)			(0x104 + 4*(x-1))
+#define OTG_HS_GOTGCTL			OTG_GOTGCTL(USB_OTG_HS_BASE)
+#define OTG_HS_GOTGINT			OTG_GOTGINT(USB_OTG_HS_BASE)
+#define OTG_HS_GAHBCFG			OTG_GAHBCFG(USB_OTG_HS_BASE)
+#define OTG_HS_GUSBCFG			OTG_GUSBCFG(USB_OTG_HS_BASE)
+#define OTG_HS_GRSTCTL			OTG_GRSTCTL(USB_OTG_HS_BASE)
+#define OTG_HS_GINTSTS			OTG_GINTSTS(USB_OTG_HS_BASE)
+#define OTG_HS_GINTMSK			OTG_GINTMSK(USB_OTG_HS_BASE)
+#define OTG_HS_GRXSTSR			OTG_GRXSTSR(USB_OTG_HS_BASE)
+#define OTG_HS_GRXSTSP			OTG_GRXSTSP(USB_OTG_HS_BASE)
+#define OTG_HS_GRXFSIZ			OTG_GRXFSIZ(USB_OTG_HS_BASE)
+#define OTG_HS_GNPTXFSIZ		OTG_GNPTXFSIZ(USB_OTG_HS_BASE)
+#define OTG_HS_GNPTXSTS			OTG_GNPTXSTS(USB_OTG_HS_BASE)
+#define OTG_HS_GCCFG			OTG_GCCFG(USB_OTG_HS_BASE)
+#define OTG_HS_CID				OTG_CID(USB_OTG_HS_BASE)
+#define OTG_HS_HPTXFSIZ			OTG_HPTXFSIZ(USB_OTG_HS_BASE)
+#define OTG_HS_DIEPTXF(x)		OTG_DIEPTXF(USB_OTG_HS_BASE, x)
 
 /* Host-mode Control and Status Registers */
-#define OTG_HCFG			0x400
-#define OTG_HFIR			0x404
-#define OTG_HFNUM			0x408
-#define OTG_HPTXSTS			0x410
-#define OTG_HAINT			0x414
-#define OTG_HAINTMSK			0x418
-#define OTG_HPRT			0x440
-#define OTG_HCCHARx			0x500
-#define OTG_HCINTx			0x508
-#define OTG_HCINTMSKx			0x50C
-#define OTG_HCTSIZx			0x510
+#define OTG_HS_HCFG			OTG_HCFG(USB_OTG_HS_BASE)
+#define OTG_HS_HFIR			OTG_HFIR(USB_OTG_HS_BASE)
+#define OTG_HS_HFNUM		OTG_HFNUM(USB_OTG_HS_BASE)
+#define OTG_HS_HPTXSTS		OTG_HPTXSTS(USB_OTG_HS_BASE)
+#define OTG_HS_HAINT		OTG_HAINT(USB_OTG_HS_BASE)
+#define OTG_HS_HAINTMSK		OTG_HAINTMSK(USB_OTG_HS_BASE)
+#define OTG_HS_HPRT			OTG_HPRT(USB_OTG_HS_BASE)
+#define OTG_HS_HCCHARx(x)	OTG_HCCHARx(USB_OTG_HS_BASE, x)
+#define OTG_HS_HCINTx(x)	OTG_HCINTx(USB_OTG_HS_BASE, x)
+#define OTG_HS_HCINTMSKx(x)	OTG_HCINTMSKx(USB_OTG_HS_BASE, x)
+#define OTG_HS_HCTSIZx(x)	OTG_HCTSIZx(USB_OTG_HS_BASE, x)
 
 /* Device-mode Control and Status Registers */
-#define OTG_DCFG			0x800
-#define OTG_DCTL			0x804
-#define OTG_DSTS			0x808
-#define OTG_DIEPMSK			0x810
-#define OTG_DOEPMSK			0x814
-#define OTG_DAINT			0x818
-#define OTG_DAINTMSK			0x81C
-#define OTG_DVBUSDIS			0x828
-#define OTG_DVBUSPULSE			0x82C
-#define OTG_DIEPEMPMSK			0x834
-#define OTG_DIEPCTL0			0x900
-#define OTG_DIEPCTL(x)			(0x900 + 0x20*(x))
-#define OTG_DOEPCTL0			0xB00
-#define OTG_DOEPCTL(x)			(0xB00 + 0x20*(x))
-#define OTG_DIEPINT(x)			(0x908 + 0x20*(x))
-#define OTG_DOEPINT(x)			(0xB08 + 0x20*(x))
-#define OTG_DIEPTSIZ0			0x910
-#define OTG_DOEPTSIZ0			0xB10
-#define OTG_DIEPTSIZ(x)			(0x910 + 0x20*(x))
-#define OTG_DTXFSTS(x)			(0x918 + 0x20*(x))
-#define OTG_DOEPTSIZ(x)			(0xB10 + 0x20*(x))
+#define OTG_HS_DCFG				OTG_DCFG(USB_OTG_HS_BASE)
+#define OTG_HS_DCTL				OTG_DCTL(USB_OTG_HS_BASE)
+#define OTG_HS_DSTS				OTG_DSTS(USB_OTG_HS_BASE)
+#define OTG_HS_DIEPMSK			OTG_DIEPMSK(USB_OTG_HS_BASE)
+#define OTG_HS_DOEPMSK			OTG_DOEPMSK(USB_OTG_HS_BASE)
+#define OTG_HS_DAINT			OTG_DAINT(USB_OTG_HS_BASE)
+#define OTG_HS_DAINTMSK			OTG_DAINTMSK(USB_OTG_HS_BASE)
+#define OTG_HS_DVBUSDIS			OTG_DVBUSDIS(USB_OTG_HS_BASE)
+#define OTG_HS_DVBUSPULSE		OTG_DVBUSPULSE(USB_OTG_HS_BASE)
+#define OTG_HS_DIEPEMPMSK		OTG_DIEPEMPMSK(USB_OTG_HS_BASE)
+#define OTG_HS_DIEPCTL0			OTG_DIEPCTL0(USB_OTG_HS_BASE)
+#define OTG_HS_DIEPCTL(x)		OTG_DIEPCTL(USB_OTG_HS_BASE, x)
+#define OTG_HS_DOEPCTL0			OTG_DOEPCTL0(USB_OTG_HS_BASE, x)
+#define OTG_HS_DOEPCTL(x)		OTG_DOEPCTL(USB_OTG_HS_BASE, x)
+#define OTG_HS_DIEPINT(x)		OTG_DIEPINT(USB_OTG_HS_BASE, x)
+#define OTG_HS_DOEPINT(x)		OTG_DOEPINT(USB_OTG_HS_BASE , x)
+#define OTG_HS_DIEPTSIZ0		OTG_DIEPTSIZ0(USB_OTG_HS_BASE)
+#define OTG_HS_DOEPTSIZ0		OTG_DOEPTSIZ0(USB_OTG_HS_BASE)
+#define OTG_HS_DIEPTSIZ(x)		OTG_DIEPTSIZ(USB_OTG_HS_BASE, x)
+#define OTG_HS_DTXFSTS(x)		OTG_DTXFSTS(USB_OTG_HS_BASE, x)
+#define OTG_HS_DOEPTSIZ(x)		OTG_DOEPTSIZ(USB_OTG_HS_BASE, x)
 
 /* Power and clock gating control and status register */
-#define OTG_PCGCCTL			0xE00
+#define OTG_HS_PCGCCTL			OTG_PCGCCTL(USB_OTG_HS_BASE)
 
 /* Data FIFO */
-#define OTG_FIFO(x)			(((x) + 1) << 12)
-
-/***********************************************************************/
-
-/* Core Global Control and Status Registers */
-#define OTG_HS_GOTGCTL			MMIO32(USB_OTG_HS_BASE + OTG_GOTGCTL)
-#define OTG_HS_GOTGINT			MMIO32(USB_OTG_HS_BASE + OTG_GOTGINT)
-#define OTG_HS_GAHBCFG			MMIO32(USB_OTG_HS_BASE + OTG_GAHBCFG)
-#define OTG_HS_GUSBCFG			MMIO32(USB_OTG_HS_BASE + OTG_GUSBCFG)
-#define OTG_HS_GRSTCTL			MMIO32(USB_OTG_HS_BASE + OTG_GRSTCTL)
-#define OTG_HS_GINTSTS			MMIO32(USB_OTG_HS_BASE + OTG_GINTSTS)
-#define OTG_HS_GINTMSK			MMIO32(USB_OTG_HS_BASE + OTG_GINTMSK)
-#define OTG_HS_GRXSTSR			MMIO32(USB_OTG_HS_BASE + OTG_GRXSTSR)
-#define OTG_HS_GRXSTSP			MMIO32(USB_OTG_HS_BASE + OTG_GRXSTSP)
-#define OTG_HS_GRXFSIZ			MMIO32(USB_OTG_HS_BASE + OTG_GRXFSIZ)
-#define OTG_HS_GNPTXFSIZ		MMIO32(USB_OTG_HS_BASE + OTG_GNPTXFSIZ)
-#define OTG_HS_GNPTXSTS			MMIO32(USB_OTG_HS_BASE + OTG_GNPTXSTS)
-#define OTG_HS_GCCFG			MMIO32(USB_OTG_HS_BASE + OTG_GCCFG)
-#define OTG_HS_CID			MMIO32(USB_OTG_HS_BASE + OTG_CID)
-#define OTG_HS_HPTXFSIZ			MMIO32(USB_OTG_HS_BASE + OTG_HPTXFSIZ)
-#define OTG_HS_DIEPTXF(x)		MMIO32(USB_OTG_HS_BASE + OTG_DIEPTXF(x))
-
-/* Host-mode Control and Status Registers */
-#define OTG_HS_HCFG			MMIO32(USB_OTG_HS_BASE + OTG_HCFG)
-#define OTG_HS_HFIR			MMIO32(USB_OTG_HS_BASE + OTG_HFIR)
-#define OTG_HS_HFNUM			MMIO32(USB_OTG_HS_BASE + OTG_HFNUM)
-#define OTG_HS_HPTXSTS			MMIO32(USB_OTG_HS_BASE + OTG_HPTXSTS)
-#define OTG_HS_HAINT			MMIO32(USB_OTG_HS_BASE + OTG_HAINT)
-#define OTG_HS_HAINTMSK			MMIO32(USB_OTG_HS_BASE + OTG_HAINTMSK)
-#define OTG_HS_HPRT			MMIO32(USB_OTG_HS_BASE + OTG_HPRT)
-#define OTG_HS_HCCHARx			MMIO32(USB_OTG_HS_BASE + OTG_HCCHARx)
-#define OTG_HS_HCINTx			MMIO32(USB_OTG_HS_BASE + OTG_HCINTx)
-#define OTG_HS_HCINTMSKx		MMIO32(USB_OTG_HS_BASE + OTG_HCINTMSKx)
-#define OTG_HS_HCTSIZx			MMIO32(USB_OTG_HS_BASE + OTG_HCTSIZx)
-
-/* Device-mode Control and Status Registers */
-#define OTG_HS_DCFG			MMIO32(USB_OTG_HS_BASE + OTG_DCFG)
-#define OTG_HS_DCTL			MMIO32(USB_OTG_HS_BASE + OTG_DCTL)
-#define OTG_HS_DSTS			MMIO32(USB_OTG_HS_BASE + OTG_DSTS)
-#define OTG_HS_DIEPMSK			MMIO32(USB_OTG_HS_BASE + OTG_DIEPMSK)
-#define OTG_HS_DOEPMSK			MMIO32(USB_OTG_HS_BASE + OTG_DOEPMSK)
-#define OTG_HS_DAINT			MMIO32(USB_OTG_HS_BASE + OTG_DAINT)
-#define OTG_HS_DAINTMSK			MMIO32(USB_OTG_HS_BASE + OTG_DAINTMSK)
-#define OTG_HS_DVBUSDIS			MMIO32(USB_OTG_HS_BASE + OTG_DVBUSDIS)
-#define OTG_HS_DVBUSPULSE		MMIO32(USB_OTG_HS_BASE + OTG_DVBUSPULSE)
-#define OTG_HS_DIEPEMPMSK		MMIO32(USB_OTG_HS_BASE + OTG_DIEPEMPMSK)
-#define OTG_HS_DIEPCTL0			MMIO32(USB_OTG_HS_BASE + OTG_DIEPCTL0)
-#define OTG_HS_DIEPCTL(x)		MMIO32(USB_OTG_HS_BASE + OTG_DIEPCTL(x))
-#define OTG_HS_DOEPCTL0			MMIO32(USB_OTG_HS_BASE + OTG_DOEPCTL0)
-#define OTG_HS_DOEPCTL(x)		MMIO32(USB_OTG_HS_BASE + OTG_DOEPCTL(x))
-#define OTG_HS_DIEPINT(x)		MMIO32(USB_OTG_HS_BASE + OTG_DIEPINT(x))
-#define OTG_HS_DOEPINT(x)		MMIO32(USB_OTG_HS_BASE + OTG_DOEPINT(x))
-#define OTG_HS_DIEPTSIZ0		MMIO32(USB_OTG_HS_BASE + OTG_DIEPTSIZ0)
-#define OTG_HS_DOEPTSIZ0		MMIO32(USB_OTG_HS_BASE + OTG_DOEPTSIZ0)
-#define OTG_HS_DIEPTSIZ(x)		MMIO32(USB_OTG_HS_BASE + \
-						OTG_DIEPTSIZ(x))
-#define OTG_HS_DTXFSTS(x)		MMIO32(USB_OTG_HS_BASE + OTG_DTXFSTS(x))
-#define OTG_HS_DOEPTSIZ(x)		MMIO32(USB_OTG_HS_BASE + \
-						OTG_DOEPTSIZ(x))
-
-/* Power and clock gating control and status register */
-#define OTG_HS_PCGCCTL			MMIO32(USB_OTG_HS_BASE + OTG_PCGCCTL)
-
-/* Data FIFO */
-#define OTG_HS_FIFO(x)			(&MMIO32(USB_OTG_HS_BASE + OTG_FIFO(x)))
-
-/* Global CSRs */
-/* OTG_HS USB control registers (OTG_FS_GOTGCTL) */
-#define OTG_HS_GOTGCTL_BSVLD		(1 << 19)
-#define OTG_HS_GOTGCTL_ASVLD		(1 << 18)
-#define OTG_HS_GOTGCTL_DBCT		(1 << 17)
-#define OTG_HS_GOTGCTL_CIDSTS		(1 << 16)
-#define OTG_HS_GOTGCTL_DHNPEN		(1 << 11)
-#define OTG_HS_GOTGCTL_HSHNPEN		(1 << 10)
-#define OTG_HS_GOTGCTL_HNPRQ		(1 << 9)
-#define OTG_HS_GOTGCTL_HNGSCS		(1 << 8)
-#define OTG_HS_GOTGCTL_SRQ		(1 << 1)
-#define OTG_HS_GOTGCTL_SRQSCS		(1 << 0)
-
-/* OTG_FS AHB configuration register (OTG_HS_GAHBCFG) */
-#define OTG_HS_GAHBCFG_GINT		0x0001
-#define OTG_HS_GAHBCFG_TXFELVL		0x0080
-#define OTG_HS_GAHBCFG_PTXFELVL		0x0100
-
-/* OTG_FS USB configuration register (OTG_HS_GUSBCFG) */
-#define OTG_HS_GUSBCFG_TOCAL		0x00000003
-#define OTG_HS_GUSBCFG_SRPCAP		0x00000100
-#define OTG_HS_GUSBCFG_HNPCAP		0x00000200
-#define OTG_HS_GUSBCFG_TRDT_MASK	(0xf << 10)
-#define OTG_HS_GUSBCFG_TRDT_16BIT	(0x5 << 10)
-#define OTG_HS_GUSBCFG_TRDT_8BIT	(0x9 << 10)
-#define OTG_HS_GUSBCFG_NPTXRWEN		0x00004000
-#define OTG_HS_GUSBCFG_FHMOD		0x20000000
-#define OTG_HS_GUSBCFG_FDMOD		0x40000000
-#define OTG_HS_GUSBCFG_CTXPKT		0x80000000
-#define OTG_HS_GUSBCFG_PHYSEL		(1 << 6)
-
-/* OTG_FS reset register (OTG_HS_GRSTCTL) */
-#define OTG_HS_GRSTCTL_AHBIDL		(1 << 31)
-/* Bits 30:11 - Reserved */
-#define OTG_HS_GRSTCTL_TXFNUM_MASK	(0x1f << 6)
-#define OTG_HS_GRSTCTL_TXFFLSH		(1 << 5)
-#define OTG_HS_GRSTCTL_RXFFLSH		(1 << 4)
-/* Bit 3 - Reserved */
-#define OTG_HS_GRSTCTL_FCRST		(1 << 2)
-#define OTG_HS_GRSTCTL_HSRST		(1 << 1)
-#define OTG_HS_GRSTCTL_CSRST		(1 << 0)
-
-/* OTG_FS interrupt status register (OTG_HS_GINTSTS) */
-#define OTG_HS_GINTSTS_WKUPINT		(1 << 31)
-#define OTG_HS_GINTSTS_SRQINT		(1 << 30)
-#define OTG_HS_GINTSTS_DISCINT		(1 << 29)
-#define OTG_HS_GINTSTS_CIDSCHG		(1 << 28)
-/* Bit 27 - Reserved */
-#define OTG_HS_GINTSTS_PTXFE		(1 << 26)
-#define OTG_HS_GINTSTS_HCINT		(1 << 25)
-#define OTG_HS_GINTSTS_HPRTINT		(1 << 24)
-/* Bits 23:22 - Reserved */
-#define OTG_HS_GINTSTS_IPXFR		(1 << 21)
-#define OTG_HS_GINTSTS_INCOMPISOOUT	(1 << 21)
-#define OTG_HS_GINTSTS_IISOIXFR		(1 << 20)
-#define OTG_HS_GINTSTS_OEPINT		(1 << 19)
-#define OTG_HS_GINTSTS_IEPINT		(1 << 18)
-/* Bits 17:16 - Reserved */
-#define OTG_HS_GINTSTS_EOPF		(1 << 15)
-#define OTG_HS_GINTSTS_ISOODRP		(1 << 14)
-#define OTG_HS_GINTSTS_ENUMDNE		(1 << 13)
-#define OTG_HS_GINTSTS_USBRST		(1 << 12)
-#define OTG_HS_GINTSTS_USBSUSP		(1 << 11)
-#define OTG_HS_GINTSTS_ESUSP		(1 << 10)
-/* Bits 9:8 - Reserved */
-#define OTG_HS_GINTSTS_GONAKEFF		(1 << 7)
-#define OTG_HS_GINTSTS_GINAKEFF		(1 << 6)
-#define OTG_HS_GINTSTS_NPTXFE		(1 << 5)
-#define OTG_HS_GINTSTS_RXFLVL		(1 << 4)
-#define OTG_HS_GINTSTS_SOF		(1 << 3)
-#define OTG_HS_GINTSTS_OTGINT		(1 << 2)
-#define OTG_HS_GINTSTS_MMIS		(1 << 1)
-#define OTG_HS_GINTSTS_CMOD		(1 << 0)
-
-/* OTG_FS interrupt mask register (OTG_HS_GINTMSK) */
-#define OTG_HS_GINTMSK_MMISM		0x00000002
-#define OTG_HS_GINTMSK_OTGINT		0x00000004
-#define OTG_HS_GINTMSK_SOFM		0x00000008
-#define OTG_HS_GINTMSK_RXFLVLM		0x00000010
-#define OTG_HS_GINTMSK_NPTXFEM		0x00000020
-#define OTG_HS_GINTMSK_GINAKEFFM	0x00000040
-#define OTG_HS_GINTMSK_GONAKEFFM	0x00000080
-#define OTG_HS_GINTMSK_ESUSPM		0x00000400
-#define OTG_HS_GINTMSK_USBSUSPM		0x00000800
-#define OTG_HS_GINTMSK_USBRST		0x00001000
-#define OTG_HS_GINTMSK_ENUMDNEM		0x00002000
-#define OTG_HS_GINTMSK_ISOODRPM		0x00004000
-#define OTG_HS_GINTMSK_EOPFM		0x00008000
-#define OTG_HS_GINTMSK_EPMISM		0x00020000
-#define OTG_HS_GINTMSK_IEPINT		0x00040000
-#define OTG_HS_GINTMSK_OEPINT		0x00080000
-#define OTG_HS_GINTMSK_IISOIXFRM	0x00100000
-#define OTG_HS_GINTMSK_IISOOXFRM	0x00200000
-#define OTG_HS_GINTMSK_IPXFRM		0x00200000
-#define OTG_HS_GINTMSK_PRTIM		0x01000000
-#define OTG_HS_GINTMSK_HCIM		0x02000000
-#define OTG_HS_GINTMSK_PTXFEM		0x04000000
-#define OTG_HS_GINTMSK_CIDSCHGM		0x10000000
-#define OTG_HS_GINTMSK_DISCINT		0x20000000
-#define OTG_HS_GINTMSK_SRQIM		0x40000000
-#define OTG_HS_GINTMSK_WUIM		0x80000000
-
-/* OTG_FS Receive Status Pop Register (OTG_HS_GRXSTSP) */
-/* Bits 31:25 - Reserved */
-#define OTG_HS_GRXSTSP_FRMNUM_MASK		(0xf << 21)
-#define OTG_HS_GRXSTSP_PKTSTS_MASK		(0xf << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_GOUTNAK		(0x1 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_OUT		(0x2 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_OUT_COMP		(0x3 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_SETUP_COMP	(0x4 << 17)
-#define OTG_HS_GRXSTSP_PKTSTS_SETUP		(0x6 << 17)
-#define OTG_HS_GRXSTSP_DPID_MASK		(0x3 << 15)
-#define OTG_HS_GRXSTSP_DPID_DATA0		(0x0 << 15)
-#define OTG_HS_GRXSTSP_DPID_DATA1		(0x2 << 15)
-#define OTG_HS_GRXSTSP_DPID_DATA2		(0x1 << 15)
-#define OTG_HS_GRXSTSP_DPID_MDATA		(0x3 << 15)
-#define OTG_HS_GRXSTSP_BCNT_MASK		(0x7ff << 4)
-#define OTG_HS_GRXSTSP_EPNUM_MASK		(0xf << 0)
-
-/* OTG_FS general core configuration register (OTG_HS_GCCFG) */
-/* Bits 31:21 - Reserved */
-#define OTG_HS_GCCFG_SOFOUTEN		(1 << 20)
-#define OTG_HS_GCCFG_VBUSBSEN		(1 << 19)
-#define OTG_HS_GCCFG_VBUSASEN		(1 << 18)
-/* Bit 17 - Reserved */
-#define OTG_HS_GCCFG_PWRDWN		(1 << 16)
-/* Bits 15:0 - Reserved */
-
-
-/* Device-mode CSRs */
-/* OTG_FS device control register (OTG_HS_DCTL) */
-/* Bits 31:12 - Reserved */
-#define OTG_HS_DCTL_POPRGDNE		(1 << 11)
-#define OTG_HS_DCTL_CGONAK		(1 << 10)
-#define OTG_HS_DCTL_SGONAK		(1 << 9)
-#define OTG_HS_DCTL_SGINAK		(1 << 8)
-#define OTG_HS_DCTL_TCTL_MASK		(7 << 4)
-#define OTG_HS_DCTL_GONSTS		(1 << 3)
-#define OTG_HS_DCTL_GINSTS		(1 << 2)
-#define OTG_HS_DCTL_SDIS		(1 << 1)
-#define OTG_HS_DCTL_RWUSIG		(1 << 0)
-
-/* OTG_FS device configuration register (OTG_HS_DCFG) */
-#define OTG_HS_DCFG_DSPD		0x0003
-#define OTG_HS_DCFG_NZLSOHSK		0x0004
-#define OTG_HS_DCFG_DAD			0x07F0
-#define OTG_HS_DCFG_PFIVL		0x1800
-
-/* OTG_FS Device IN Endpoint Common Interrupt Mask Register (OTG_HS_DIEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_HS_DIEPMSK_BIM		(1 << 9)
-#define OTG_HS_DIEPMSK_TXFURM		(1 << 8)
-/* Bit 7 - Reserved */
-#define OTG_HS_DIEPMSK_INEPNEM		(1 << 6)
-#define OTG_HS_DIEPMSK_INEPNMM		(1 << 5)
-#define OTG_HS_DIEPMSK_ITTXFEMSK	(1 << 4)
-#define OTG_HS_DIEPMSK_TOM		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_HS_DIEPMSK_EPDM		(1 << 1)
-#define OTG_HS_DIEPMSK_XFRCM		(1 << 0)
-
-/* OTG_FS Device OUT Endpoint Common Interrupt Mask Register (OTG_HS_DOEPMSK) */
-/* Bits 31:10 - Reserved */
-#define OTG_HS_DOEPMSK_BOIM		(1 << 9)
-#define OTG_HS_DOEPMSK_OPEM		(1 << 8)
-/* Bit 7 - Reserved */
-#define OTG_HS_DOEPMSK_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_HS_DOEPMSK_OTEPDM		(1 << 4)
-#define OTG_HS_DOEPMSK_STUPM		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_HS_DOEPMSK_EPDM		(1 << 1)
-#define OTG_HS_DOEPMSK_XFRCM		(1 << 0)
-
-/* OTG_FS Device Control IN Endpoint 0 Control Register (OTG_HS_DIEPCTL0) */
-#define OTG_HS_DIEPCTL0_EPENA		(1 << 31)
-#define OTG_HS_DIEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_HS_DIEPCTLX_SD0PID		(1 << 28)
-#define OTG_HS_DIEPCTL0_SNAK		(1 << 27)
-#define OTG_HS_DIEPCTL0_CNAK		(1 << 26)
-#define OTG_HS_DIEPCTL0_TXFNUM_MASK	(0xf << 22)
-#define OTG_HS_DIEPCTL0_STALL		(1 << 21)
-/* Bit 20 - Reserved */
-#define OTG_HS_DIEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_HS_DIEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_HS_DIEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_HS_DIEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_HS_DIEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device Control OUT Endpoint 0 Control Register (OTG_HS_DOEPCTL0) */
-#define OTG_HS_DOEPCTL0_EPENA		(1 << 31)
-#define OTG_HS_DOEPCTL0_EPDIS		(1 << 30)
-/* Bits 29:28 - Reserved */
-#define OTG_HS_DOEPCTLX_SD0PID		(1 << 28)
-#define OTG_HS_DOEPCTL0_SNAK		(1 << 27)
-#define OTG_HS_DOEPCTL0_CNAK		(1 << 26)
-/* Bits 25:22 - Reserved */
-#define OTG_HS_DOEPCTL0_STALL		(1 << 21)
-#define OTG_HS_DOEPCTL0_SNPM		(1 << 20)
-#define OTG_HS_DOEPCTL0_EPTYP_MASK	(0x3 << 18)
-#define OTG_HS_DOEPCTL0_NAKSTS		(1 << 17)
-/* Bit 16 - Reserved */
-#define OTG_HS_DOEPCTL0_USBAEP		(1 << 15)
-/* Bits 14:2 - Reserved */
-#define OTG_HS_DOEPCTL0_MPSIZ_MASK	(0x3 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_64	(0x0 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_32	(0x1 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_16	(0x2 << 0)
-#define OTG_HS_DOEPCTL0_MPSIZ_8		(0x3 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_HS_DIEPINTx) */
-/* Bits 31:8 - Reserved */
-#define OTG_HS_DIEPINTX_TXFE		(1 << 7)
-#define OTG_HS_DIEPINTX_INEPNE		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_HS_DIEPINTX_ITTXFE		(1 << 4)
-#define OTG_HS_DIEPINTX_TOC		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_HS_DIEPINTX_EPDISD		(1 << 1)
-#define OTG_HS_DIEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device IN Endpoint Interrupt Register (OTG_HS_DOEPINTx) */
-/* Bits 31:7 - Reserved */
-#define OTG_HS_DOEPINTX_B2BSTUP		(1 << 6)
-/* Bit 5 - Reserved */
-#define OTG_HS_DOEPINTX_OTEPDIS		(1 << 4)
-#define OTG_HS_DOEPINTX_STUP		(1 << 3)
-/* Bit 2 - Reserved */
-#define OTG_HS_DOEPINTX_EPDISD		(1 << 1)
-#define OTG_HS_DOEPINTX_XFRC		(1 << 0)
-
-/* OTG_FS Device OUT Endpoint 0 Transfer Size Register (OTG_HS_DOEPTSIZ0) */
-/* Bit 31 - Reserved */
-#define OTG_HS_DIEPSIZ0_STUPCNT_1	(0x1 << 29)
-#define OTG_HS_DIEPSIZ0_STUPCNT_2	(0x2 << 29)
-#define OTG_HS_DIEPSIZ0_STUPCNT_3	(0x3 << 29)
-#define OTG_HS_DIEPSIZ0_STUPCNT_MASK	(0x3 << 29)
-/* Bits 28:20 - Reserved */
-#define OTG_HS_DIEPSIZ0_PKTCNT		(1 << 19)
-/* Bits 18:7 - Reserved */
-#define OTG_HS_DIEPSIZ0_XFRSIZ_MASK	(0x7f << 0)
+#define OTG_HS_FIFO(x)			OTG_FIFO(USB_OTG_HS_BASE, x)
 
 #endif

--- a/lib/usb/usb_f107.c
+++ b/lib/usb/usb_f107.c
@@ -52,23 +52,23 @@ const struct _usbd_driver stm32f107_usb_driver = {
 /** Initialize the USB device controller hardware of the STM32. */
 static usbd_device *stm32f107_usbd_init(void)
 {
-	OTG_FS_GINTSTS = OTG_FS_GINTSTS_MMIS;
+	OTG_FS_GINTSTS = OTG_GINTSTS_MMIS;
 
-	OTG_FS_GUSBCFG |= OTG_FS_GUSBCFG_PHYSEL;
+	OTG_FS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;
 	/* Enable VBUS sensing in device mode and power down the PHY. */
-	OTG_FS_GCCFG |= OTG_FS_GCCFG_VBUSBSEN | OTG_FS_GCCFG_PWRDWN;
+	OTG_FS_GCCFG |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
 
 	/* Wait for AHB idle. */
-	while (!(OTG_FS_GRSTCTL & OTG_FS_GRSTCTL_AHBIDL));
+	while (!(OTG_FS_GRSTCTL & OTG_GRSTCTL_AHBIDL));
 	/* Do core soft reset. */
-	OTG_FS_GRSTCTL |= OTG_FS_GRSTCTL_CSRST;
-	while (OTG_FS_GRSTCTL & OTG_FS_GRSTCTL_CSRST);
+	OTG_FS_GRSTCTL |= OTG_GRSTCTL_CSRST;
+	while (OTG_FS_GRSTCTL & OTG_GRSTCTL_CSRST);
 
 	/* Force peripheral only mode. */
-	OTG_FS_GUSBCFG |= OTG_FS_GUSBCFG_FDMOD | OTG_FS_GUSBCFG_TRDT_MASK;
+	OTG_FS_GUSBCFG |= OTG_GUSBCFG_FDMOD | OTG_GUSBCFG_TRDT_MASK;
 
 	/* Full speed device. */
-	OTG_FS_DCFG |= OTG_FS_DCFG_DSPD;
+	OTG_FS_DCFG |= OTG_DCFG_DSPD;
 
 	/* Restart the PHY clock. */
 	OTG_FS_PCGCCTL = 0;
@@ -77,14 +77,14 @@ static usbd_device *stm32f107_usbd_init(void)
 	usbd_dev.fifo_mem_top = stm32f107_usb_driver.rx_fifo_size;
 
 	/* Unmask interrupts for TX and RX. */
-	OTG_FS_GAHBCFG |= OTG_FS_GAHBCFG_GINT;
-	OTG_FS_GINTMSK = OTG_FS_GINTMSK_ENUMDNEM |
-			 OTG_FS_GINTMSK_RXFLVLM |
-			 OTG_FS_GINTMSK_IEPINT |
-			 OTG_FS_GINTMSK_USBSUSPM |
-			 OTG_FS_GINTMSK_WUIM;
+	OTG_FS_GAHBCFG |= OTG_GAHBCFG_GINT;
+	OTG_FS_GINTMSK = OTG_GINTMSK_ENUMDNEM |
+			 OTG_GINTMSK_RXFLVLM |
+			 OTG_GINTMSK_IEPINT |
+			 OTG_GINTMSK_USBSUSPM |
+			 OTG_GINTMSK_WUIM;
 	OTG_FS_DAINTMSK = 0xF;
-	OTG_FS_DIEPMSK = OTG_FS_DIEPMSK_XFRCM;
+	OTG_FS_DIEPMSK = OTG_DIEPMSK_XFRCM;
 
 	return &usbd_dev;
 }

--- a/lib/usb/usb_f207.c
+++ b/lib/usb/usb_f207.c
@@ -52,23 +52,23 @@ const struct _usbd_driver stm32f207_usb_driver = {
 /** Initialize the USB device controller hardware of the STM32. */
 static usbd_device *stm32f207_usbd_init(void)
 {
-	OTG_HS_GINTSTS = OTG_HS_GINTSTS_MMIS;
+	OTG_HS_GINTSTS = OTG_GINTSTS_MMIS;
 
-	OTG_HS_GUSBCFG |= OTG_HS_GUSBCFG_PHYSEL;
+	OTG_HS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;
 	/* Enable VBUS sensing in device mode and power down the PHY. */
-	OTG_HS_GCCFG |= OTG_HS_GCCFG_VBUSBSEN | OTG_HS_GCCFG_PWRDWN;
+	OTG_HS_GCCFG |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
 
 	/* Wait for AHB idle. */
-	while (!(OTG_HS_GRSTCTL & OTG_HS_GRSTCTL_AHBIDL));
+	while (!(OTG_HS_GRSTCTL & OTG_GRSTCTL_AHBIDL));
 	/* Do core soft reset. */
-	OTG_HS_GRSTCTL |= OTG_HS_GRSTCTL_CSRST;
-	while (OTG_HS_GRSTCTL & OTG_HS_GRSTCTL_CSRST);
+	OTG_HS_GRSTCTL |= OTG_GRSTCTL_CSRST;
+	while (OTG_HS_GRSTCTL & OTG_GRSTCTL_CSRST);
 
 	/* Force peripheral only mode. */
-	OTG_HS_GUSBCFG |= OTG_HS_GUSBCFG_FDMOD | OTG_HS_GUSBCFG_TRDT_MASK;
+	OTG_HS_GUSBCFG |= OTG_GUSBCFG_FDMOD | OTG_GUSBCFG_TRDT_MASK;
 
 	/* Full speed device. */
-	OTG_HS_DCFG |= OTG_HS_DCFG_DSPD;
+	OTG_HS_DCFG |= OTG_DCFG_DSPD;
 
 	/* Restart the PHY clock. */
 	OTG_HS_PCGCCTL = 0;
@@ -77,14 +77,14 @@ static usbd_device *stm32f207_usbd_init(void)
 	usbd_dev.fifo_mem_top = stm32f207_usb_driver.rx_fifo_size;
 
 	/* Unmask interrupts for TX and RX. */
-	OTG_HS_GAHBCFG |= OTG_HS_GAHBCFG_GINT;
-	OTG_HS_GINTMSK = OTG_HS_GINTMSK_ENUMDNEM |
-			 OTG_HS_GINTMSK_RXFLVLM |
-			 OTG_HS_GINTMSK_IEPINT |
-			 OTG_HS_GINTMSK_USBSUSPM |
-			 OTG_HS_GINTMSK_WUIM;
+	OTG_HS_GAHBCFG |= OTG_GAHBCFG_GINT;
+	OTG_HS_GINTMSK = OTG_GINTMSK_ENUMDNEM |
+			 OTG_GINTMSK_RXFLVLM |
+			 OTG_GINTMSK_IEPINT |
+			 OTG_GINTMSK_USBSUSPM |
+			 OTG_GINTMSK_WUIM;
 	OTG_HS_DAINTMSK = 0xF;
-	OTG_HS_DIEPMSK = OTG_HS_DIEPMSK_XFRCM;
+	OTG_HS_DIEPMSK = OTG_DIEPMSK_XFRCM;
 
 	return &usbd_dev;
 }

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -20,8 +20,7 @@
 #include <string.h>
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/tools.h>
-#include <libopencm3/stm32/otg_fs.h>
-#include <libopencm3/stm32/otg_hs.h>
+#include <libopencm3/stm32/common/otg_common_all.h>
 #include <libopencm3/usb/usbd.h>
 #include "usb_private.h"
 #include "usb_fx07_common.h"
@@ -29,13 +28,71 @@
 /* The FS core and the HS core have the same register layout.
  * As the code can be used on both cores, the registers offset is modified
  * according to the selected cores base address. */
-#define dev_base_address (usbd_dev->driver->base_address)
-#define REBASE(x)        MMIO32((x) + (dev_base_address))
-#define REBASE_FIFO(x)   (&MMIO32((dev_base_address) + (OTG_FIFO(x))))
+#define dev_base_addr (usbd_dev->driver->base_address)
+
+/* Core Global Control and Status Registers */
+#define USBD_OTG_GOTGCTL			OTG_GOTGCTL(dev_base_addr)
+#define USBD_OTG_GOTGINT			OTG_GOTGINT(dev_base_addr)
+#define USBD_OTG_GAHBCFG			OTG_GAHBCFG(dev_base_addr)
+#define USBD_OTG_GUSBCFG			OTG_GUSBCFG(dev_base_addr)
+#define USBD_OTG_GRSTCTL			OTG_GRSTCTL(dev_base_addr)
+#define USBD_OTG_GINTSTS			OTG_GINTSTS(dev_base_addr)
+#define USBD_OTG_GINTMSK			OTG_GINTMSK(dev_base_addr)
+#define USBD_OTG_GRXSTSR			OTG_GRXSTSR(dev_base_addr)
+#define USBD_OTG_GRXSTSP			OTG_GRXSTSP(dev_base_addr)
+#define USBD_OTG_GRXFSIZ			OTG_GRXFSIZ(dev_base_addr)
+#define USBD_OTG_GNPTXFSIZ		OTG_GNPTXFSIZ(dev_base_addr)
+#define USBD_OTG_GNPTXSTS			OTG_GNPTXSTS(dev_base_addr)
+#define USBD_OTG_GCCFG			OTG_GCCFG(dev_base_addr)
+#define USBD_OTG_CID				OTG_CID(dev_base_addr)
+#define USBD_OTG_HPTXFSIZ			OTG_HPTXFSIZ(dev_base_addr)
+#define USBD_OTG_DIEPTXF(x)		OTG_DIEPTXF(dev_base_addr, x)
+
+/* Host-mode Control and Status Registers */
+#define USBD_OTG_HCFG			OTG_HCFG(dev_base_addr)
+#define USBD_OTG_HFIR			OTG_HFIR(dev_base_addr)
+#define USBD_OTG_HFNUM		OTG_HFNUM(dev_base_addr)
+#define USBD_OTG_HPTXSTS		OTG_HPTXSTS(dev_base_addr)
+#define USBD_OTG_HAINT		OTG_HAINT(dev_base_addr)
+#define USBD_OTG_HAINTMSK		OTG_HAINTMSK(dev_base_addr)
+#define USBD_OTG_HPRT			OTG_HPRT(dev_base_addr)
+#define USBD_OTG_HCCHARx(x)	OTG_HCCHARx(dev_base_addr, x)
+#define USBD_OTG_HCINTx(x)	OTG_HCINTx(dev_base_addr, x)
+#define USBD_OTG_HCINTMSKx(x)	OTG_HCINTMSKx(dev_base_addr, x)
+#define USBD_OTG_HCTSIZx(x)	OTG_HCTSIZx(dev_base_addr, x)
+
+/* Device-mode Control and Status Registers */
+#define USBD_OTG_DCFG				OTG_DCFG(dev_base_addr)
+#define USBD_OTG_DCTL				OTG_DCTL(dev_base_addr)
+#define USBD_OTG_DSTS				OTG_DSTS(dev_base_addr)
+#define USBD_OTG_DIEPMSK			OTG_DIEPMSK(dev_base_addr)
+#define USBD_OTG_DOEPMSK			OTG_DOEPMSK(dev_base_addr)
+#define USBD_OTG_DAINT			OTG_DAINT(dev_base_addr)
+#define USBD_OTG_DAINTMSK			OTG_DAINTMSK(dev_base_addr)
+#define USBD_OTG_DVBUSDIS			OTG_DVBUSDIS(dev_base_addr)
+#define USBD_OTG_DVBUSPULSE		OTG_DVBUSPULSE(dev_base_addr)
+#define USBD_OTG_DIEPEMPMSK		OTG_DIEPEMPMSK(dev_base_addr)
+#define USBD_OTG_DIEPCTL0			OTG_DIEPCTL0(dev_base_addr)
+#define USBD_OTG_DIEPCTL(x)		OTG_DIEPCTL(dev_base_addr, x)
+#define USBD_OTG_DOEPCTL0			OTG_DOEPCTL0(dev_base_addr, x)
+#define USBD_OTG_DOEPCTL(x)		OTG_DOEPCTL(dev_base_addr, x)
+#define USBD_OTG_DIEPINT(x)		OTG_DIEPINT(dev_base_addr, x)
+#define USBD_OTG_DOEPINT(x)		OTG_DOEPINT(dev_base_addr , x)
+#define USBD_OTG_DIEPTSIZ0		OTG_DIEPTSIZ0(dev_base_addr)
+#define USBD_OTG_DOEPTSIZ0		OTG_DOEPTSIZ0(dev_base_addr)
+#define USBD_OTG_DIEPTSIZ(x)		OTG_DIEPTSIZ(dev_base_addr, x)
+#define USBD_OTG_DTXFSTS(x)		OTG_DTXFSTS(dev_base_addr, x)
+#define USBD_OTG_DOEPTSIZ(x)		OTG_DOEPTSIZ(dev_base_addr, x)
+
+/* Power and clock gating control and status register */
+#define USBD_OTG_PCGCCTL			OTG_PCGCCTL(dev_base_addr)
+
+/* Data FIFO */
+#define USBD_OTG_FIFO(x)			OTG_FIFO(dev_base_addr, x)
 
 void stm32fx07_set_address(usbd_device *usbd_dev, uint8_t addr)
 {
-	REBASE(OTG_DCFG) = (REBASE(OTG_DCFG) & ~OTG_FS_DCFG_DAD) | (addr << 4);
+	USBD_OTG_DCFG = (USBD_OTG_DCFG & ~OTG_DCFG_DAD) | (addr << 4);
 }
 
 void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
@@ -52,29 +109,29 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 	if (addr == 0) { /* For the default control endpoint */
 		/* Configure IN part. */
 		if (max_size >= 64) {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_64;
+			USBD_OTG_DIEPCTL0 = OTG_DIEPCTL0_MPSIZ_64;
 		} else if (max_size >= 32) {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_32;
+			USBD_OTG_DIEPCTL0 = OTG_DIEPCTL0_MPSIZ_32;
 		} else if (max_size >= 16) {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_16;
+			USBD_OTG_DIEPCTL0 = OTG_DIEPCTL0_MPSIZ_16;
 		} else {
-			REBASE(OTG_DIEPCTL0) = OTG_FS_DIEPCTL0_MPSIZ_8;
+			USBD_OTG_DIEPCTL0 = OTG_DIEPCTL0_MPSIZ_8;
 		}
 
-		REBASE(OTG_DIEPTSIZ0) =
-			(max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
-		REBASE(OTG_DIEPCTL0) |=
-			OTG_FS_DIEPCTL0_EPENA | OTG_FS_DIEPCTL0_SNAK;
+		USBD_OTG_DIEPTSIZ0 =
+			(max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
+		USBD_OTG_DIEPCTL0 |=
+			OTG_DIEPCTL0_EPENA | OTG_DIEPCTL0_SNAK;
 
 		/* Configure OUT part. */
-		usbd_dev->doeptsiz[0] = OTG_FS_DIEPSIZ0_STUPCNT_1 |
-			OTG_FS_DIEPSIZ0_PKTCNT |
-			(max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
-		REBASE(OTG_DOEPTSIZ(0)) = usbd_dev->doeptsiz[0];
-		REBASE(OTG_DOEPCTL(0)) |=
-		    OTG_FS_DOEPCTL0_EPENA | OTG_FS_DIEPCTL0_SNAK;
+		usbd_dev->doeptsiz[0] = OTG_DIEPSIZ0_STUPCNT_1 |
+			OTG_DIEPSIZ0_PKTCNT |
+			(max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
+		USBD_OTG_DOEPTSIZ(0) = usbd_dev->doeptsiz[0];
+		USBD_OTG_DOEPCTL(0) |=
+		    OTG_DOEPCTL0_EPENA | OTG_DIEPCTL0_SNAK;
 
-		REBASE(OTG_GNPTXFSIZ) = ((max_size / 4) << 16) |
+		USBD_OTG_GNPTXFSIZ = ((max_size / 4) << 16) |
 					 usbd_dev->driver->rx_fifo_size;
 		usbd_dev->fifo_mem_top += max_size / 4;
 		usbd_dev->fifo_mem_top_ep0 = usbd_dev->fifo_mem_top;
@@ -83,15 +140,15 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 	}
 
 	if (dir) {
-		REBASE(OTG_DIEPTXF(addr)) = ((max_size / 4) << 16) |
+		USBD_OTG_DIEPTXF(addr) = ((max_size / 4) << 16) |
 					     usbd_dev->fifo_mem_top;
 		usbd_dev->fifo_mem_top += max_size / 4;
 
-		REBASE(OTG_DIEPTSIZ(addr)) =
-		    (max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
-		REBASE(OTG_DIEPCTL(addr)) |=
-		    OTG_FS_DIEPCTL0_EPENA | OTG_FS_DIEPCTL0_SNAK | (type << 18)
-		    | OTG_FS_DIEPCTL0_USBAEP | OTG_FS_DIEPCTLX_SD0PID
+		USBD_OTG_DIEPTSIZ(addr) =
+		    (max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
+		USBD_OTG_DIEPCTL(addr) |=
+		    OTG_DIEPCTL0_EPENA | OTG_DIEPCTL0_SNAK | (type << 18)
+		    | OTG_DIEPCTL0_USBAEP | OTG_DIEPCTLX_SD0PID
 		    | (addr << 22) | max_size;
 
 		if (callback) {
@@ -101,12 +158,12 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 	}
 
 	if (!dir) {
-		usbd_dev->doeptsiz[addr] = OTG_FS_DIEPSIZ0_PKTCNT |
-				 (max_size & OTG_FS_DIEPSIZ0_XFRSIZ_MASK);
-		REBASE(OTG_DOEPTSIZ(addr)) = usbd_dev->doeptsiz[addr];
-		REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_EPENA |
-		    OTG_FS_DOEPCTL0_USBAEP | OTG_FS_DIEPCTL0_CNAK |
-		    OTG_FS_DOEPCTLX_SD0PID | (type << 18) | max_size;
+		usbd_dev->doeptsiz[addr] = OTG_DIEPSIZ0_PKTCNT |
+				 (max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
+		USBD_OTG_DOEPTSIZ(addr) = usbd_dev->doeptsiz[addr];
+		USBD_OTG_DOEPCTL(addr) |= OTG_DOEPCTL0_EPENA |
+		    OTG_DOEPCTL0_USBAEP | OTG_DIEPCTL0_CNAK |
+		    OTG_DOEPCTLX_SD0PID | (type << 18) | max_size;
 
 		if (callback) {
 			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
@@ -125,9 +182,9 @@ void stm32fx07_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall)
 {
 	if (addr == 0) {
 		if (stall) {
-			REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTL0_STALL;
+			USBD_OTG_DIEPCTL(addr) |= OTG_DIEPCTL0_STALL;
 		} else {
-			REBASE(OTG_DIEPCTL(addr)) &= ~OTG_FS_DIEPCTL0_STALL;
+			USBD_OTG_DIEPCTL(addr) &= ~OTG_DIEPCTL0_STALL;
 		}
 	}
 
@@ -135,17 +192,17 @@ void stm32fx07_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall)
 		addr &= 0x7F;
 
 		if (stall) {
-			REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTL0_STALL;
+			USBD_OTG_DIEPCTL(addr) |= OTG_DIEPCTL0_STALL;
 		} else {
-			REBASE(OTG_DIEPCTL(addr)) &= ~OTG_FS_DIEPCTL0_STALL;
-			REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTLX_SD0PID;
+			USBD_OTG_DIEPCTL(addr) &= ~OTG_DIEPCTL0_STALL;
+			USBD_OTG_DIEPCTL(addr) |= OTG_DIEPCTLX_SD0PID;
 		}
 	} else {
 		if (stall) {
-			REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_STALL;
+			USBD_OTG_DOEPCTL(addr) |= OTG_DOEPCTL0_STALL;
 		} else {
-			REBASE(OTG_DOEPCTL(addr)) &= ~OTG_FS_DOEPCTL0_STALL;
-			REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTLX_SD0PID;
+			USBD_OTG_DOEPCTL(addr) &= ~OTG_DOEPCTL0_STALL;
+			USBD_OTG_DOEPCTL(addr) |= OTG_DOEPCTLX_SD0PID;
 		}
 	}
 }
@@ -154,11 +211,11 @@ uint8_t stm32fx07_ep_stall_get(usbd_device *usbd_dev, uint8_t addr)
 {
 	/* Return non-zero if STALL set. */
 	if (addr & 0x80) {
-		return (REBASE(OTG_DIEPCTL(addr & 0x7f)) &
-				OTG_FS_DIEPCTL0_STALL) ? 1 : 0;
+		return (USBD_OTG_DIEPCTL(addr & 0x7f) &
+				OTG_DIEPCTL0_STALL) ? 1 : 0;
 	} else {
-		return (REBASE(OTG_DOEPCTL(addr)) &
-				OTG_FS_DOEPCTL0_STALL) ? 1 : 0;
+		return (USBD_OTG_DOEPCTL(addr) &
+				OTG_DOEPCTL0_STALL) ? 1 : 0;
 	}
 }
 
@@ -172,9 +229,9 @@ void stm32fx07_ep_nak_set(usbd_device *usbd_dev, uint8_t addr, uint8_t nak)
 	usbd_dev->force_nak[addr] = nak;
 
 	if (nak) {
-		REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_SNAK;
+		USBD_OTG_DOEPCTL(addr) |= OTG_DOEPCTL0_SNAK;
 	} else {
-		REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_CNAK;
+		USBD_OTG_DOEPCTL(addr) |= OTG_DOEPCTL0_CNAK;
 	}
 }
 
@@ -187,15 +244,15 @@ uint16_t stm32fx07_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
 	addr &= 0x7F;
 
 	/* Return if endpoint is already enabled. */
-	if (REBASE(OTG_DIEPTSIZ(addr)) & OTG_FS_DIEPSIZ0_PKTCNT) {
+	if (USBD_OTG_DIEPTSIZ(addr) & OTG_DIEPSIZ0_PKTCNT) {
 		return 0;
 	}
 
 	/* Enable endpoint for transmission. */
-	REBASE(OTG_DIEPTSIZ(addr)) = OTG_FS_DIEPSIZ0_PKTCNT | len;
-	REBASE(OTG_DIEPCTL(addr)) |= OTG_FS_DIEPCTL0_EPENA |
-				     OTG_FS_DIEPCTL0_CNAK;
-	volatile uint32_t *fifo = REBASE_FIFO(addr);
+	USBD_OTG_DIEPTSIZ(addr) = OTG_DIEPSIZ0_PKTCNT | len;
+	USBD_OTG_DIEPCTL(addr) |= OTG_DIEPCTL0_EPENA |
+				     OTG_DIEPCTL0_CNAK;
+	volatile uint32_t *fifo = USBD_OTG_FIFO(addr);
 
 	/* Copy buffer to endpoint FIFO, note - memcpy does not work */
 	for (i = len; i > 0; i -= 4) {
@@ -215,7 +272,7 @@ uint16_t stm32fx07_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
 	len = MIN(len, usbd_dev->rxbcnt);
 	usbd_dev->rxbcnt -= len;
 
-	volatile uint32_t *fifo = REBASE_FIFO(addr);
+	volatile uint32_t *fifo = USBD_OTG_FIFO(addr);
 	for (i = len; i >= 4; i -= 4) {
 		*buf32++ = *fifo++;
 	}
@@ -225,10 +282,10 @@ uint16_t stm32fx07_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
 		memcpy(buf32, &extra, i);
 	}
 
-	REBASE(OTG_DOEPTSIZ(addr)) = usbd_dev->doeptsiz[addr];
-	REBASE(OTG_DOEPCTL(addr)) |= OTG_FS_DOEPCTL0_EPENA |
+	USBD_OTG_DOEPTSIZ(addr) = usbd_dev->doeptsiz[addr];
+	USBD_OTG_DOEPCTL(addr) |= OTG_DOEPCTL0_EPENA |
 	    (usbd_dev->force_nak[addr] ?
-	     OTG_FS_DOEPCTL0_SNAK : OTG_FS_DOEPCTL0_CNAK);
+	     OTG_DOEPCTL0_SNAK : OTG_DOEPCTL0_CNAK);
 
 	return len;
 }
@@ -236,37 +293,37 @@ uint16_t stm32fx07_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
 void stm32fx07_poll(usbd_device *usbd_dev)
 {
 	/* Read interrupt status register. */
-	uint32_t intsts = REBASE(OTG_GINTSTS);
+	uint32_t intsts = USBD_OTG_GINTSTS;
 	int i;
 
-	if (intsts & OTG_FS_GINTSTS_ENUMDNE) {
+	if (intsts & OTG_GINTSTS_ENUMDNE) {
 		/* Handle USB RESET condition. */
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_ENUMDNE;
+		USBD_OTG_GINTSTS = OTG_GINTSTS_ENUMDNE;
 		usbd_dev->fifo_mem_top = usbd_dev->driver->rx_fifo_size;
 		_usbd_reset(usbd_dev);
 		return;
 	}
 
 	/* Note: RX and TX handled differently in this device. */
-	if (intsts & OTG_FS_GINTSTS_RXFLVL) {
+	if (intsts & OTG_GINTSTS_RXFLVL) {
 		/* Receive FIFO non-empty. */
-		uint32_t rxstsp = REBASE(OTG_GRXSTSP);
-		uint32_t pktsts = rxstsp & OTG_FS_GRXSTSP_PKTSTS_MASK;
-		if ((pktsts != OTG_FS_GRXSTSP_PKTSTS_OUT) &&
-		    (pktsts != OTG_FS_GRXSTSP_PKTSTS_SETUP)) {
+		uint32_t rxstsp = USBD_OTG_GRXSTSP;
+		uint32_t pktsts = rxstsp & OTG_GRXSTSP_PKTSTS_MASK;
+		if ((pktsts != OTG_GRXSTSP_PKTSTS_OUT) &&
+		    (pktsts != OTG_GRXSTSP_PKTSTS_SETUP)) {
 			return;
 		}
 
-		uint8_t ep = rxstsp & OTG_FS_GRXSTSP_EPNUM_MASK;
+		uint8_t ep = rxstsp & OTG_GRXSTSP_EPNUM_MASK;
 		uint8_t type;
-		if (pktsts == OTG_FS_GRXSTSP_PKTSTS_SETUP) {
+		if (pktsts == OTG_GRXSTSP_PKTSTS_SETUP) {
 			type = USB_TRANSACTION_SETUP;
 		} else {
 			type = USB_TRANSACTION_OUT;
 		}
 
 		/* Save packet size for stm32f107_ep_read_packet(). */
-		usbd_dev->rxbcnt = (rxstsp & OTG_FS_GRXSTSP_BCNT_MASK) >> 4;
+		usbd_dev->rxbcnt = (rxstsp & OTG_GRXSTSP_BCNT_MASK) >> 4;
 
 		/*
 		 * FIXME: Why is a delay needed here?
@@ -283,7 +340,7 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 
 		/* Discard unread packet data. */
 		for (i = 0; i < usbd_dev->rxbcnt; i += 4) {
-			(void)*REBASE_FIFO(ep);
+			(void)*USBD_OTG_FIFO(ep);
 		}
 
 		usbd_dev->rxbcnt = 0;
@@ -291,10 +348,10 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 
 	/*
 	 * There is no global interrupt flag for transmit complete.
-	 * The XFRC bit must be checked in each OTG_FS_DIEPINT(x).
+	 * The XFRC bit must be checked in each OTG_DIEPINT(x).
 	 */
 	for (i = 0; i < 4; i++) { /* Iterate over endpoints. */
-		if (REBASE(OTG_DIEPINT(i)) & OTG_FS_DIEPINTX_XFRC) {
+		if (USBD_OTG_DIEPINT(i) & OTG_DIEPINTX_XFRC) {
 			/* Transfer complete. */
 			if (usbd_dev->user_callback_ctr[i]
 						       [USB_TRANSACTION_IN]) {
@@ -302,43 +359,43 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 					[USB_TRANSACTION_IN](usbd_dev, i);
 			}
 
-			REBASE(OTG_DIEPINT(i)) = OTG_FS_DIEPINTX_XFRC;
+			USBD_OTG_DIEPINT(i) = OTG_DIEPINTX_XFRC;
 		}
 	}
 
-	if (intsts & OTG_FS_GINTSTS_USBSUSP) {
+	if (intsts & OTG_GINTSTS_USBSUSP) {
 		if (usbd_dev->user_callback_suspend) {
 			usbd_dev->user_callback_suspend();
 		}
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_USBSUSP;
+		USBD_OTG_GINTSTS = OTG_GINTSTS_USBSUSP;
 	}
 
-	if (intsts & OTG_FS_GINTSTS_WKUPINT) {
+	if (intsts & OTG_GINTSTS_WKUPINT) {
 		if (usbd_dev->user_callback_resume) {
 			usbd_dev->user_callback_resume();
 		}
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_WKUPINT;
+		USBD_OTG_GINTSTS = OTG_GINTSTS_WKUPINT;
 	}
 
-	if (intsts & OTG_FS_GINTSTS_SOF) {
+	if (intsts & OTG_GINTSTS_SOF) {
 		if (usbd_dev->user_callback_sof) {
 			usbd_dev->user_callback_sof();
 		}
-		REBASE(OTG_GINTSTS) = OTG_FS_GINTSTS_SOF;
+		USBD_OTG_GINTSTS = OTG_GINTSTS_SOF;
 	}
 
 	if (usbd_dev->user_callback_sof) {
-		REBASE(OTG_GINTMSK) |= OTG_FS_GINTMSK_SOFM;
+		USBD_OTG_GINTMSK |= OTG_GINTMSK_SOFM;
 	} else {
-		REBASE(OTG_GINTMSK) &= ~OTG_FS_GINTMSK_SOFM;
+		USBD_OTG_GINTMSK &= ~OTG_GINTMSK_SOFM;
 	}
 }
 
 void stm32fx07_disconnect(usbd_device *usbd_dev, bool disconnected)
 {
 	if (disconnected) {
-		REBASE(OTG_DCTL) |= OTG_FS_DCTL_SDIS;
+		USBD_OTG_DCTL |= OTG_DCTL_SDIS;
 	} else {
-		REBASE(OTG_DCTL) &= ~OTG_FS_DCTL_SDIS;
+		USBD_OTG_DCTL &= ~OTG_DCTL_SDIS;
 	}
 }


### PR DESCRIPTION
Earlier include/libopencm3/stm32/otg_{fs, hs}.h contain common content (double copy, things could go wrong easily).
now, the common content has been moved to include/libopencm3/stm32/common/otg_common_all.h
and include/libopencm3/stm32/otg_{fs, hs}.h has been modified to use include/libopencm3/stm32/common/otg_common_all.h

Also, changes have been made to lib/usb/usb_{f107, f207, fx07_common}.c to use the intended copy only.
The cause of regression in lib/usb/usb_fx07_common.c (see e11b7d5d6df88b90efa9d53ebca80cf1cb3676dd) will be avoided since, none
of the include/libopencm3/stm32/otg_{hs, fs}.h have been included.

lib/usb/usb_fx07_common.c:
earlier, REBASE(offset) was used to access registers, now the registers can be accessed using USBD_OTG_*

lib/usb/usb_{f207, f107}.c:
they are modified to use include/libopencm3/stm32/otg_{fs, hs}.h

Overall the commit is cleaning up the double defination and prevent regression in future.
@H2OBrain have a look