### PR TITLE
STM32F0: adc_start_conv_reg() & continuous fix

### DIFF
--- a/lib/stm32/f0/adc.c
+++ b/lib/stm32/f0/adc.c
@@ -196,9 +196,6 @@ void adc_start_conversion_regular(uint32_t adc)
 {
 	/* Start conversion on regular channels. */
 	ADC_CR(adc) |= ADC_CR_ADSTART;
-
-	/* Wait until the ADC starts the conversion. */
-	while (ADC_CR(adc) & ADC_CR_ADSTART);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
ADSTART with not go back to zero when using the ADC in continuous conversion mode. This is according to the description on page 259 of DM00031936.pdf.

I am expecting that the functions provided in adc.h should also work for setting the ADC up in continuous mode?

This might theoretically break existing code that relied on the old behavior, so I guess this patch needs further tweaks.