### PR TITLE
Pulls/usb set get config

### DIFF
--- a/include/libopencm3/stm32/otg_common.h
+++ b/include/libopencm3/stm32/otg_common.h
@@ -124,6 +124,7 @@
 #define OTG_GRSTCTL_AHBIDL		(1 << 31)
 /* Bits 30:11 - Reserved */
 #define OTG_GRSTCTL_TXFNUM_MASK		(0x1f << 6)
+#define OTG_GRSTCTL_TXFNUM_ALL		(0x10 << 6)
 #define OTG_GRSTCTL_TXFFLSH		(1 << 5)
 #define OTG_GRSTCTL_RXFFLSH		(1 << 4)
 /* Bit 3 - Reserved */

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -117,8 +117,22 @@ void stm32fx07_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 
 void stm32fx07_endpoints_reset(usbd_device *usbd_dev)
 {
+	int i;
 	/* The core resets the endpoints automatically on reset. */
 	usbd_dev->fifo_mem_top = usbd_dev->fifo_mem_top_ep0;
+
+	/* Disable any currently active endpoints */
+	for (i = 1; i < 4; i++) {
+		if (REBASE(OTG_DOEPCTL(i)) & OTG_DOEPCTL0_EPENA) {
+			REBASE(OTG_DOEPCTL(i)) |= OTG_DOEPCTL0_EPDIS;
+		}
+		if (REBASE(OTG_DIEPCTL(i)) & OTG_DIEPCTL0_EPENA) {
+			REBASE(OTG_DIEPCTL(i)) |= OTG_DIEPCTL0_EPDIS;
+		}
+	}
+
+	/* Flush all tx/rx fifos */
+	REBASE(OTG_GRSTCTL) = OTG_GRSTCTL_TXFFLSH | OTG_GRSTCTL_TXFNUM_ALL | OTG_GRSTCTL_RXFFLSH;
 }
 
 void stm32fx07_ep_stall_set(usbd_device *usbd_dev, uint8_t addr, uint8_t stall)

--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -310,7 +310,8 @@ static int usb_standard_get_configuration(usbd_device *usbd_dev,
 	if (*len > 1) {
 		*len = 1;
 	}
-	(*buf)[0] = usbd_dev->current_config;
+	const struct usb_config_descriptor *cfg = &usbd_dev->config[usbd_dev->current_config - 1];
+	(*buf)[0] = cfg->bConfigurationValue;
 
 	return 1;
 }


### PR DESCRIPTION
Some basic fixes uncovered while setting up test suites for a lot of other usb features.
This relates to https://github.com/libopencm3/libopencm3/issues/526
https://github.com/libopencm3/libopencm3/issues/519 
https://github.com/libopencm3/libopencm3/issues/499

I intend to merge these "soon" as they are needed for stable reliable tests that will be used for merging more work.

This includes _part_ of #473 only pertaining to the set_config portions, as I don't have a test suite for multiple interfaces (yet)