### PR TITLE
Added USB_FNR register defines

### DIFF
--- a/include/libopencm3/stm32/usb.h
+++ b/include/libopencm3/stm32/usb.h
@@ -113,6 +113,17 @@ LGPL License Terms @ref lgpl_license
 #define USB_CLR_ISTR_SOF()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_SOF)
 #define USB_CLR_ISTR_ESOF()	CLR_REG_BIT(USB_ISTR_REG, USB_ISTR_ESOF)
 
+/* USB Frame Number Register bits ------------------------------------------ */
+
+#define USB_FNR_RXDP		(1 << 15)
+#define USB_FNR_RXDM		(1 << 14)
+#define USB_FNR_LCK		(1 << 13)
+
+#define USB_FNR_LSOF_SHIFT	11
+#define USB_FNR_LSOF		(3 << USB_FNR_LSOF_SHIFT)
+
+#define USB_FNR_FN		(0x7FF << 0)
+
 /* --- USB device address register masks / bits ---------------------------- */
 
 #define USB_DADDR_EF	0x0080


### PR DESCRIPTION
credit: @fenugrec
originally presented in #479 but the commit was a single, so had to seperate out the FNR work.

@fenugrec please review the commit to confirm that i have not missed anything.