### PR TITLE
Fix offset for GPIO_BRR on stm32f0

### DIFF
--- a/include/libopencm3/stm32/f0/gpio.h
+++ b/include/libopencm3/stm32/f0/gpio.h
@@ -41,7 +41,7 @@
 /* Register definitions                                                      */
 /*****************************************************************************/
 
-#define GPIO_BRR(port)			MMIO32(port + 0x24)
+#define GPIO_BRR(port)			MMIO32(port + 0x28)
 #define GPIOA_BRR			GPIO_BRR(GPIOA)
 #define GPIOB_BRR			GPIO_BRR(GPIOB)
 #define GPIOC_BRR			GPIO_BRR(GPIOC)


### PR DESCRIPTION
Per section 9.4.11 of the reference manual, the offset for the BRR register for F0 chips should be 0x28, not 0x24