### PR TITLE
Wait for ADC to be ready after in adc_power_on(..)

### DIFF
--- a/lib/stm32/f0/adc.c
+++ b/lib/stm32/f0/adc.c
@@ -487,6 +487,7 @@ void adc_power_off(uint32_t adc)
 void adc_power_on(uint32_t adc)
 {
 	ADC_CR(adc) |= ADC_CR_ADEN;
+	while ( (ADC_ISR(adc) & ADC_ISR_ADRDY) == 0 );
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This waits for the ADC_ISR_ADRDY flag to become one in the ADC_ISR register. This makes adc_power_on(..) closer to the power on example in the reference manual (DM00031936.pdf) on page 935.
