### PR TITLE
stm32f0: Fix TSC_IOGxCR

### DIFF
--- a/include/libopencm3/stm32/f0/tsc.h
+++ b/include/libopencm3/stm32/f0/tsc.h
@@ -52,7 +52,7 @@
 #define TSC_IOSCR			MMIO32(TSC_BASE + 0x20)
 #define TSC_IOCCR			MMIO32(TSC_BASE + 0x28)
 #define TSC_IOGCSR			MMIO32(TSC_BASE + 0x30)
-#define TSC_IOGxCR(x)			MMIO8(TSC_BASE + 0x34 + (x)*4)
+#define TSC_IOGxCR(x)			MMIO32(TSC_BASE + 0x34 + ((x)-1)*4)
 
 /*****************************************************************************/
 /* Register values                                                           */


### PR DESCRIPTION
TSC_IOGxCR is actually a 32 bit register, of which 13 bits are used
(rest are reserved).

Also, added x-1 since G0 is not a valid group, TSC_IOGCSR_GxE(1) is supposed
to be at 0x34, not 0x38.