### PR TITLE
usb: Fix definition of usbd_control_complete_callback

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -76,7 +76,7 @@ extern void usbd_register_resume_callback(usbd_device *usbd_dev,
 extern void usbd_register_sof_callback(usbd_device *usbd_dev,
 				       void (*callback)(void));
 
-typedef int (*usbd_control_complete_callback)(usbd_device *usbd_dev,
+typedef void (*usbd_control_complete_callback)(usbd_device *usbd_dev,
 		struct usb_setup_data *req);
 
 typedef int (*usbd_control_callback)(usbd_device *usbd_dev,


### PR DESCRIPTION
Commit 4b892724cf74 ("usb: provide typedefs for all the function
callbacks.") appears to have acidentally changed the return type of
the control complete callback (from void to int) resulting in spurious
warnings building USB applications.

Restore the original type.