### PR TITLE
All STM32 family pwr.h must use LIBOPENCM3_PWR_H as include guard so …

### DIFF
--- a/include/libopencm3/stm32/f2/pwr.h
+++ b/include/libopencm3/stm32/f2/pwr.h
@@ -30,8 +30,8 @@ LGPL License Terms @ref lgpl_license
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBOPENCM3_PWR_F2_H
-#define LIBOPENCM3_PWR_F2_H
+#ifndef LIBOPENCM3_PWR_H
+#define LIBOPENCM3_PWR_H
 
 #include <libopencm3/stm32/common/pwr_common_all.h>
 

--- a/include/libopencm3/stm32/f3/pwr.h
+++ b/include/libopencm3/stm32/f3/pwr.h
@@ -38,8 +38,8 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBOPENCM3_PWR_F3_H
-#define LIBOPENCM3_PWR_F3_H
+#ifndef LIBOPENCM3_PWR_H
+#define LIBOPENCM3_PWR_H
 
 #include <libopencm3/stm32/common/pwr_common_all.h>
 


### PR DESCRIPTION
…that

pwr_common.h can detect that it has been referenced by pwr.h for
each family. F2 and F3 had the wrong include guard.