### PR TITLE
STM32 ADC standardization and cleanup

### DIFF
--- a/include/libopencm3/stm32/common/adc_common_v1.h
+++ b/include/libopencm3/stm32/common/adc_common_v1.h
@@ -357,7 +357,7 @@ specific memorymap.h header before including this header file.*/
 BEGIN_DECLS
 
 void adc_power_on(uint32_t adc);
-void adc_off(uint32_t adc);
+void adc_power_off(uint32_t adc);
 void adc_enable_analog_watchdog_regular(uint32_t adc);
 void adc_disable_analog_watchdog_regular(uint32_t adc);
 void adc_enable_analog_watchdog_injected(uint32_t adc);

--- a/include/libopencm3/stm32/f0/adc.h
+++ b/include/libopencm3/stm32/f0/adc.h
@@ -249,25 +249,9 @@
  * @ingroup adc_defines
  *
  *@{*/
-#define ADC_CHANNEL0		0x00
-#define ADC_CHANNEL1		0x01
-#define ADC_CHANNEL2		0x02
-#define ADC_CHANNEL3		0x03
-#define ADC_CHANNEL4		0x04
-#define ADC_CHANNEL5		0x05
-#define ADC_CHANNEL6		0x06
-#define ADC_CHANNEL7		0x07
-#define ADC_CHANNEL8		0x08
-#define ADC_CHANNEL9		0x09
-#define ADC_CHANNEL10		0x0A
-#define ADC_CHANNEL11		0x0B
-#define ADC_CHANNEL12		0x0C
-#define ADC_CHANNEL13		0x0D
-#define ADC_CHANNEL14		0x0E
-#define ADC_CHANNEL15		0x0F
-#define ADC_CHANNEL_TEMP	0x10
-#define ADC_CHANNEL_VREF	0x11
-#define ADC_CHANNEL_VBAT	0x12
+#define ADC_CHANNEL_TEMP	16
+#define ADC_CHANNEL_VREF	17
+#define ADC_CHANNEL_VBAT	18
 /**@}*/
 
 /** @defgroup adc_api_opmode ADC Operation Modes

--- a/include/libopencm3/stm32/f0/memorymap.h
+++ b/include/libopencm3/stm32/f0/memorymap.h
@@ -111,6 +111,6 @@
 /* ST provided factory calibration values @ 3.3V */
 #define ST_VREFINT_CAL		MMIO16(0x1FFFF7BA)
 #define ST_TSENSE_CAL1_30C	MMIO16(0x1FFFF7B8)
-#define ST_TSENSE_CAL2_110	MMIO16(0x1FFFF7C2)
+#define ST_TSENSE_CAL2_110C	MMIO16(0x1FFFF7C2)
 
 #endif

--- a/include/libopencm3/stm32/f1/adc.h
+++ b/include/libopencm3/stm32/f1/adc.h
@@ -75,10 +75,6 @@ LGPL License Terms @ref lgpl_license
 /* ADC regular data register (ADC_DR) */
 #define ADC_DR(block)			MMIO32((block) + 0x4c)
 
-/* --- ADC Channels ------------------------------------------------------- */
-#define ADC_CHANNEL_TEMP        ADC_CHANNEL16
-#define ADC_CHANNEL_VREFINT     ADC_CHANNEL17
-
 
 /* --- ADC_CR1 values ------------------------------------------------------ */
 
@@ -396,6 +392,14 @@ and ADC2
 #define ADC_DATA_MSK			(0xffff << ADC_DA)
 #define ADC_ADC2DATA_MSK		(0xffff << ADC_ADC2DATA_LSB)
 					/* ADC1 only (dual mode) */
+
+/** @defgroup adc_channel ADC Channel Numbers
+ * @ingroup adc_defines
+ *
+ *@{*/
+#define ADC_CHANNEL_TEMP	16
+#define ADC_CHANNEL_VREF	17
+/**@}*/
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -475,47 +475,23 @@
 #define ADC_CFGR_DMAEN		(1 << 0)
 
 
-/*------- ADC_SMPR1 values ---------*/
-#define ADC_SMPR1_SMP8_LSB		24
-#define ADC_SMPR1_SMP7_LSB		21
-#define ADC_SMPR1_SMP6_LSB		18
-#define ADC_SMPR1_SMP5_LSB		15
-#define ADC_SMPR1_SMP4_LSB		12
-#define ADC_SMPR1_SMP3_LSB		9
-#define ADC_SMPR1_SMP2_LSB		6
-#define ADC_SMPR1_SMP1_LSB		3
-#define ADC_SMPR1_SMP8_MSK		(0x7 << ADC_SMP8_LSB)
-#define ADC_SMPR1_SMP7_MSK		(0x7 << ADC_SMP7_LSB)
-#define ADC_SMPR1_SMP6_MSK		(0x7 << ADC_SMP6_LSB)
-#define ADC_SMPR1_SMP5_MSK		(0x7 << ADC_SMP5_LSB)
-#define ADC_SMPR1_SMP4_MSK		(0x7 << ADC_SMP4_LSB)
-#define ADC_SMPR1_SMP3_MSK		(0x7 << ADC_SMP3_LSB)
-#define ADC_SMPR1_SMP2_MSK		(0x7 << ADC_SMP2_LSB)
-#define ADC_SMPR1_SMP1_MSK		(0x7 << ADC_SMP1_LSB)
 /****************************************************************************/
-/* ADC_SMPR1 ADC Sample Time Selection for Channels */
-/** @defgroup adc_sample_r1 ADC Sample Time Selection for ADC1
+/* ADC_SMPRx ADC Sample Time Selection for Channels */
+/** @defgroup adc_sample ADC Sample Time Selection values
 @ingroup adc_defines
 
 @{*/
-#define ADC_SMPR1_SMP_1DOT5CYC		0x0
-#define ADC_SMPR1_SMP_2DOT5CYC		0x1
-#define ADC_SMPR1_SMP_4DOT5CYC		0x2
-#define ADC_SMPR1_SMP_7DOT5CYC		0x3
-#define ADC_SMPR1_SMP_19DOT5CYC		0x4
-#define ADC_SMPR1_SMP_61DOT5CYC		0x5
-#define ADC_SMPR1_SMP_181DOT5CYC	0x6
-#define ADC_SMPR1_SMP_601DOT5CYC	0x7
+#define ADC_SMPR_SMP_1DOT5CYC		0x0
+#define ADC_SMPR_SMP_2DOT5CYC		0x1
+#define ADC_SMPR_SMP_4DOT5CYC		0x2
+#define ADC_SMPR_SMP_7DOT5CYC		0x3
+#define ADC_SMPR_SMP_19DOT5CYC		0x4
+#define ADC_SMPR_SMP_61DOT5CYC		0x5
+#define ADC_SMPR_SMP_181DOT5CYC		0x6
+#define ADC_SMPR_SMP_601DOT5CYC		0x7
 /**@}*/
 
 /* SMPx[2:0]: Channel x sampling time selection */
-
-
-/*------- ADC_SMPR2 values ---------*/
-
-/* SMPx[2:0]: Channel x sampling time selection */
-
-
 
 /*------- ADC_TR1 values ---------*/
 

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -247,11 +247,16 @@
 #define ADC3_CALFACT		ADC_CALFACT(ADC3_BASE)
 #define ADC4_CALFACT		ADC_CALFACT(ADC4_BASE)
 
-/* ADC common (shared) registers */
-#define	ADC_COMMON_REGISTERS_BASE	(ADC1_BASE+0x300)
-#define ADC_CSR				MMIO32(ADC_COMMON_REGISTERS_BASE + 0x0)
-#define ADC_CCR				MMIO32(ADC_COMMON_REGISTERS_BASE + 0x8)
-#define ADC_CDR				MMIO32(ADC_COMMON_REGISTERS_BASE + 0xA)
+/* ADC common (shared) registers, adc_pair is ADC12 or ADC34 */
+#define ADC_CSR(adc_pair)		MMIO32((adc_pair) + 0x300 + 0x0)
+#define ADC_CCR(adc_pair)		MMIO32((adc_pair) + 0x300 + 0x8)
+#define ADC_CDR(adc_pair)		MMIO32((adc_pair) + 0x300 + 0xa)
+#define ADC12_CSR			ADC_CSR(ADC1)
+#define ADC12_CCR			ADC_CCR(ADC1)
+#define ADC12_CDR			ADC_CDR(ADC1)
+#define ADC34_CSR			ADC_CSR(ADC3)
+#define ADC34_CCR			ADC_CCR(ADC3)
+#define ADC34_CDR			ADC_CDR(ADC3)
 
 
 /*------- ADC_ISR values ---------*/
@@ -903,8 +908,8 @@ uint32_t adc_read_regular(uint32_t adc);
 uint32_t adc_read_injected(uint32_t adc, uint8_t reg);
 void adc_set_injected_offset(uint32_t adc, uint8_t reg, uint32_t offset);
 
-void adc_set_clk_prescale(uint32_t prescaler);
-void adc_set_multi_mode(uint32_t mode);
+void adc_set_clk_prescale(uint32_t adc, uint32_t prescaler);
+void adc_set_multi_mode(uint32_t adc, uint32_t mode);
 void adc_enable_external_trigger_regular(uint32_t adc, uint32_t trigger,
 					 uint32_t polarity);
 void adc_enable_external_trigger_injected(uint32_t adc, uint32_t trigger,

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -865,6 +865,14 @@
 
 /* Bits 15:0 RDATA_MST[15:0]: Regular data of the master ADC. */
 
+/** @defgroup adc_channel ADC Channel Numbers
+ * @ingroup adc_defines
+ *
+ *@{*/
+#define ADC_CHANNEL_TEMP	16
+#define ADC_CHANNEL_VBAT	17
+#define ADC_CHANNEL_VREF	18
+/**@}*/
 
 
 BEGIN_DECLS

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -870,7 +870,7 @@
 BEGIN_DECLS
 
 void adc_power_on(uint32_t adc);
-void adc_off(uint32_t adc);
+void adc_power_off(uint32_t adc);
 void adc_enable_analog_watchdog_regular(uint32_t adc);
 void adc_disable_analog_watchdog_regular(uint32_t adc);
 void adc_enable_analog_watchdog_injected(uint32_t adc);

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -334,11 +334,10 @@
 /* ADCALDIF: Differential mode for calibration */
 #define ADC_CR_ADCALDIF		(1 << 30)
 
-/* ADVREGEN: ADC voltage regulador enable */
-#define ADC_CR_ADVREGEN_INTERMEDIATE	(0x0 << 28)
+/** ADVREGEN: ADC voltage regulator enable */
 #define ADC_CR_ADVREGEN_ENABLE		(0x1 << 28)
 #define ADC_CR_ADVREGEN_DISABLE		(0x2 << 28)
-/* --- Bit 0x3 reserved --- */
+#define ADC_CR_ADVREGEN_MASK		(0x3 << 28)
 
 /* JADSTP: ADC stop of injected conversion command */
 #define ADC_CR_JADSTP		(1 << 5)
@@ -920,6 +919,8 @@ bool adc_awd(uint32_t adc);
 /*void adc_set_dma_terminate(uint32_t adc);*/
 void adc_enable_temperature_sensor(void);
 void adc_disable_temperature_sensor(void);
+void adc_enable_regulator(uint32_t adc);
+void adc_disable_regulator(uint32_t adc);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f3/memorymap.h
+++ b/include/libopencm3/stm32/f3/memorymap.h
@@ -124,6 +124,6 @@
 /* ST provided factory calibration values @ 3.3V */
 #define ST_VREFINT_CAL		MMIO16(0x1FFFF7BA)
 #define ST_TSENSE_CAL1_30C	MMIO16(0x1FFFF7B8)
-#define ST_TSENSE_CAL2_110	MMIO16(0x1FFFF7C2)
+#define ST_TSENSE_CAL2_110C	MMIO16(0x1FFFF7C2)
 
 #endif

--- a/include/libopencm3/stm32/f4/adc.h
+++ b/include/libopencm3/stm32/f4/adc.h
@@ -84,11 +84,15 @@ LGPL License Terms @ref lgpl_license
 
 /* --- ADC Channels ------------------------------------------------------- */
 
-/* Thanks ST! F40x and F41x are on 16, F42x and F43x are on 18! */
-#define ADC_CHANNEL_TEMP_F40	ADC_CHANNEL16
-#define ADC_CHANNEL_TEMP_F42	ADC_CHANNEL18
-#define ADC_CHANNEL_VREFINT	ADC_CHANNEL17
-#define ADC_CHANNEL_VBAT	ADC_CHANNEL18
+/** @defgroup adc_channel ADC Channel Numbers
+ * @ingroup adc_defines
+ * Thanks ST! F40x and F41x are on 16, F42x and F43x are on 18!
+ *@{*/
+#define ADC_CHANNEL_TEMP_F40	16
+#define ADC_CHANNEL_TEMP_F42	18
+#define ADC_CHANNEL_VREF	17
+#define ADC_CHANNEL_VBAT	18
+/**@}*/
 
 /* --- ADC_SR values ------------------------------------------------------- */
 

--- a/include/libopencm3/stm32/f4/memorymap.h
+++ b/include/libopencm3/stm32/f4/memorymap.h
@@ -150,6 +150,6 @@
 /* ST provided factory calibration values @ 3.3V */
 #define ST_VREFINT_CAL		MMIO16(0x1FFF7A2A)
 #define ST_TSENSE_CAL1_30C	MMIO16(0x1FFF7A2C)
-#define ST_TSENSE_CAL2_110	MMIO16(0x1FFF7A2E)
+#define ST_TSENSE_CAL2_110C	MMIO16(0x1FFF7A2E)
 
 #endif

--- a/include/libopencm3/stm32/l1/adc.h
+++ b/include/libopencm3/stm32/l1/adc.h
@@ -91,11 +91,14 @@ LGPL License Terms @ref lgpl_license
 #define ADC_CSR				MMIO32(ADC1 + 0x300)
 #define ADC_CCR				MMIO32(ADC1 + 0x304)
 
-
-/* These are _not_ consistent unfortunately! */
-#define ADC_CHANNEL_TEMP        ADC_CHANNEL16
-#define ADC_CHANNEL_VREFINT     ADC_CHANNEL17
-#define ADC_CHANNEL_VBAT        ADC_CHANNEL18
+/** @defgroup adc_channel ADC Channel Numbers
+ * @ingroup adc_defines
+ *
+ *@{*/
+#define ADC_CHANNEL_TEMP	ADC_CHANNEL16
+#define ADC_CHANNEL_VREF	ADC_CHANNEL17
+#define ADC_CHANNEL_VBAT	ADC_CHANNEL18
+/**@}*/
 
 /* --- ADC_SR values ------------------------------------------------------- */
 #define ADC_SR_JCNR			(1 << 9)

--- a/lib/stm32/common/adc_common_v1.c
+++ b/lib/stm32/common/adc_common_v1.c
@@ -53,7 +53,7 @@ and ADC, reset ADC and set the prescaler divider. Set dual mode to independent
 
 @code
     rcc_periph_clock_enable(RCC_ADC1);
-    adc_off(ADC1);
+    adc_power_off(ADC1);
     rcc_periph_reset_pulse(RST_ADC1);
     rcc_set_adcpre(RCC_CFGR_ADCPRE_PCLK2_DIV2);
     adc_set_dual_mode(ADC_CR1_DUALMOD_IND);
@@ -104,7 +104,7 @@ Turn off the ADC to reduce power consumption to a few microamps.
 adc_reg_base.
 */
 
-void adc_off(uint32_t adc)
+void adc_power_off(uint32_t adc)
 {
 	ADC_CR2(adc) &= ~ADC_CR2_ADON;
 }

--- a/lib/stm32/f1/adc.c
+++ b/lib/stm32/f1/adc.c
@@ -55,7 +55,7 @@ and ADC, reset ADC and set the prescaler divider. Set dual mode to independent
 
 @code
 	rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_ADC1EN);
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 	rcc_peripheral_reset(&RCC_APB2RSTR, RCC_APB2RSTR_ADC1RST);
 	rcc_peripheral_clear_reset(&RCC_APB2RSTR, RCC_APB2RSTR_ADC1RST);
 	rcc_set_adcpre(RCC_CFGR_ADCPRE_PCLK2_DIV2);

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -1197,5 +1197,30 @@ void adc_disable_temperature_sensor()
 
 /*---------------------------------------------------------------------------*/
 
+/**
+ * Enable the ADC Voltage regulator
+ * Before any use of the ADC, the ADC Voltage regulator must be enabled.
+ * You must wait up to 10uSecs afterwards before trying anything else.
+ * @param[in] adc ADC block register address base
+ * @sa adc_disable_regulator
+ */
+void adc_enable_regulator(uint32_t adc)
+{
+	ADC_CR(adc) &= ~ADC_CR_ADVREGEN_MASK;
+	ADC_CR(adc) |= ADC_CR_ADVREGEN_ENABLE;
+}
+
+/**
+ * Disable the ADC Voltage regulator
+ * You can disable the adc vreg when not in use to save power
+ * @param[in] adc ADC block register address base
+ * @sa adc_enable_regulator
+ */
+void adc_disable_regulator(uint32_t adc)
+{
+	ADC_CR(adc) &= ~ADC_CR_ADVREGEN_MASK;
+	ADC_CR(adc) |= ADC_CR_ADVREGEN_DISABLE;
+}
+
 /**@}*/
 

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -97,7 +97,7 @@
  * adc_reg_base
 */
 
-void adc_off(uint32_t adc)
+void adc_power_off(uint32_t adc)
 {
 	ADC_CR(adc) &= ~ADC_CR_ADEN;
 }

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -931,10 +931,10 @@ void adc_power_on(uint32_t adc)
  * adc_ccr_adcpre
 */
 
-void adc_set_clk_prescale(uint32_t prescale)
+void adc_set_clk_prescale(uint32_t adc, uint32_t prescale)
 {
-	uint32_t reg32 = ((ADC_CCR & ~ADC_CCR_CKMODE_MASK) | prescale);
-	ADC_CCR = reg32;
+	uint32_t reg32 = ((ADC_CCR(adc) & ~ADC_CCR_CKMODE_MASK) | prescale);
+	ADC_CCR(adc) = reg32;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -949,9 +949,9 @@ void adc_set_clk_prescale(uint32_t prescale)
  * adc_multi_mode
 */
 
-void adc_set_multi_mode(uint32_t mode)
+void adc_set_multi_mode(uint32_t adc, uint32_t mode)
 {
-	ADC_CCR |= mode;
+	ADC_CCR(adc) |= mode;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1177,7 +1177,7 @@ bool adc_awd(uint32_t adc)
 
 void adc_enable_temperature_sensor()
 {
-	ADC_CCR |= ADC_CCR_TSEN;
+	ADC12_CCR |= ADC_CCR_TSEN;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1192,7 +1192,7 @@ void adc_enable_temperature_sensor()
 
 void adc_disable_temperature_sensor()
 {
-	ADC_CCR &= ~ADC_CCR_TSEN;
+	ADC12_CCR &= ~ADC_CCR_TSEN;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
~~DEPENDS ON https://github.com/libopencm3/libopencm3/pull/561~~ merged

This is further work cleaning up some of the common functionality across the ADCs, paving the way for upcoming patches that reduce duplication and bring in L0 and L4 support, and merge the f0/f3 adc code.