### PR TITLE
Add nonblocking calls to usart

### DIFF
--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -114,6 +114,7 @@ void usart_send(uint32_t usart, uint16_t data);
 uint16_t usart_recv(uint32_t usart);
 bool usart_is_send_ready(uint32_t usart);
 void usart_wait_send_ready(uint32_t usart);
+bool usart_is_recv_ready(uint32_t usart);
 void usart_wait_recv_ready(uint32_t usart);
 void usart_send_blocking(uint32_t usart, uint16_t data);
 uint16_t usart_recv_blocking(uint32_t usart);

--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -112,6 +112,7 @@ void usart_enable(uint32_t usart);
 void usart_disable(uint32_t usart);
 void usart_send(uint32_t usart, uint16_t data);
 uint16_t usart_recv(uint32_t usart);
+bool usart_is_send_ready(uint32_t usart);
 void usart_wait_send_ready(uint32_t usart);
 void usart_wait_recv_ready(uint32_t usart);
 void usart_send_blocking(uint32_t usart, uint16_t data);

--- a/include/libopencm3/stm32/f0/usart.h
+++ b/include/libopencm3/stm32/f0/usart.h
@@ -322,6 +322,7 @@ void usart_send(uint32_t usart, uint8_t data);
 uint8_t usart_recv(uint32_t usart);
 bool usart_is_send_ready(uint32_t usart);
 void usart_wait_send_ready(uint32_t usart);
+bool usart_is_recv_ready(uint32_t usart);
 void usart_wait_recv_ready(uint32_t usart);
 void usart_send_blocking(uint32_t usart, uint8_t data);
 uint8_t usart_recv_blocking(uint32_t usart);

--- a/include/libopencm3/stm32/f0/usart.h
+++ b/include/libopencm3/stm32/f0/usart.h
@@ -320,6 +320,7 @@ void usart_enable(uint32_t usart);
 void usart_disable(uint32_t usart);
 void usart_send(uint32_t usart, uint8_t data);
 uint8_t usart_recv(uint32_t usart);
+bool usart_is_send_ready(uint32_t usart);
 void usart_wait_send_ready(uint32_t usart);
 void usart_wait_recv_ready(uint32_t usart);
 void usart_send_blocking(uint32_t usart, uint8_t data);

--- a/lib/stm32/common/usart_common_f124.c
+++ b/lib/stm32/common/usart_common_f124.c
@@ -77,7 +77,7 @@ uint16_t usart_recv(uint32_t usart)
 
 bool usart_is_send_ready(uint32_t usart)
 {
-	return ((USART_SR(usart) & USART_SR_TXE) == 0);
+	return ((USART_SR(usart) & USART_SR_TXE) == 1);
 }
 
 
@@ -109,7 +109,7 @@ usart_reg_base
 
 bool usart_is_recv_ready(uint32_t usart)
 {
-	return ((USART_SR(usart) & USART_SR_RXNE) == 0);
+	return ((USART_SR(usart) & USART_SR_RXNE) == 1);
 }
 
 

--- a/lib/stm32/common/usart_common_f124.c
+++ b/lib/stm32/common/usart_common_f124.c
@@ -99,6 +99,22 @@ void usart_wait_send_ready(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART check if Received Data Available
+
+Check if data buffer holds a valid received data word.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@returns boolean: data buffer holds a valid received data word.
+*/
+
+bool usart_is_recv_ready(uint32_t usart)
+{
+	return ((USART_SR(usart) & USART_SR_RXNE) == 0);
+}
+
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Received Data Available
 
 Blocks until the receive data buffer holds a valid received data word.

--- a/lib/stm32/common/usart_common_f124.c
+++ b/lib/stm32/common/usart_common_f124.c
@@ -77,7 +77,6 @@ uint16_t usart_recv(uint32_t usart)
 
 bool usart_is_send_ready(uint32_t usart)
 {
-	/* Wait until the data has been transferred into the shift register. */
 	return ((USART_SR(usart) & USART_SR_TXE) == 0);
 }
 

--- a/lib/stm32/common/usart_common_f124.c
+++ b/lib/stm32/common/usart_common_f124.c
@@ -65,6 +65,24 @@ uint16_t usart_recv(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Check if Transmit Data Buffer is empty
+ *
+ * Check if transmit data buffer is empty and is ready to accept
+ * the next data word.
+ *
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+ * usart_reg_base
+ * @returns boolean: transmit data buffer is ready to accept the next data word
+ */
+
+bool usart_is_send_ready(uint32_t usart)
+{
+	/* Wait until the data has been transferred into the shift register. */
+	return ((USART_SR(usart) & USART_SR_TXE) == 0);
+}
+
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Transmit Data Buffer Empty
 
 Blocks until the transmit data buffer becomes empty and is ready to accept the

--- a/lib/stm32/f0/usart.c
+++ b/lib/stm32/f0/usart.c
@@ -203,7 +203,7 @@ uint8_t usart_recv(uint32_t usart)
 
 bool usart_is_send_ready(uint32_t usart)
 {
-	return ((USART_ISR(usart) & USART_ISR_TXE) == 0);
+	return ((USART_ISR(usart) & USART_ISR_TXE) == 1);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -234,7 +234,7 @@ usart_reg_base
 
 bool usart_is_recv_ready(uint32_t usart)
 {
-	return ((USART_ISR(usart) & USART_ISR_RXNE) == 0);
+	return ((USART_ISR(usart) & USART_ISR_RXNE) == 1);
 }
 
 

--- a/lib/stm32/f0/usart.c
+++ b/lib/stm32/f0/usart.c
@@ -203,7 +203,6 @@ uint8_t usart_recv(uint32_t usart)
 
 bool usart_is_send_ready(uint32_t usart)
 {
-	/* Wait until the data has been transferred into the shift register. */
 	return ((USART_ISR(usart) & USART_ISR_TXE) == 0);
 }
 

--- a/lib/stm32/f0/usart.c
+++ b/lib/stm32/f0/usart.c
@@ -191,6 +191,23 @@ uint8_t usart_recv(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Check if Transmit Data Buffer is Empty
+ *
+ * Check if transmit data buffer is empty and is ready to accept
+ * the next data word.
+ *
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+ * usart_reg_base
+ * @returns boolean: transmit data buffer is ready to accept the next data word
+ */
+
+bool usart_is_send_ready(uint32_t usart)
+{
+	/* Wait until the data has been transferred into the shift register. */
+	return ((USART_ISR(usart) & USART_ISR_TXE) == 0);
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Transmit Data Buffer Empty
  *
  * Blocks until the transmit data buffer becomes empty and is ready to accept

--- a/lib/stm32/f0/usart.c
+++ b/lib/stm32/f0/usart.c
@@ -224,6 +224,22 @@ void usart_wait_send_ready(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART check if Received Data Available
+
+Check if data buffer holds a valid received data word.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@returns boolean: data buffer holds a valid received data word.
+*/
+
+bool usart_is_recv_ready(uint32_t usart)
+{
+	return ((USART_ISR(usart) & USART_ISR_RXNE) == 0);
+}
+
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Received Data Available
  *
  * Blocks until the receive data buffer holds a valid received data word.

--- a/lib/stm32/f3/usart.c
+++ b/lib/stm32/f3/usart.c
@@ -62,6 +62,23 @@ uint16_t usart_recv(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Check if Transmit Data Buffer is Empty
+ *
+ * Check if transmit data buffer is empty and is ready to accept
+ * the next data word.
+ *
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+ * usart_reg_base
+ * @returns boolean: transmit data buffer is ready to accept the next data word
+ */
+
+bool usart_is_send_ready(uint32_t usart)
+{
+	return ((USART_ISR(usart) & USART_ISR_TXE) == 0);
+}
+
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Transmit Data Buffer Empty
  *
  * Blocks until the transmit data buffer becomes empty and is ready to accept
@@ -76,6 +93,22 @@ void usart_wait_send_ready(uint32_t usart)
 	/* Wait until the data has been transferred into the shift register. */
 	while ((USART_ISR(usart) & USART_ISR_TXE) == 0);
 }
+
+/*---------------------------------------------------------------------------*/
+/** @brief USART check if Received Data Available
+
+Check if data buffer holds a valid received data word.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@returns boolean: data buffer holds a valid received data word.
+*/
+
+bool usart_is_recv_ready(uint32_t usart)
+{
+	return ((USART_SR(usart) & USART_SR_RXNE) == 0);
+}
+
 
 /*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Received Data Available

--- a/lib/stm32/f3/usart.c
+++ b/lib/stm32/f3/usart.c
@@ -74,7 +74,7 @@ uint16_t usart_recv(uint32_t usart)
 
 bool usart_is_send_ready(uint32_t usart)
 {
-	return ((USART_ISR(usart) & USART_ISR_TXE) == 0);
+	return ((USART_ISR(usart) & USART_ISR_TXE) == 1);
 }
 
 
@@ -106,7 +106,7 @@ usart_reg_base
 
 bool usart_is_recv_ready(uint32_t usart)
 {
-	return ((USART_SR(usart) & USART_SR_RXNE) == 0);
+	return ((USART_SR(usart) & USART_SR_RXNE) == 1);
 }
 
 


### PR DESCRIPTION
Add nonblocking calls to check the status of the usart.
Instead of busy waiting you can do something else waiting to transmit next byte or waiting to receive data. 
