### PR TITLE
stm32l1: Add eeprom to memory maps

### DIFF
--- a/lib/stm32/l1/libopencm3_stm32l1.ld
+++ b/lib/stm32/l1/libopencm3_stm32l1.ld
@@ -92,6 +92,11 @@ SECTIONS
 		_ebss = .;
 	} >ram
 
+	.eeprom (NOLOAD) : {
+		. = ALIGN(4);
+		*(.eeprom*)
+	} >eep
+
 	/*
 	 * The .eh_frame section appears to be used for C++ exception handling.
 	 * You may need to fix this if you're using C++.


### PR DESCRIPTION
NOTE: the "eep" sections were added to the memory map sections of the ld scripts long ago, but I only found this portion of it while cleaning up some local repos just now.  Any thoughts on this?


By adding an "eep" memory section, and a NOLOAD step into the linker
scripts, you can now let gcc allocate variables in eeprom for you.
However, as fitting for eeprom, they cannot be initialized, and will not
be loaded at any time.  This simply lets you get place variables in the
eeprom space.

Example:

struct whatever __attribute__((section(".eeprom"))) blah;
struct another __attribute__((section(".eeprom"))) wop;
printf("%#x", &blah); // ==> 0x08080000
printf("%#x", &wop); // ==> 0x08080000 +  sizeof(blah)

You can read directly out of these variables, but need to use the
eeprom_ routines for writing to them.