### PR TITLE
stm32f3: ld: support initialized code/data on CCM.

### DIFF
--- a/ld/devices.data
+++ b/ld/devices.data
@@ -110,10 +110,10 @@ stm32f2[01][57]?e* stm32f2 ROM=512K RAM=128K
 stm32f20[57]?f* stm32f2 ROM=768K RAM=128K
 stm32f2[01][57]?g* stm32f2 ROM=1024K RAM=128K
 
-stm32f302?b* stm32f3ccm ROM=128K RAM=24K CCM=8K
-stm32f302?c* stm32f3ccm ROM=256K RAM=32K CCM=8K
-stm32f303?b* stm32f3ccm ROM=128K RAM=32K CCM=8K
-stm32f3[01]3?c* stm32f3ccm ROM=256K RAM=40K CCM=8K
+stm32f302?b* stm32f3 ROM=128K RAM=24K CCM=8K
+stm32f302?c* stm32f3 ROM=256K RAM=32K CCM=8K
+stm32f303?b* stm32f3 ROM=128K RAM=32K CCM=8K
+stm32f3[01]3?c* stm32f3 ROM=256K RAM=40K CCM=8K
 stm32f373?8* stm32f3 ROM=64K RAM=16K
 stm32f373?b* stm32f3 ROM=128K RAM=24K
 stm32f373?c* stm32f3 ROM=256K RAM=32K
@@ -311,7 +311,6 @@ rm46l852* rm46l ROM=1280K RAM=192K
 ################################################################################
 # the STM32 family groups
 
-stm32f3ccm stm32f3 CCM_OFF=0x10000000
 stm32f4ccm stm32f4 CCM_OFF=0x10000000
 stm32l1eep stm32l1 EEP_OFF=0x08080000
 
@@ -336,7 +335,7 @@ lpc17[78]x lpc17 RAM1_OFF=0x20000000 RAM2_OFF=0x20040000
 stm32f0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0 -mthumb -DSTM32F0 -lopencm3_stm32f0 -msoft-float
 stm32f1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F1 -lopencm3_stm32f1 -msoft-float
 stm32f2 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F2 -lopencm3_stm32f2 -msoft-float
-stm32f3 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F3 -lopencm3_stm32f3 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+stm32f3 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 CCM_OFF=0x10000000 -mcpu=cortex-m4 -mthumb -DSTM32F3 -lopencm3_stm32f3 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 stm32f4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F4 -lopencm3_stm32f4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 stm32l0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0 -mthumb -DSTM32L0 -lopencm3_stm32l0 -msoft-float
 stm32l1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32L1 -lopencm3_stm32l1 -msoft-float

--- a/ld/linker.ld.S
+++ b/ld/linker.ld.S
@@ -47,8 +47,12 @@ MEMORY
 #if defined(_RAM2)
 	ram2 (rwx) : ORIGIN = _RAM2_OFF, LENGTH = _RAM2
 #endif
-#if defined(_CCM)
+#if defined(_CCM_OFF)
+#	if defined(_CCM)
 	ccm (rwx) : ORIGIN = _CCM_OFF, LENGTH = _CCM
+#	else
+	ccm (rwx) : ORIGIN = _CCM_OFF, LENGTH = 0K
+#	endif
 #endif
 #if defined(_EEP)
 	eep (r) : ORIGIN = _EEP_OFF, LENGTH = _EEP
@@ -137,10 +141,23 @@ SECTIONS
 	} >eep
 #endif
 
-#if defined(_CCM)
-	.ccm : {
-		*(.ccmram*)
+#if defined(_CCM_OFF)
+	.ccm_data : {
+		_ccm_data = .;
+		*(.ccm_text*)	/* CCM program code */
 		. = ALIGN(4);
+		*(.ccm_rodata*)	/* CCM read-only data */
+		. = ALIGN(4);
+		*(.ccm_data*)	/* CCM read-write initialized data */
+		. = ALIGN(4);
+		_ccm_edata = .;
+	} >ccm AT >rom
+	_ccm_data_loadaddr = LOADADDR(.ccm_data);
+
+	.ccm_bss : {
+		*(.ccm_bss*) /* CCM read-write zero initialized data */
+		. = ALIGN(4);
+		_ccm_ebss = .;
 	} >ccm
 #endif
 

--- a/lib/stm32/f3/libopencm3_stm32f3.ld
+++ b/lib/stm32/f3/libopencm3_stm32f3.ld
@@ -22,7 +22,7 @@
 /* Memory regions must be defined in the ld script which includes this one. */
 
 /* Enforce emmition of the vector table. */
-EXTERN (vector_table)
+EXTERN(vector_table)
 
 /* Define the entry point of the output file. */
 ENTRY(reset_handler)
@@ -91,6 +91,24 @@ SECTIONS
 		. = ALIGN(4);
 		_ebss = .;
 	} >ram
+
+	.ccm_data : {
+		_ccm_data = .;
+		*(.ccm_text*)	/* CCM program code */
+		. = ALIGN(4);
+		*(.ccm_rodata*)	/* CCM read-only data */
+		. = ALIGN(4);
+		*(.ccm_data*)	/* CCM read-write initialized data */
+		. = ALIGN(4);
+		_ccm_edata = .;
+	} >ccm AT >rom
+	_ccm_data_loadaddr = LOADADDR(.ccm_data);
+
+	.ccm_bss : {
+		*(.ccm_bss*) /* CCm read-write zero initialized data */
+		. = ALIGN(4);
+		_ccm_ebss = .;
+	} >ccm
 
 	/*
 	 * The .eh_frame section appears to be used for C++ exception handling.

--- a/lib/stm32/f3/vector_chipset.c
+++ b/lib/stm32/f3/vector_chipset.c
@@ -20,8 +20,24 @@
 
 #include <libopencm3/cm3/scb.h>
 
+extern unsigned _ccm_data_loadaddr, _ccm_data, _ccm_edata, _ccm_ebss;
+
 static void pre_main(void)
 {
+	volatile unsigned *src, *dest;
+
 	/* Enable access to Floating-Point coprocessor. */
 	SCB_CPACR |= SCB_CPACR_FULL * (SCB_CPACR_CP10 | SCB_CPACR_CP11);
+
+	/* copy initialized code and data to CCM RAM */
+	for (src = &_ccm_data_loadaddr, dest = &_ccm_data;
+		dest < &_ccm_edata;
+		src++, dest++) {
+		*dest = *src;
+	}
+
+	/* clear zero-initialized data on CCM RAM */
+	while (dest < &_ccm_ebss) {
+		*dest++ = 0;
+	}
 }


### PR DESCRIPTION
This commit adds support for initialized code/data on CCM (Core Coupled
Memory) on stm32f3 by:
- Splitting .ccm section into two sections:
  - .ccm_data for initialized code/data with subsections:
    - .ccm_text for CCM program code
    - .ccm_rodata for CCM read-only data
    - .ccm_data for CCM read-write initialized data
  - .ccm_bss for CCM uninitialized data
- Adding corresponding initialization loops in the series' pre_main()
- Adapting automatic ld script generation tools to produce correct
  scripts for the whole f3 series (as not all of them have CCM RAM)

Usage:

Code can be put into CCM and sped up by up to ~30% with:

```
__attribute__((section(".ccm_text"))) void ex_handler(void) {}
```

Variables may also be put into CCM accordingly:

```
__attribute__((section(".ccm_rodata"))) const int ex_rodata = 1;
__attribute__((section(".ccm_data"))) int ex_data = 2;
__attribute__((section(".ccm_bss"))) int ex_bss;
```
