### PR TITLE
Add inital RCC subsystem support for the STM32F7.

### DIFF
--- a/include/libopencm3/stm32/f7/flash.h
+++ b/include/libopencm3/stm32/f7/flash.h
@@ -1,4 +1,15 @@
-/* This provides unification of code over STM32F subfamilies */
+/** @defgroup flash_defines FLASH Defines
+ *
+ * @ingroup STM32F7xx_defines
+ *
+ * @brief Defined Constants and Types for the STM32F7xx FLASH Memory
+ *
+ * @version 1.0.0
+ *
+ * @date 14 January 2014
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
 
 /*
  * This file is part of the libopencm3 project.
@@ -17,24 +28,10 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_FLASH_H
+#define LIBOPENCM3_FLASH_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/flash.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/flash.h>
-#elif defined(STM32F2)
-#       include <libopencm3/stm32/f2/flash.h>
-#elif defined(STM32F3)
-#       include <libopencm3/stm32/f3/flash.h>
-#elif defined(STM32F4)
-#       include <libopencm3/stm32/f4/flash.h>
-#elif defined(STM32F7)
-#       include <libopencm3/stm32/f7/flash.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/flash.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/flash_common_f24.h>
+
 #endif
 

--- a/include/libopencm3/stm32/f7/rcc.h
+++ b/include/libopencm3/stm32/f7/rcc.h
@@ -594,6 +594,35 @@
 #define RCC_DCKCFGR2_UART1SEL_MASK		0x3
 #define RCC_DCKCFGR2_UART1SEL_SHIFT		0
 
+extern uint32_t rcc_ahb_frequency;
+extern uint32_t rcc_apb1_frequency;
+extern uint32_t rcc_apb2_frequency;
+
+typedef enum {
+	CLOCK_3V3_216MHZ,
+	CLOCK_3V3_END
+} clock_3v3_t;
+
+typedef struct {
+	uint8_t pllm;
+	uint16_t plln;
+	uint8_t pllp;
+	uint8_t pllq;
+	uint32_t flash_config;
+	uint8_t hpre;
+	uint8_t ppre1;
+	uint8_t ppre2;
+	uint8_t power_save;
+	uint32_t apb1_frequency;
+	uint32_t apb2_frequency;
+} clock_scale_t;
+
+extern const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END];
+
+enum rcc_osc {
+	PLL, HSE, HSI, LSE, LSI
+};
+
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))
 
 enum rcc_periph_clken {
@@ -869,7 +898,32 @@ enum rcc_periph_rst {
 #include <libopencm3/stm32/common/rcc_common_all.h>
 
 BEGIN_DECLS
-
+void rcc_osc_ready_int_clear(enum rcc_osc osc);
+void rcc_osc_ready_int_enable(enum rcc_osc osc);
+void rcc_osc_ready_int_disable(enum rcc_osc osc);
+int rcc_osc_ready_int_flag(enum rcc_osc osc);
+void rcc_css_int_clear(void);
+int rcc_css_int_flag(void);
+void rcc_wait_for_osc_ready(enum rcc_osc osc);
+void rcc_wait_for_sysclk_status(enum rcc_osc osc);
+void rcc_osc_on(enum rcc_osc osc);
+void rcc_osc_off(enum rcc_osc osc);
+void rcc_css_enable(void);
+void rcc_css_disable(void);
+void rcc_osc_bypass_enable(enum rcc_osc osc);
+void rcc_osc_bypass_disable(enum rcc_osc osc);
+void rcc_set_sysclk_source(uint32_t clk);
+void rcc_set_pll_source(uint32_t pllsrc);
+void rcc_set_ppre2(uint32_t ppre2);
+void rcc_set_ppre1(uint32_t ppre1);
+void rcc_set_hpre(uint32_t hpre);
+void rcc_set_rtcpre(uint32_t rtcpre);
+void rcc_set_main_pll_hsi(uint32_t pllm, uint32_t plln, uint32_t pllp,
+			  uint32_t pllq);
+void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
+			  uint32_t pllq);
+uint32_t rcc_system_clock_source(void);
+void rcc_clock_setup_hse_3v3(const clock_scale_t *clock);
 END_DECLS
 
 #endif

--- a/include/libopencm3/stm32/rcc.h
+++ b/include/libopencm3/stm32/rcc.h
@@ -30,6 +30,8 @@
 #       include <libopencm3/stm32/f3/rcc.h>
 #elif defined(STM32F4)
 #       include <libopencm3/stm32/f4/rcc.h>
+#elif defined(STM32F7)
+#	include <libopencm3/stm32/f7/rcc.h>
 #elif defined(STM32L0)
 #       include <libopencm3/stm32/l0/rcc.h>
 #elif defined(STM32L1)

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -42,7 +42,7 @@ ARFLAGS		= rcs
 
 OBJS		= rcc.o gpio.o gpio_common_all.o gpio_common_f0234.o
 
-OBJS		+= rcc_common_all.o
+OBJS		+= rcc_common_all.o flash_common_f234.o flash_common_f24.o
 
 VPATH += ../../usb:../:../../cm3:../common
 VPATH += ../../ethernet

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -40,7 +40,9 @@ CFLAGS		= -Os -g \
 
 ARFLAGS		= rcs
 
-OBJS		= gpio.o gpio_common_all.o gpio_common_f0234.o
+OBJS		= rcc.o gpio.o gpio_common_all.o gpio_common_f0234.o
+
+OBJS		+= rcc_common_all.o
 
 VPATH += ../../usb:../:../../cm3:../common
 VPATH += ../../ethernet

--- a/lib/stm32/f7/rcc.c
+++ b/lib/stm32/f7/rcc.c
@@ -1,9 +1,377 @@
+#include <libopencm3/cm3/assert.h>
 #include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/flash.h>
 
 uint32_t rcc_ahb_frequency = 16000000;
 uint32_t rcc_apb1_frequency = 16000000;
 uint32_t rcc_apb2_frequency = 16000000;
 
-uint32_t rcc_system_clock_source(void) {
-	return (RCC_GFGR & 0x000c) >> 2;
+const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END] = {
+	{ /* 216MHz */
+		.pllm = 25,
+		.plln = 432,
+		.pllp = 2,
+		.pllq = 9,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
+				FLASH_ACR_LATENCY_7WS,
+		.apb1_frequency = 108000000,
+		.apb2_frequency = 216000000,
+	},
+};
+
+void rcc_osc_ready_int_clear(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		RCC_CIR |= RCC_CIR_PLLRDYC;
+		break;
+	case HSE:
+		RCC_CIR |= RCC_CIR_HSERDYC;
+		break;
+	case HSI:
+		RCC_CIR |= RCC_CIR_HSIRDYC;
+		break;
+	case LSE:
+		RCC_CIR |= RCC_CIR_LSERDYC;
+		break;
+	case LSI:
+		RCC_CIR |= RCC_CIR_LSIRDYC;
+		break;
+	}
+}
+
+void rcc_osc_ready_int_enable(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		RCC_CIR |= RCC_CIR_PLLRDYIE;
+		break;
+	case HSE:
+		RCC_CIR |= RCC_CIR_HSERDYIE;
+		break;
+	case HSI:
+		RCC_CIR |= RCC_CIR_HSIRDYIE;
+		break;
+	case LSE:
+		RCC_CIR |= RCC_CIR_LSERDYIE;
+		break;
+	case LSI:
+		RCC_CIR |= RCC_CIR_LSIRDYIE;
+		break;
+	}
+}
+
+void rcc_osc_ready_int_disable(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		RCC_CIR &= ~RCC_CIR_PLLRDYIE;
+		break;
+	case HSE:
+		RCC_CIR &= ~RCC_CIR_HSERDYIE;
+		break;
+	case HSI:
+		RCC_CIR &= ~RCC_CIR_HSIRDYIE;
+		break;
+	case LSE:
+		RCC_CIR &= ~RCC_CIR_LSERDYIE;
+		break;
+	case LSI:
+		RCC_CIR &= ~RCC_CIR_LSIRDYIE;
+		break;
+	}
+}
+
+int rcc_osc_ready_int_flag(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		return ((RCC_CIR & RCC_CIR_PLLRDYF) != 0);
+		break;
+	case HSE:
+		return ((RCC_CIR & RCC_CIR_HSERDYF) != 0);
+		break;
+	case HSI:
+		return ((RCC_CIR & RCC_CIR_HSIRDYF) != 0);
+		break;
+	case LSE:
+		return ((RCC_CIR & RCC_CIR_LSERDYF) != 0);
+		break;
+	case LSI:
+		return ((RCC_CIR & RCC_CIR_LSIRDYF) != 0);
+		break;
+	}
+
+	cm3_assert_not_reached();
+}
+
+void rcc_css_int_clear(void)
+{
+	RCC_CIR |= RCC_CIR_CSSC;
+}
+
+int rcc_css_int_flag(void)
+{
+	return ((RCC_CIR & RCC_CIR_CSSF) != 0);
+}
+
+void rcc_wait_for_osc_ready(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
+		break;
+	case HSE:
+		while ((RCC_CR & RCC_CR_HSERDY) == 0);
+		break;
+	case HSI:
+		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
+		break;
+	case LSE:
+		while ((RCC_BDCR & RCC_BDCR_LSERDY) == 0);
+		break;
+	case LSI:
+		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
+		break;
+	}
+}
+
+void rcc_wait_for_sysclk_status(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_PLL);
+		break;
+	case HSE:
+		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSE);
+		break;
+	case HSI:
+		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSI);
+		break;
+	default:
+		/* Shouldn't be reached. */
+		break;
+	}
+}
+
+void rcc_osc_on(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		RCC_CR |= RCC_CR_PLLON;
+		break;
+	case HSE:
+		RCC_CR |= RCC_CR_HSEON;
+		break;
+	case HSI:
+		RCC_CR |= RCC_CR_HSION;
+		break;
+	case LSE:
+		RCC_BDCR |= RCC_BDCR_LSEON;
+		break;
+	case LSI:
+		RCC_CSR |= RCC_CSR_LSION;
+		break;
+	}
+}
+
+void rcc_osc_off(enum rcc_osc osc)
+{
+	switch (osc) {
+	case PLL:
+		RCC_CR &= ~RCC_CR_PLLON;
+		break;
+	case HSE:
+		RCC_CR &= ~RCC_CR_HSEON;
+		break;
+	case HSI:
+		RCC_CR &= ~RCC_CR_HSION;
+		break;
+	case LSE:
+		RCC_BDCR &= ~RCC_BDCR_LSEON;
+		break;
+	case LSI:
+		RCC_CSR &= ~RCC_CSR_LSION;
+		break;
+	}
+}
+
+void rcc_css_enable(void)
+{
+	RCC_CR |= RCC_CR_CSSON;
+}
+
+void rcc_css_disable(void)
+{
+	RCC_CR &= ~RCC_CR_CSSON;
+}
+
+void rcc_osc_bypass_enable(enum rcc_osc osc)
+{
+	switch (osc) {
+	case HSE:
+		RCC_CR |= RCC_CR_HSEBYP;
+		break;
+	case LSE:
+		RCC_BDCR |= RCC_BDCR_LSEBYP;
+		break;
+	case PLL:
+	case HSI:
+	case LSI:
+		/* Do nothing, only HSE/LSE allowed here. */
+		break;
+	}
+}
+
+void rcc_osc_bypass_disable(enum rcc_osc osc)
+{
+	switch (osc) {
+	case HSE:
+		RCC_CR &= ~RCC_CR_HSEBYP;
+		break;
+	case LSE:
+		RCC_BDCR &= ~RCC_BDCR_LSEBYP;
+		break;
+	case PLL:
+	case HSI:
+	case LSI:
+		/* Do nothing, only HSE/LSE allowed here. */
+		break;
+	}
+}
+
+
+
+void rcc_set_sysclk_source(uint32_t clk)
+{
+	uint32_t reg32;
+
+	reg32 = RCC_CFGR;
+	reg32 &= ~((1 << 1) | (1 << 0));
+	RCC_CFGR = (reg32 | clk);
+}
+
+void rcc_set_pll_source(uint32_t pllsrc)
+{
+	uint32_t reg32;
+
+	reg32 = RCC_PLLCFGR;
+	reg32 &= ~(1 << 22);
+	RCC_PLLCFGR = (reg32 | (pllsrc << 22));
+}
+
+void rcc_set_ppre2(uint32_t ppre2)
+{
+	uint32_t reg32;
+
+	reg32 = RCC_CFGR;
+	reg32 &= ~((1 << 13) | (1 << 14) | (1 << 15));
+	RCC_CFGR = (reg32 | (ppre2 << 13));
+}
+
+void rcc_set_ppre1(uint32_t ppre1)
+{
+	uint32_t reg32;
+
+	reg32 = RCC_CFGR;
+	reg32 &= ~((1 << 10) | (1 << 11) | (1 << 12));
+	RCC_CFGR = (reg32 | (ppre1 << 10));
+}
+
+void rcc_set_hpre(uint32_t hpre)
+{
+	uint32_t reg32;
+
+	reg32 = RCC_CFGR;
+	reg32 &= ~((1 << 4) | (1 << 5) | (1 << 6) | (1 << 7));
+	RCC_CFGR = (reg32 | (hpre << 4));
+}
+
+void rcc_set_rtcpre(uint32_t rtcpre)
+{
+	uint32_t reg32;
+
+	reg32 = RCC_CFGR;
+	reg32 &= ~((1 << 16) | (1 << 17) | (1 << 18) | (1 << 19) | (1 << 20));
+	RCC_CFGR = (reg32 | (rtcpre << 16));
+}
+
+void rcc_set_main_pll_hsi(uint32_t pllm, uint32_t plln, uint32_t pllp,
+			  uint32_t pllq)
+{
+	RCC_PLLCFGR = (pllm << RCC_PLLCFGR_PLLM_SHIFT) |
+		(plln << RCC_PLLCFGR_PLLN_SHIFT) |
+		(((pllp >> 1) - 1) << RCC_PLLCFGR_PLLP_SHIFT) |
+		(pllq << RCC_PLLCFGR_PLLQ_SHIFT);
+}
+
+void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
+			  uint32_t pllq)
+{
+	RCC_PLLCFGR = (pllm << RCC_PLLCFGR_PLLM_SHIFT) |
+		(plln << RCC_PLLCFGR_PLLN_SHIFT) |
+		(((pllp >> 1) - 1) << RCC_PLLCFGR_PLLP_SHIFT) |
+		RCC_PLLCFGR_PLLSRC |
+		(pllq << RCC_PLLCFGR_PLLQ_SHIFT);
+}
+
+uint32_t rcc_system_clock_source(void)
+{
+	/* Return the clock source which is used as system clock. */
+	return (RCC_CFGR & 0x000c) >> 2;
+}
+
+void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
+{
+	/* Enable internal high-speed oscillator. */
+	rcc_osc_on(HSI);
+	rcc_wait_for_osc_ready(HSI);
+
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
+
+	/* Enable external high-speed oscillator 8MHz. */
+	rcc_osc_on(HSE);
+	rcc_wait_for_osc_ready(HSE);
+
+	/* Enable/disable high performance mode */
+/*	if (!clock->power_save) {
+		pwr_set_vos_scale(SCALE1);
+	} else {
+		pwr_set_vos_scale(SCALE2);
+	}
+*/
+	/*
+	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Do this before touching the PLL (TODO: why?).
+	 */
+	rcc_set_hpre(clock->hpre);
+	rcc_set_ppre1(clock->ppre1);
+	rcc_set_ppre2(clock->ppre2);
+
+	rcc_set_main_pll_hse(clock->pllm, clock->plln,
+			clock->pllp, clock->pllq);
+
+	/* Enable PLL oscillator and wait for it to stabilize. */
+	rcc_osc_on(PLL);
+	rcc_wait_for_osc_ready(PLL);
+
+	/* Configure flash settings. */
+	flash_set_ws(clock->flash_config);
+
+	/* Select PLL as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_PLL);
+
+	/* Wait for PLL clock to be selected. */
+	rcc_wait_for_sysclk_status(PLL);
+
+	/* Set the peripheral clock frequencies used. */
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
+
+	/* Disable internal high-speed oscillator. */
+	rcc_osc_off(HSI);
 }

--- a/lib/stm32/f7/rcc.c
+++ b/lib/stm32/f7/rcc.c
@@ -1,0 +1,9 @@
+#include <libopencm3/stm32/rcc.h>
+
+uint32_t rcc_ahb_frequency = 16000000;
+uint32_t rcc_apb1_frequency = 16000000;
+uint32_t rcc_apb2_frequency = 16000000;
+
+uint32_t rcc_system_clock_source(void) {
+	return (RCC_GFGR & 0x000c) >> 2;
+}


### PR DESCRIPTION
Just uses the default reset clock. Actual PLL values coming later.
