### PR TITLE
RCC namespace cleanups [BREAKING]

### DIFF
--- a/include/libopencm3/stm32/common/pwr_common_l01.h
+++ b/include/libopencm3/stm32/common/pwr_common_l01.h
@@ -77,15 +77,15 @@
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
-	RANGE1,
-	RANGE2,
-	RANGE3,
+enum pwr_vos_scale {
+	PWR_SCALE1,
+	PWR_SCALE2,
+	PWR_SCALE3,
 } vos_scale_t;
 
 BEGIN_DECLS
 
-void pwr_set_vos_scale(vos_scale_t scale);
+void pwr_set_vos_scale(enum pwr_vos_scale scale);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -383,7 +383,7 @@ extern uint32_t rcc_ahb_frequency;
 extern uint32_t rcc_apb1_frequency;
 
 enum rcc_osc {
-	HSI14, HSI, HSE, PLL, LSI, LSE, HSI48
+	RCC_HSI14, RCC_HSI, RCC_HSE, RCC_PLL, RCC_LSI, RCC_LSE, RCC_HSI48
 };
 
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))

--- a/include/libopencm3/stm32/f1/rcc.h
+++ b/include/libopencm3/stm32/f1/rcc.h
@@ -540,7 +540,7 @@ extern uint32_t rcc_apb2_frequency;
 /* --- Function prototypes ------------------------------------------------- */
 
 enum rcc_osc {
-	PLL, PLL2, PLL3, HSE, HSI, LSE, LSI
+	RCC_PLL, RCC_PLL2, RCC_PLL3, RCC_HSE, RCC_HSI, RCC_LSE, RCC_LSI
 };
 
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))

--- a/include/libopencm3/stm32/f2/rcc.h
+++ b/include/libopencm3/stm32/f2/rcc.h
@@ -478,12 +478,12 @@ extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
-	CLOCK_3V3_120MHZ,
-	CLOCK_3V3_END
-} clock_3v3_t;
+enum rcc_clock_3v3 {
+	RCC_CLOCK_3V3_120MHZ,
+	RCC_CLOCK_3V3_END
+};
 
-typedef struct {
+struct rcc_clock_scale {
 	uint8_t pllm;
 	uint16_t plln;
 	uint8_t pllp;
@@ -494,12 +494,12 @@ typedef struct {
 	uint8_t ppre2;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
-} clock_scale_t;
+};
 
-extern const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END];
 
 typedef enum {
-	PLL, HSE, HSI, LSE, LSI
+	RCC_PLL, RCC_HSE, RCC_HSI, RCC_LSE, RCC_LSI
 } osc_t;
 
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))
@@ -751,7 +751,7 @@ void rcc_set_main_pll_hsi(uint32_t pllm, uint32_t plln, uint32_t pllp,
 void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq);
 uint32_t rcc_system_clock_source(void);
-void rcc_clock_setup_hse_3v3(const clock_scale_t *clock);
+void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
 void rcc_backupdomain_reset(void);
 
 END_DECLS

--- a/include/libopencm3/stm32/f3/rcc.h
+++ b/include/libopencm3/stm32/f3/rcc.h
@@ -411,13 +411,13 @@ extern uint32_t rcc_apb2_frequency;
 /* --- Function prototypes ------------------------------------------------- */
 
 enum rcc_clock {
-	CLOCK_44MHZ,
-	CLOCK_48MHZ,
-	CLOCK_64MHZ,
-	CLOCK_END
+	RCC_CLOCK_44MHZ,
+	RCC_CLOCK_48MHZ,
+	RCC_CLOCK_64MHZ,
+	RCC_CLOCK_END
 };
 
-typedef struct {
+struct rcc_clock_scale {
 	uint8_t pll;
 	uint8_t pllsrc;
 	uint32_t flash_config;
@@ -427,12 +427,12 @@ typedef struct {
 	uint8_t power_save;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
-} clock_scale_t;
+};
 
-extern const clock_scale_t hsi_8mhz[CLOCK_END];
+extern const struct rcc_clock_scale hsi_8mhz[RCC_CLOCK_END];
 
-enum osc {
-	PLL, HSE, HSI, LSE, LSI
+enum rcc_osc {
+	RCC_PLL, RCC_HSE, RCC_HSI, RCC_LSE, RCC_LSI
 };
 
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))
@@ -580,21 +580,21 @@ enum rcc_periph_rst {
 
 BEGIN_DECLS
 
-void rcc_osc_ready_int_clear(enum osc osc);
-void rcc_osc_ready_int_enable(enum osc osc);
-void rcc_osc_ready_int_disable(enum osc osc);
-int rcc_osc_ready_int_flag(enum osc osc);
+void rcc_osc_ready_int_clear(enum rcc_osc osc);
+void rcc_osc_ready_int_enable(enum rcc_osc osc);
+void rcc_osc_ready_int_disable(enum rcc_osc osc);
+int rcc_osc_ready_int_flag(enum rcc_osc osc);
 void rcc_css_int_clear(void);
 int rcc_css_int_flag(void);
-void rcc_wait_for_osc_ready(enum osc osc);
-void rcc_wait_for_osc_not_ready(enum osc osc);
-void rcc_wait_for_sysclk_status(enum osc osc);
-void rcc_osc_on(enum osc osc);
-void rcc_osc_off(enum osc osc);
+void rcc_wait_for_osc_ready(enum rcc_osc osc);
+void rcc_wait_for_osc_not_ready(enum rcc_osc osc);
+void rcc_wait_for_sysclk_status(enum rcc_osc osc);
+void rcc_osc_on(enum rcc_osc osc);
+void rcc_osc_off(enum rcc_osc osc);
 void rcc_css_enable(void);
 void rcc_css_disable(void);
-void rcc_osc_bypass_enable(enum osc osc);
-void rcc_osc_bypass_disable(enum osc osc);
+void rcc_osc_bypass_enable(enum rcc_osc osc);
+void rcc_osc_bypass_disable(enum rcc_osc osc);
 void rcc_set_sysclk_source(uint32_t clk);
 void rcc_set_pll_source(uint32_t pllsrc);
 void rcc_set_ppre2(uint32_t ppre2);
@@ -604,7 +604,7 @@ void rcc_set_prediv(uint32_t prediv);
 void rcc_set_pll_multiplier(uint32_t pll);
 uint32_t rcc_get_system_clock_source(void);
 void rcc_backupdomain_reset(void);
-void rcc_clock_setup_hsi(const clock_scale_t *clock);
+void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock);
 void rcc_set_i2c_clock_hsi(uint32_t i2c);
 void rcc_set_i2c_clock_sysclk(uint32_t i2c);
 uint32_t rcc_get_i2c_clocks(void);

--- a/include/libopencm3/stm32/f4/pwr.h
+++ b/include/libopencm3/stm32/f4/pwr.h
@@ -72,14 +72,14 @@ LGPL License Terms @ref lgpl_license
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
-	SCALE1,
-	SCALE2,
-} vos_scale_t;
+enum pwr_vos_scale {
+	PWR_SCALE1,
+	PWR_SCALE2,
+};
 
 BEGIN_DECLS
 
-void pwr_set_vos_scale(vos_scale_t scale);
+void pwr_set_vos_scale(enum pwr_vos_scale scale);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -546,15 +546,15 @@ extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
-	CLOCK_3V3_48MHZ,
-	CLOCK_3V3_84MHZ,
-	CLOCK_3V3_120MHZ,
-	CLOCK_3V3_168MHZ,
-	CLOCK_3V3_END
-} clock_3v3_t;
+enum rcc_clock_3v3 {
+	RCC_CLOCK_3V3_48MHZ,
+	RCC_CLOCK_3V3_84MHZ,
+	RCC_CLOCK_3V3_120MHZ,
+	RCC_CLOCK_3V3_168MHZ,
+	RCC_CLOCK_3V3_END
+};
 
-typedef struct {
+struct rcc_clock_scale {
 	uint8_t pllm;
 	uint16_t plln;
 	uint8_t pllp;
@@ -566,15 +566,19 @@ typedef struct {
 	uint8_t power_save;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
-} clock_scale_t;
+};
 
-extern const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END];
-extern const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END];
-extern const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END];
-extern const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END];
 
 enum rcc_osc {
-	PLL, HSE, HSI, LSE, LSI
+	RCC_PLL,
+	RCC_HSE,
+	RCC_HSI,
+	RCC_LSE,
+	RCC_LSI
 };
 
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))
@@ -854,7 +858,7 @@ void rcc_set_main_pll_hsi(uint32_t pllm, uint32_t plln, uint32_t pllp,
 void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq);
 uint32_t rcc_system_clock_source(void);
-void rcc_clock_setup_hse_3v3(const clock_scale_t *clock);
+void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -478,7 +478,7 @@ extern uint32_t rcc_apb2_frequency;
 /* --- Function prototypes ------------------------------------------------- */
 
 enum rcc_osc {
-	PLL, HSE, HSI48, HSI16, MSI, LSE, LSI
+	RCC_PLL, RCC_HSE, RCC_HSI48, RCC_HSI16, RCC_MSI, RCC_LSE, RCC_LSI
 };
 
 

--- a/include/libopencm3/stm32/l1/rcc.h
+++ b/include/libopencm3/stm32/l1/rcc.h
@@ -388,7 +388,7 @@
 #define RCC_CSR_LSIRDY				(1 << 1)
 #define RCC_CSR_LSION				(1 << 0)
 
-typedef struct {
+struct rcc_clock_scale {
 	uint8_t pll_mul;
 	uint16_t pll_div;
 	uint8_t pll_source;
@@ -396,23 +396,23 @@ typedef struct {
 	uint8_t hpre;
 	uint8_t ppre1;
 	uint8_t ppre2;
-	vos_scale_t voltage_scale;
+	enum pwr_vos_scale voltage_scale;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
 	uint8_t msi_range;
-} clock_scale_t;
+};
 
-typedef enum {
-	CLOCK_VRANGE1_HSI_PLL_24MHZ,
-	CLOCK_VRANGE1_HSI_PLL_32MHZ,
-	CLOCK_VRANGE1_HSI_RAW_16MHZ,
-	CLOCK_VRANGE1_HSI_RAW_4MHZ,
-	CLOCK_VRANGE1_MSI_RAW_4MHZ,
-	CLOCK_VRANGE1_MSI_RAW_2MHZ,
-	CLOCK_CONFIG_END
-} clock_config_entry_t;
+enum rcc_clock_config_entry {
+	RCC_CLOCK_VRANGE1_HSI_PLL_24MHZ,
+	RCC_CLOCK_VRANGE1_HSI_PLL_32MHZ,
+	RCC_CLOCK_VRANGE1_HSI_RAW_16MHZ,
+	RCC_CLOCK_VRANGE1_HSI_RAW_4MHZ,
+	RCC_CLOCK_VRANGE1_MSI_RAW_4MHZ,
+	RCC_CLOCK_VRANGE1_MSI_RAW_2MHZ,
+	RCC_CLOCK_CONFIG_END
+};
 
-extern const clock_scale_t clock_config[CLOCK_CONFIG_END];
+extern const struct rcc_clock_scale rcc_clock_config[RCC_CLOCK_CONFIG_END];
 
 
 /* --- Variable definitions ------------------------------------------------ */
@@ -422,9 +422,9 @@ extern uint32_t rcc_apb2_frequency;
 
 /* --- Function prototypes ------------------------------------------------- */
 
-typedef enum {
-	PLL, HSE, HSI, MSI, LSE, LSI
-} osc_t;
+enum rcc_osc {
+	RCC_PLL, RCC_HSE, RCC_HSI, RCC_MSI, RCC_LSE, RCC_LSI
+};
 
 #define _REG_BIT(base, bit)		(((base) << 5) + (bit))
 
@@ -580,20 +580,20 @@ enum rcc_periph_rst {
 
 BEGIN_DECLS
 
-void rcc_osc_ready_int_clear(osc_t osc);
-void rcc_osc_ready_int_enable(osc_t osc);
-void rcc_osc_ready_int_disable(osc_t osc);
-int rcc_osc_ready_int_flag(osc_t osc);
+void rcc_osc_ready_int_clear(enum rcc_osc osc);
+void rcc_osc_ready_int_enable(enum rcc_osc osc);
+void rcc_osc_ready_int_disable(enum rcc_osc osc);
+int rcc_osc_ready_int_flag(enum rcc_osc osc);
 void rcc_css_int_clear(void);
 int rcc_css_int_flag(void);
-void rcc_wait_for_osc_ready(osc_t osc);
-void rcc_wait_for_sysclk_status(osc_t osc);
-void rcc_osc_on(osc_t osc);
-void rcc_osc_off(osc_t osc);
+void rcc_wait_for_osc_ready(enum rcc_osc osc);
+void rcc_wait_for_sysclk_status(enum rcc_osc osc);
+void rcc_osc_on(enum rcc_osc osc);
+void rcc_osc_off(enum rcc_osc osc);
 void rcc_css_enable(void);
 void rcc_css_disable(void);
-void rcc_osc_bypass_enable(osc_t osc);
-void rcc_osc_bypass_disable(osc_t osc);
+void rcc_osc_bypass_enable(enum rcc_osc osc);
+void rcc_osc_bypass_disable(enum rcc_osc osc);
 void rcc_set_sysclk_source(uint32_t clk);
 void rcc_set_pll_configuration(uint32_t source, uint32_t multiplier,
 			       uint32_t divisor);
@@ -606,9 +606,9 @@ void rcc_set_usbpre(uint32_t usbpre);
 void rcc_set_rtcpre(uint32_t rtcpre);
 uint32_t rcc_system_clock_source(void);
 void rcc_rtc_select_clock(uint32_t clock);
-void rcc_clock_setup_msi(const clock_scale_t *clock);
-void rcc_clock_setup_hsi(const clock_scale_t *clock);
-void rcc_clock_setup_pll(const clock_scale_t *clock);
+void rcc_clock_setup_msi(const struct rcc_clock_scale *clock);
+void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock);
+void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
 void rcc_backupdomain_reset(void);
 
 END_DECLS

--- a/lib/stm32/common/pwr_common_l01.c
+++ b/lib/stm32/common/pwr_common_l01.c
@@ -24,19 +24,19 @@
 #include <libopencm3/stm32/pwr.h>
 #include <libopencm3/stm32/rcc.h>
 
-void pwr_set_vos_scale(vos_scale_t scale)
+void pwr_set_vos_scale(enum pwr_vos_scale scale)
 {
 	/* You are not allowed to write zeros here, don't try and optimize! */
 	uint32_t reg = PWR_CR;
 	reg &= ~(PWR_CR_VOS_MASK);
 	switch (scale) {
-	case RANGE1:
+	case PWR_SCALE1:
 		reg |= PWR_CR_VOS_RANGE1;
 		break;
-	case RANGE2:
+	case PWR_SCALE2:
 		reg |= PWR_CR_VOS_RANGE2;
 		break;
-	case RANGE3:
+	case PWR_SCALE3:
 		reg |= PWR_CR_VOS_RANGE3;
 		break;
 	}

--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -56,25 +56,25 @@ uint32_t rcc_apb1_frequency = 8000000; /* 8MHz after reset */
 void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CIR |= RCC_CIR_HSI48RDYC;
 		break;
-	case HSI14:
+	case RCC_HSI14:
 		RCC_CIR |= RCC_CIR_HSI14RDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYC;
 		break;
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYC;
 		break;
 	}
@@ -89,25 +89,25 @@ void rcc_osc_ready_int_clear(enum rcc_osc osc)
 void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CIR |= RCC_CIR_HSI48RDYIE;
 		break;
-	case HSI14:
+	case RCC_HSI14:
 		RCC_CIR |= RCC_CIR_HSI14RDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYIE;
 		break;
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -122,25 +122,25 @@ void rcc_osc_ready_int_enable(enum rcc_osc osc)
 void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CIR &= ~RCC_CIR_HSI48RDYC;
 		break;
-	case HSI14:
+	case RCC_HSI14:
 		RCC_CIR &= ~RCC_CIR_HSI14RDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR &= ~RCC_CIR_HSIRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR &= ~RCC_CIR_HSERDYC;
 		break;
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR &= ~RCC_CIR_PLLRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR &= ~RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR &= ~RCC_CIR_LSIRDYC;
 		break;
 	}
@@ -156,25 +156,25 @@ void rcc_osc_ready_int_disable(enum rcc_osc osc)
 int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSI48:
+	case RCC_HSI48:
 		return (RCC_CIR & RCC_CIR_HSI48RDYF) != 0;
 		break;
-	case HSI14:
+	case RCC_HSI14:
 		return (RCC_CIR & RCC_CIR_HSI14RDYF) != 0;
 		break;
-	case HSI:
+	case RCC_HSI:
 		return (RCC_CIR & RCC_CIR_HSIRDYF) != 0;
 		break;
-	case HSE:
+	case RCC_HSE:
 		return (RCC_CIR & RCC_CIR_HSERDYF) != 0;
 		break;
-	case PLL:
+	case RCC_PLL:
 		return (RCC_CIR & RCC_CIR_PLLRDYF) != 0;
 		break;
-	case LSE:
+	case RCC_LSE:
 		return (RCC_CIR & RCC_CIR_LSERDYF) != 0;
 		break;
-	case LSI:
+	case RCC_LSI:
 		return (RCC_CIR & RCC_CIR_LSIRDYF) != 0;
 		break;
 	}
@@ -211,25 +211,25 @@ int rcc_css_int_flag(void)
 void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSI48:
+	case RCC_HSI48:
 		while ((RCC_CR2 & RCC_CR2_HSI48RDY) == 0);
 		break;
-	case HSI14:
+	case RCC_HSI14:
 		while ((RCC_CR2 & RCC_CR2_HSI14RDY) == 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_BDCR & RCC_BDCR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
@@ -250,25 +250,25 @@ void rcc_wait_for_osc_ready(enum rcc_osc osc)
 void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CR2 |= RCC_CR2_HSI48ON;
 		break;
-	case HSI14:
+	case RCC_HSI14:
 		RCC_CR2 |= RCC_CR2_HSI14ON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR |= RCC_CR_HSION;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
 	}
@@ -288,25 +288,25 @@ void rcc_osc_on(enum rcc_osc osc)
 void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CR2 &= ~RCC_CR2_HSI48ON;
 		break;
-	case HSI14:
+	case RCC_HSI14:
 		RCC_CR2 &= ~RCC_CR2_HSI14ON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR &= ~RCC_CR_HSION;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
-	case PLL:
+	case RCC_PLL:
 		/* don't do anything */
 		break;
 	}
@@ -344,17 +344,17 @@ void rcc_css_disable(void)
 void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEBYP;
 		break;
-	case HSI48:
-	case HSI14:
-	case HSI:
-	case LSI:
-	case PLL:
+	case RCC_HSI48:
+	case RCC_HSI14:
+	case RCC_HSI:
+	case RCC_LSI:
+	case RCC_PLL:
 		/* Do nothing */
 		break;
 	}
@@ -374,17 +374,17 @@ void rcc_osc_bypass_enable(enum rcc_osc osc)
 void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEBYP;
 		break;
-	case HSI48:
-	case HSI14:
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_HSI48:
+	case RCC_HSI14:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing */
 		break;
 	}
@@ -400,21 +400,21 @@ void rcc_osc_bypass_disable(enum rcc_osc osc)
 void rcc_set_sysclk_source(enum rcc_osc clk)
 {
 	switch (clk) {
-	case HSI:
+	case RCC_HSI:
 		RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_SW) | RCC_CFGR_SW_HSI;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_SW) | RCC_CFGR_SW_HSE;
 		break;
-	case PLL:
+	case RCC_PLL:
 		RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_SW) | RCC_CFGR_SW_PLL;
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_SW) | RCC_CFGR_SW_HSI48;
 		break;
-	case LSI:
-	case LSE:
-	case HSI14:
+	case RCC_LSI:
+	case RCC_LSE:
+	case RCC_HSI14:
 		/* do nothing */
 		break;
 	}
@@ -429,17 +429,17 @@ void rcc_set_sysclk_source(enum rcc_osc clk)
 void rcc_set_usbclk_source(enum rcc_osc clk)
 {
 	switch (clk) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CFGR3 |= RCC_CFGR3_USBSW;
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CFGR3 &= ~RCC_CFGR3_USBSW;
 		break;
-	case HSI:
-	case HSE:
-	case LSI:
-	case LSE:
-	case HSI14:
+	case RCC_HSI:
+	case RCC_HSE:
+	case RCC_LSI:
+	case RCC_LSE:
+	case RCC_HSI14:
 		/* do nothing */
 		break;
 	}
@@ -506,13 +506,13 @@ enum rcc_osc rcc_system_clock_source(void)
 	/* Return the clock source which is used as system clock. */
 	switch (RCC_CFGR & RCC_CFGR_SWS) {
 	case RCC_CFGR_SWS_HSI:
-		return HSI;
+		return RCC_HSI;
 	case RCC_CFGR_SWS_HSE:
-		return HSE;
+		return RCC_HSE;
 	case RCC_CFGR_SWS_PLL:
-		return PLL;
+		return RCC_PLL;
 	case RCC_CFGR_SWS_HSI48:
-		return HSI48;
+		return RCC_HSI48;
 	}
 
 	cm3_assert_not_reached();
@@ -526,14 +526,14 @@ enum rcc_osc rcc_system_clock_source(void)
  
 enum rcc_osc rcc_usb_clock_source(void)
 {
-	return (RCC_CFGR3 & RCC_CFGR3_USBSW) ? PLL : HSI48;
+	return (RCC_CFGR3 & RCC_CFGR3_USBSW) ? RCC_PLL : RCC_HSI48;
 }
 
 void rcc_clock_setup_in_hsi_out_8mhz(void)
 {
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
-	rcc_set_sysclk_source(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+	rcc_set_sysclk_source(RCC_HSI);
 
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
@@ -546,9 +546,9 @@ void rcc_clock_setup_in_hsi_out_8mhz(void)
 
 void rcc_clock_setup_in_hsi_out_16mhz(void)
 {
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
-	rcc_set_sysclk_source(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+	rcc_set_sysclk_source(RCC_HSI);
 
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
@@ -560,9 +560,9 @@ void rcc_clock_setup_in_hsi_out_16mhz(void)
 
 	RCC_CFGR &= ~RCC_CFGR_PLLSRC;
 
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
-	rcc_set_sysclk_source(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
+	rcc_set_sysclk_source(RCC_PLL);
 
 	rcc_apb1_frequency = 16000000;
 	rcc_ahb_frequency = 16000000;
@@ -571,9 +571,9 @@ void rcc_clock_setup_in_hsi_out_16mhz(void)
 
 void rcc_clock_setup_in_hsi_out_24mhz(void)
 {
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
-	rcc_set_sysclk_source(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+	rcc_set_sysclk_source(RCC_HSI);
 
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
@@ -585,9 +585,9 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 
 	RCC_CFGR &= ~RCC_CFGR_PLLSRC;
 
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
-	rcc_set_sysclk_source(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
+	rcc_set_sysclk_source(RCC_PLL);
 
 	rcc_apb1_frequency = 24000000;
 	rcc_ahb_frequency = 24000000;
@@ -595,9 +595,9 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 
 void rcc_clock_setup_in_hsi_out_32mhz(void)
 {
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
-	rcc_set_sysclk_source(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+	rcc_set_sysclk_source(RCC_HSI);
 
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
@@ -609,9 +609,9 @@ void rcc_clock_setup_in_hsi_out_32mhz(void)
 
 	RCC_CFGR &= ~RCC_CFGR_PLLSRC;
 
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
-	rcc_set_sysclk_source(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
+	rcc_set_sysclk_source(RCC_PLL);
 
 	rcc_apb1_frequency = 32000000;
 	rcc_ahb_frequency = 32000000;
@@ -619,9 +619,9 @@ void rcc_clock_setup_in_hsi_out_32mhz(void)
 
 void rcc_clock_setup_in_hsi_out_40mhz(void)
 {
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
-	rcc_set_sysclk_source(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+	rcc_set_sysclk_source(RCC_HSI);
 
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
@@ -633,9 +633,9 @@ void rcc_clock_setup_in_hsi_out_40mhz(void)
 
 	RCC_CFGR &= ~RCC_CFGR_PLLSRC;
 
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
-	rcc_set_sysclk_source(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
+	rcc_set_sysclk_source(RCC_PLL);
 
 	rcc_apb1_frequency = 40000000;
 	rcc_ahb_frequency = 40000000;
@@ -643,9 +643,9 @@ void rcc_clock_setup_in_hsi_out_40mhz(void)
 
 void rcc_clock_setup_in_hsi_out_48mhz(void)
 {
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
-	rcc_set_sysclk_source(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+	rcc_set_sysclk_source(RCC_HSI);
 
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
@@ -657,9 +657,9 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 
 	RCC_CFGR &= ~RCC_CFGR_PLLSRC;
 
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
-	rcc_set_sysclk_source(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
+	rcc_set_sysclk_source(RCC_PLL);
 
 	rcc_apb1_frequency = 48000000;
 	rcc_ahb_frequency = 48000000;
@@ -667,15 +667,15 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 
 void rcc_clock_setup_in_hsi48_out_48mhz(void)
 {
-	rcc_osc_on(HSI48);
-	rcc_wait_for_osc_ready(HSI48);
+	rcc_osc_on(RCC_HSI48);
+	rcc_wait_for_osc_ready(RCC_HSI48);
 	
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
 	
 	flash_set_ws(FLASH_ACR_LATENCY_024_048MHZ);
 
-	rcc_set_sysclk_source(HSI48);
+	rcc_set_sysclk_source(RCC_HSI48);
 
 	rcc_apb1_frequency = 48000000;
 	rcc_ahb_frequency = 48000000;

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -70,25 +70,25 @@ use.
 void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYC;
 		break;
-	case PLL2:
+	case RCC_PLL2:
 		RCC_CIR |= RCC_CIR_PLL2RDYC;
 		break;
-	case PLL3:
+	case RCC_PLL3:
 		RCC_CIR |= RCC_CIR_PLL3RDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYC;
 		break;
 	}
@@ -103,25 +103,25 @@ void rcc_osc_ready_int_clear(enum rcc_osc osc)
 void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYIE;
 		break;
-	case PLL2:
+	case RCC_PLL2:
 		RCC_CIR |= RCC_CIR_PLL2RDYIE;
 		break;
-	case PLL3:
+	case RCC_PLL3:
 		RCC_CIR |= RCC_CIR_PLL3RDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -136,25 +136,25 @@ void rcc_osc_ready_int_enable(enum rcc_osc osc)
 void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR &= ~RCC_CIR_PLLRDYIE;
 		break;
-	case PLL2:
+	case RCC_PLL2:
 		RCC_CIR &= ~RCC_CIR_PLL2RDYIE;
 		break;
-	case PLL3:
+	case RCC_PLL3:
 		RCC_CIR &= ~RCC_CIR_PLL3RDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR &= ~RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR &= ~RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR &= ~RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR &= ~RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -170,25 +170,25 @@ void rcc_osc_ready_int_disable(enum rcc_osc osc)
 int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		return ((RCC_CIR & RCC_CIR_PLLRDYF) != 0);
 		break;
-	case PLL2:
+	case RCC_PLL2:
 		return ((RCC_CIR & RCC_CIR_PLL2RDYF) != 0);
 		break;
-	case PLL3:
+	case RCC_PLL3:
 		return ((RCC_CIR & RCC_CIR_PLL3RDYF) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		return ((RCC_CIR & RCC_CIR_HSERDYF) != 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		return ((RCC_CIR & RCC_CIR_HSIRDYF) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		return ((RCC_CIR & RCC_CIR_LSERDYF) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		return ((RCC_CIR & RCC_CIR_LSIRDYF) != 0);
 		break;
 	}
@@ -226,25 +226,25 @@ int rcc_css_int_flag(void)
 void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case PLL2:
+	case RCC_PLL2:
 		while ((RCC_CR & RCC_CR_PLL2RDY) == 0);
 		break;
-	case PLL3:
+	case RCC_PLL3:
 		while ((RCC_CR & RCC_CR_PLL3RDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_BDCR & RCC_BDCR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
@@ -268,25 +268,25 @@ pwr_disable_backup_domain_write_protect).
 void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
-	case PLL2:
+	case RCC_PLL2:
 		RCC_CR |= RCC_CR_PLL2ON;
 		break;
-	case PLL3:
+	case RCC_PLL3:
 		RCC_CR |= RCC_CR_PLL3ON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR |= RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
 	}
@@ -309,25 +309,25 @@ backup domain write protection has been removed (see
 void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR &= ~RCC_CR_PLLON;
 		break;
-	case PLL2:
+	case RCC_PLL2:
 		RCC_CR &= ~RCC_CR_PLL2ON;
 		break;
-	case PLL3:
+	case RCC_PLL3:
 		RCC_CR &= ~RCC_CR_PLL3ON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR &= ~RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
 	}
@@ -370,17 +370,17 @@ pwr_disable_backup_domain_write_protect).
 void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case PLL2:
-	case PLL3:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_PLL2:
+	case RCC_PLL3:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -403,17 +403,17 @@ pwr_disable_backup_domain_write_protect) or the backup domain has been reset
 void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case PLL2:
-	case PLL3:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_PLL2:
+	case RCC_PLL3:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -533,7 +533,7 @@ void rcc_set_rtc_clock_source(enum rcc_osc clock_source)
 	uint32_t reg32;
 
 	switch (clock_source) {
-	case LSE:
+	case RCC_LSE:
 		/* Turn the LSE on and wait while it stabilises. */
 		RCC_BDCR |= RCC_BDCR_LSEON;
 		while ((reg32 = (RCC_BDCR & RCC_BDCR_LSERDY)) == 0);
@@ -542,7 +542,7 @@ void rcc_set_rtc_clock_source(enum rcc_osc clock_source)
 		RCC_BDCR &= ~((1 << 8) | (1 << 9));
 		RCC_BDCR |= (1 << 8);
 		break;
-	case LSI:
+	case RCC_LSI:
 		/* Turn the LSI on and wait while it stabilises. */
 		RCC_CSR |= RCC_CSR_LSION;
 		while ((reg32 = (RCC_CSR & RCC_CSR_LSIRDY)) == 0);
@@ -551,7 +551,7 @@ void rcc_set_rtc_clock_source(enum rcc_osc clock_source)
 		RCC_BDCR &= ~((1 << 8) | (1 << 9));
 		RCC_BDCR |= (1 << 9);
 		break;
-	case HSE:
+	case RCC_HSE:
 		/* Turn the HSE on and wait while it stabilises. */
 		RCC_CR |= RCC_CR_HSEON;
 		while ((reg32 = (RCC_CR & RCC_CR_HSERDY)) == 0);
@@ -560,10 +560,10 @@ void rcc_set_rtc_clock_source(enum rcc_osc clock_source)
 		RCC_BDCR &= ~((1 << 8) | (1 << 9));
 		RCC_BDCR |= (1 << 9) | (1 << 8);
 		break;
-	case PLL:
-	case PLL2:
-	case PLL3:
-	case HSI:
+	case RCC_PLL:
+	case RCC_PLL2:
+	case RCC_PLL3:
+	case RCC_HSI:
 		/* Unusable clock source, here to prevent warnings. */
 		/* Turn off clock sources to RTC. */
 		RCC_BDCR &= ~((1 << 8) | (1 << 9));
@@ -692,8 +692,8 @@ uint32_t rcc_system_clock_source(void)
 void rcc_clock_setup_in_hsi_out_64mhz(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
@@ -725,8 +725,8 @@ void rcc_clock_setup_in_hsi_out_64mhz(void)
 	rcc_set_pll_source(RCC_CFGR_PLLSRC_HSI_CLK_DIV2);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
@@ -745,8 +745,8 @@ void rcc_clock_setup_in_hsi_out_64mhz(void)
 void rcc_clock_setup_in_hsi_out_48mhz(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
@@ -779,8 +779,8 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 	rcc_set_pll_source(RCC_CFGR_PLLSRC_HSI_CLK_DIV2);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
@@ -799,8 +799,8 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 void rcc_clock_setup_in_hsi_out_24mhz(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
@@ -832,8 +832,8 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 	rcc_set_pll_source(RCC_CFGR_PLLSRC_HSI_CLK_DIV2);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
@@ -852,15 +852,15 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 void rcc_clock_setup_in_hse_8mhz_out_24mhz(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
 
 	/* Enable external high-speed oscillator 8MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
@@ -896,8 +896,8 @@ void rcc_clock_setup_in_hse_8mhz_out_24mhz(void)
 	rcc_set_pllxtpre(RCC_CFGR_PLLXTPRE_HSE_CLK);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
@@ -916,15 +916,15 @@ void rcc_clock_setup_in_hse_8mhz_out_24mhz(void)
 void rcc_clock_setup_in_hse_8mhz_out_72mhz(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
 
 	/* Enable external high-speed oscillator 8MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
@@ -960,8 +960,8 @@ void rcc_clock_setup_in_hse_8mhz_out_72mhz(void)
 	rcc_set_pllxtpre(RCC_CFGR_PLLXTPRE_HSE_CLK);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
@@ -980,15 +980,15 @@ void rcc_clock_setup_in_hse_8mhz_out_72mhz(void)
 void rcc_clock_setup_in_hse_12mhz_out_72mhz(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
 
 	/* Enable external high-speed oscillator 16MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
@@ -1024,8 +1024,8 @@ void rcc_clock_setup_in_hse_12mhz_out_72mhz(void)
 	rcc_set_pllxtpre(RCC_CFGR_PLLXTPRE_HSE_CLK);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
@@ -1044,15 +1044,15 @@ void rcc_clock_setup_in_hse_12mhz_out_72mhz(void)
 void rcc_clock_setup_in_hse_16mhz_out_72mhz(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
 
 	/* Enable external high-speed oscillator 16MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
@@ -1088,8 +1088,8 @@ void rcc_clock_setup_in_hse_16mhz_out_72mhz(void)
 	rcc_set_pllxtpre(RCC_CFGR_PLLXTPRE_HSE_CLK_DIV2);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
@@ -1108,8 +1108,8 @@ void rcc_clock_setup_in_hse_16mhz_out_72mhz(void)
 void rcc_clock_setup_in_hse_25mhz_out_72mhz(void)
 {
 	/* Enable external high-speed oscillator 25MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
@@ -1134,8 +1134,8 @@ void rcc_clock_setup_in_hse_25mhz_out_72mhz(void)
 	rcc_set_pll2_multiplication_factor(RCC_CFGR2_PLL2MUL_PLL2_CLK_MUL8);
 
 	/* Enable PLL2 oscillator and wait for it to stabilize */
-	rcc_osc_on(PLL2);
-	rcc_wait_for_osc_ready(PLL2);
+	rcc_osc_on(RCC_PLL2);
+	rcc_wait_for_osc_ready(RCC_PLL2);
 
 	/* Set pll1 prediv/multiplier, prediv1 src, and usb predivider */
 	rcc_set_pllxtpre(RCC_CFGR_PLLXTPRE_HSE_CLK);
@@ -1146,8 +1146,8 @@ void rcc_clock_setup_in_hse_25mhz_out_72mhz(void)
 	rcc_set_usbpre(RCC_CFGR_USBPRE_PLL_VCO_CLK_DIV3);
 
 	/* enable PLL1 and wait for it to stabilize */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);

--- a/lib/stm32/f2/rcc.c
+++ b/lib/stm32/f2/rcc.c
@@ -48,7 +48,7 @@ uint32_t rcc_ahb_frequency = 16000000;
 uint32_t rcc_apb1_frequency = 16000000;
 uint32_t rcc_apb2_frequency = 16000000;
 
-const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 120MHz */
 		.pllm = 8,
 		.plln = 240,
@@ -67,19 +67,19 @@ const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
 void rcc_osc_ready_int_clear(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYC;
 		break;
 	}
@@ -88,19 +88,19 @@ void rcc_osc_ready_int_clear(osc_t osc)
 void rcc_osc_ready_int_enable(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -109,19 +109,19 @@ void rcc_osc_ready_int_enable(osc_t osc)
 void rcc_osc_ready_int_disable(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR &= ~RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR &= ~RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR &= ~RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR &= ~RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR &= ~RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -130,19 +130,19 @@ void rcc_osc_ready_int_disable(osc_t osc)
 int rcc_osc_ready_int_flag(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		return ((RCC_CIR & RCC_CIR_PLLRDYF) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		return ((RCC_CIR & RCC_CIR_HSERDYF) != 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		return ((RCC_CIR & RCC_CIR_HSIRDYF) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		return ((RCC_CIR & RCC_CIR_LSERDYF) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		return ((RCC_CIR & RCC_CIR_LSIRDYF) != 0);
 		break;
 	}
@@ -163,19 +163,19 @@ int rcc_css_int_flag(void)
 void rcc_wait_for_osc_ready(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_BDCR & RCC_BDCR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
@@ -184,13 +184,13 @@ void rcc_wait_for_osc_ready(osc_t osc)
 void rcc_wait_for_sysclk_status(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_PLL);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSE);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSI);
 		break;
 	default:
@@ -202,19 +202,19 @@ void rcc_wait_for_sysclk_status(osc_t osc)
 void rcc_osc_on(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR |= RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
 	}
@@ -223,19 +223,19 @@ void rcc_osc_on(osc_t osc)
 void rcc_osc_off(osc_t osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR &= ~RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR &= ~RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
 	}
@@ -254,15 +254,15 @@ void rcc_css_disable(void)
 void rcc_osc_bypass_enable(osc_t osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -271,15 +271,15 @@ void rcc_osc_bypass_enable(osc_t osc)
 void rcc_osc_bypass_disable(osc_t osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -364,18 +364,18 @@ uint32_t rcc_system_clock_source(void)
 	return (RCC_CFGR & 0x000c) >> 2;
 }
 
-void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
+void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
 
 	/* Enable external high-speed oscillator 8MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 
 	/*
 	 * Set prescalers for AHB, ADC, ABP1, ABP2.
@@ -389,8 +389,8 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 			     clock->pllp, clock->pllq);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Configure flash settings. */
 	flash_set_ws(clock->flash_config);
@@ -399,7 +399,7 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 	rcc_set_sysclk_source(RCC_CFGR_SW_PLL);
 
 	/* Wait for PLL clock to be selected. */
-	rcc_wait_for_sysclk_status(PLL);
+	rcc_wait_for_sysclk_status(RCC_PLL);
 
 	/* Set the peripheral clock frequencies used. */
 	rcc_apb1_frequency = clock->apb1_frequency;

--- a/lib/stm32/f3/rcc.c
+++ b/lib/stm32/f3/rcc.c
@@ -44,7 +44,7 @@ uint32_t rcc_ahb_frequency = 8000000;
 uint32_t rcc_apb1_frequency = 8000000;
 uint32_t rcc_apb2_frequency = 8000000;
 
-const clock_scale_t hsi_8mhz[CLOCK_END] = {
+const struct rcc_clock_scale rcc_hsi_8mhz[RCC_CLOCK_END] = {
 	{ /* 44MHz */
 		.pll = RCC_CFGR_PLLMUL_PLL_IN_CLK_X11,
 		.pllsrc = RCC_CFGR_PLLSRC_HSI_DIV2,
@@ -77,85 +77,85 @@ const clock_scale_t hsi_8mhz[CLOCK_END] = {
 	}
 };
 
-void rcc_osc_ready_int_clear(enum osc osc)
+void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYC;
 		break;
 	}
 }
 
-void rcc_osc_ready_int_enable(enum osc osc)
+void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYIE;
 		break;
 	}
 }
 
-void rcc_osc_ready_int_disable(enum osc osc)
+void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR &= ~RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR &= ~RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR &= ~RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR &= ~RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR &= ~RCC_CIR_LSIRDYIE;
 		break;
 	}
 }
 
-int rcc_osc_ready_int_flag(enum osc osc)
+int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		return ((RCC_CIR & RCC_CIR_PLLRDYF) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		return ((RCC_CIR & RCC_CIR_HSERDYF) != 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		return ((RCC_CIR & RCC_CIR_HSIRDYF) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		return ((RCC_CIR & RCC_CIR_LSERDYF) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		return ((RCC_CIR & RCC_CIR_LSIRDYF) != 0);
 		break;
 	}
@@ -173,59 +173,59 @@ int rcc_css_int_flag(void)
 	return ((RCC_CIR & RCC_CIR_CSSF) != 0);
 }
 
-void rcc_wait_for_osc_ready(enum osc osc)
+void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_BDCR & RCC_BDCR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
 }
 
 
-void rcc_wait_for_osc_not_ready(enum osc osc)
+void rcc_wait_for_osc_not_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) != 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_BDCR & RCC_BDCR_LSERDY) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) != 0);
 		break;
 	}
 }
 
-void rcc_wait_for_sysclk_status(enum osc osc)
+void rcc_wait_for_sysclk_status(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_PLL);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSE);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSI);
 		break;
 	default:
@@ -234,43 +234,43 @@ void rcc_wait_for_sysclk_status(enum osc osc)
 	}
 }
 
-void rcc_osc_on(enum osc osc)
+void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR |= RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
 	}
 }
 
-void rcc_osc_off(enum osc osc)
+void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR &= ~RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR &= ~RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
 	}
@@ -286,35 +286,35 @@ void rcc_css_disable(void)
 	RCC_CR &= ~RCC_CR_CSSON;
 }
 
-void rcc_osc_bypass_enable(enum osc osc)
+void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
 }
 
-void rcc_osc_bypass_disable(enum osc osc)
+void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -393,22 +393,22 @@ uint32_t rcc_get_system_clock_source(void)
 }
 
 
-void rcc_clock_setup_hsi(const clock_scale_t *clock)
+void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_HSI); /* XXX: se cayo */
-	rcc_wait_for_sysclk_status(HSI);
+	rcc_wait_for_sysclk_status(RCC_HSI);
 
-	rcc_osc_off(PLL);
-	rcc_wait_for_osc_not_ready(PLL);
+	rcc_osc_off(RCC_PLL);
+	rcc_wait_for_osc_not_ready(RCC_PLL);
 	rcc_set_pll_source(clock->pllsrc);
 	rcc_set_pll_multiplier(clock->pll);
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 	/*
 	 * Set prescalers for AHB, ADC, ABP1, ABP2.
 	 * Do this before touching the PLL (TODO: why?).
@@ -421,7 +421,7 @@ void rcc_clock_setup_hsi(const clock_scale_t *clock)
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_PLL); /* XXX: se cayo */
 	/* Wait for PLL clock to be selected. */
-	rcc_wait_for_sysclk_status(PLL);
+	rcc_wait_for_sysclk_status(RCC_PLL);
 
 	/* Set the peripheral clock frequencies used. */
 	rcc_apb1_frequency = clock->apb1_frequency;

--- a/lib/stm32/f4/pwr.c
+++ b/lib/stm32/f4/pwr.c
@@ -36,11 +36,11 @@
 
 #include <libopencm3/stm32/pwr.h>
 
-void pwr_set_vos_scale(vos_scale_t scale)
+void pwr_set_vos_scale(enum pwr_vos_scale scale)
 {
-	if (scale == SCALE1) {
+	if (scale == PWR_SCALE1) {
 		PWR_CR |= PWR_CR_VOS;
-	} else if (scale == SCALE2) {
+	} else if (scale == PWR_SCALE2) {
 		PWR_CR &= PWR_CR_VOS;
 	}
 }

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -49,7 +49,7 @@ uint32_t rcc_ahb_frequency = 16000000;
 uint32_t rcc_apb1_frequency = 16000000;
 uint32_t rcc_apb2_frequency = 16000000;
 
-const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 8,
 		.plln = 96,
@@ -106,7 +106,7 @@ const clock_scale_t hse_8mhz_3v3[CLOCK_3V3_END] = {
 	},
 };
 
-const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 12,
 		.plln = 96,
@@ -163,7 +163,7 @@ const clock_scale_t hse_12mhz_3v3[CLOCK_3V3_END] = {
 	},
 };
 
-const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 16,
 		.plln = 96,
@@ -220,7 +220,7 @@ const clock_scale_t hse_16mhz_3v3[CLOCK_3V3_END] = {
 	},
 };
 
-const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END] = {
+const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 48MHz */
 		.pllm = 25,
 		.plln = 96,
@@ -280,19 +280,19 @@ const clock_scale_t hse_25mhz_3v3[CLOCK_3V3_END] = {
 void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYC;
 		break;
 	}
@@ -301,19 +301,19 @@ void rcc_osc_ready_int_clear(enum rcc_osc osc)
 void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -322,19 +322,19 @@ void rcc_osc_ready_int_enable(enum rcc_osc osc)
 void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR &= ~RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR &= ~RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR &= ~RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR &= ~RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR &= ~RCC_CIR_LSIRDYIE;
 		break;
 	}
@@ -343,19 +343,19 @@ void rcc_osc_ready_int_disable(enum rcc_osc osc)
 int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		return ((RCC_CIR & RCC_CIR_PLLRDYF) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		return ((RCC_CIR & RCC_CIR_HSERDYF) != 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		return ((RCC_CIR & RCC_CIR_HSIRDYF) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		return ((RCC_CIR & RCC_CIR_LSERDYF) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		return ((RCC_CIR & RCC_CIR_LSIRDYF) != 0);
 		break;
 	}
@@ -376,19 +376,19 @@ int rcc_css_int_flag(void)
 void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_BDCR & RCC_BDCR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
@@ -397,13 +397,13 @@ void rcc_wait_for_osc_ready(enum rcc_osc osc)
 void rcc_wait_for_sysclk_status(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_PLL);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSE);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) != RCC_CFGR_SWS_HSI);
 		break;
 	default:
@@ -415,19 +415,19 @@ void rcc_wait_for_sysclk_status(enum rcc_osc osc)
 void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR |= RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
 	}
@@ -436,19 +436,19 @@ void rcc_osc_on(enum rcc_osc osc)
 void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR &= ~RCC_CR_PLLON;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR &= ~RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
 	}
@@ -467,15 +467,15 @@ void rcc_css_disable(void)
 void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR |= RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -484,21 +484,19 @@ void rcc_osc_bypass_enable(enum rcc_osc osc)
 void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_BDCR &= ~RCC_BDCR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
 }
-
-
 
 void rcc_set_sysclk_source(uint32_t clk)
 {
@@ -579,24 +577,24 @@ uint32_t rcc_system_clock_source(void)
 	return (RCC_CFGR & 0x000c) >> 2;
 }
 
-void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
+void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
 
 	/* Enable external high-speed oscillator 8MHz. */
-	rcc_osc_on(HSE);
-	rcc_wait_for_osc_ready(HSE);
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
 
 	/* Enable/disable high performance mode */
 	if (!clock->power_save) {
-		pwr_set_vos_scale(SCALE1);
+		pwr_set_vos_scale(PWR_SCALE1);
 	} else {
-		pwr_set_vos_scale(SCALE2);
+		pwr_set_vos_scale(PWR_SCALE2);
 	}
 
 	/*
@@ -611,8 +609,8 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 			clock->pllp, clock->pllq);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Configure flash settings. */
 	flash_set_ws(clock->flash_config);
@@ -621,16 +619,14 @@ void rcc_clock_setup_hse_3v3(const clock_scale_t *clock)
 	rcc_set_sysclk_source(RCC_CFGR_SW_PLL);
 
 	/* Wait for PLL clock to be selected. */
-	rcc_wait_for_sysclk_status(PLL);
+	rcc_wait_for_sysclk_status(RCC_PLL);
 
 	/* Set the peripheral clock frequencies used. */
 	rcc_apb1_frequency = clock->apb1_frequency;
 	rcc_apb2_frequency = clock->apb2_frequency;
 
 	/* Disable internal high-speed oscillator. */
-	rcc_osc_off(HSI);
+	rcc_osc_off(RCC_HSI);
 }
-
-
 
 /**@}*/

--- a/lib/stm32/l0/rcc.c
+++ b/lib/stm32/l0/rcc.c
@@ -40,25 +40,25 @@
 void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CR |= RCC_CR_MSION;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CRRCR |= RCC_CRRCR_HSI48ON;
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		RCC_CR |= RCC_CR_HSI16ON;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR |= RCC_CSR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
 	}
@@ -67,25 +67,25 @@ void rcc_osc_on(enum rcc_osc osc)
 void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR &= ~RCC_CR_PLLON;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CR &= ~RCC_CR_MSION;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CRRCR &= ~RCC_CRRCR_HSI48ON;
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		RCC_CR &= ~RCC_CR_HSI16ON;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR &= ~RCC_CSR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
 	}
@@ -95,10 +95,10 @@ void rcc_osc_off(enum rcc_osc osc)
 void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR |= RCC_CSR_LSEBYP;
 		break;
 	default:
@@ -111,10 +111,10 @@ void rcc_osc_bypass_enable(enum rcc_osc osc)
 void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR &= ~RCC_CSR_LSEBYP;
 		break;
 	default:
@@ -134,25 +134,25 @@ void rcc_osc_bypass_disable(enum rcc_osc osc)
 void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CICR |= RCC_CICR_PLLRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CICR |= RCC_CICR_HSERDYC;
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CICR |= RCC_CICR_HSI48RDYC;
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		RCC_CICR |= RCC_CICR_HSI16RDYC;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CICR |= RCC_CICR_MSIRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CICR |= RCC_CICR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CICR |= RCC_CICR_LSIRDYC;
 		break;
 	}
@@ -166,25 +166,25 @@ void rcc_osc_ready_int_clear(enum rcc_osc osc)
 void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIER |= RCC_CIER_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIER |= RCC_CIER_HSERDYIE;
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CIER |= RCC_CIER_HSI48RDYIE;
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		RCC_CIER |= RCC_CIER_HSI16RDYIE;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CIER |= RCC_CIER_MSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIER |= RCC_CIER_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIER |= RCC_CIER_LSIRDYIE;
 		break;
 	}
@@ -198,25 +198,25 @@ void rcc_osc_ready_int_enable(enum rcc_osc osc)
 void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIER &= ~RCC_CIER_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIER &= ~RCC_CIER_HSERDYIE;
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		RCC_CIER &= ~RCC_CIER_HSI48RDYIE;
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		RCC_CIER &= ~RCC_CIER_HSI16RDYIE;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CIER &= ~RCC_CIER_MSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIER &= ~RCC_CIER_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIER &= ~RCC_CIER_LSIRDYIE;
 		break;
 	}
@@ -231,25 +231,25 @@ void rcc_osc_ready_int_disable(enum rcc_osc osc)
 int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		return ((RCC_CIFR & RCC_CIFR_PLLRDYF) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		return ((RCC_CIFR & RCC_CIFR_HSERDYF) != 0);
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		return ((RCC_CIFR & RCC_CIFR_HSI48RDYF) != 0);
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		return ((RCC_CIFR & RCC_CIFR_HSI16RDYF) != 0);
 		break;
-	case MSI:
+	case RCC_MSI:
 		return ((RCC_CIFR & RCC_CIFR_MSIRDYF) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		return ((RCC_CIFR & RCC_CIFR_LSERDYF) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		return ((RCC_CIFR & RCC_CIFR_LSIRDYF) != 0);
 		break;
 	}
@@ -266,25 +266,25 @@ int rcc_osc_ready_int_flag(enum rcc_osc osc)
 void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		while ((RCC_CR & RCC_CR_HSI16RDY) == 0);
 		break;
-	case HSI48:
+	case RCC_HSI48:
 		while ((RCC_CRRCR & RCC_CRRCR_HSI48RDY) == 0);
 		break;
-	case MSI:
+	case RCC_MSI:
 		while ((RCC_CR & RCC_CR_MSIRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_CSR & RCC_CSR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
@@ -314,21 +314,21 @@ void rcc_set_hsi48_source_pll(void) {
 void rcc_set_sysclk_source(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CFGR |=  RCC_CFGR_SW_PLL;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_SW_MASK) | RCC_CFGR_SW_HSE;
 		break;
-	case HSI16:
+	case RCC_HSI16:
 		RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_SW_MASK) | RCC_CFGR_SW_HSI16;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_SW_MASK) | RCC_CFGR_SW_MSI;
 		break;
-	case HSI48:
-	case LSE:
-	case LSI:
+	case RCC_HSI48:
+	case RCC_LSE:
+	case RCC_LSI:
 		break;
 	}
 }

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -48,7 +48,7 @@ uint32_t rcc_ahb_frequency = 2097000;
 uint32_t rcc_apb1_frequency = 2097000;
 uint32_t rcc_apb2_frequency = 2097000;
 
-const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
+const struct rcc_clock_scale rcc_clock_config[RCC_CLOCK_CONFIG_END] = {
 	{ /* 24MHz PLL from HSI */
 		.pll_source = RCC_CFGR_PLLSRC_HSI_CLK,
 		.pll_mul = RCC_CFGR_PLLMUL_MUL3,
@@ -56,7 +56,7 @@ const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 		.hpre = RCC_CFGR_HPRE_SYSCLK_NODIV,
 		.ppre1 = RCC_CFGR_PPRE1_HCLK_NODIV,
 		.ppre2 = RCC_CFGR_PPRE2_HCLK_NODIV,
-		.voltage_scale = RANGE1,
+		.voltage_scale = PWR_SCALE1,
 		.flash_config = FLASH_ACR_LATENCY_1WS,
 		.apb1_frequency = 24000000,
 		.apb2_frequency = 24000000,
@@ -68,7 +68,7 @@ const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 		.hpre = RCC_CFGR_HPRE_SYSCLK_NODIV,
 		.ppre1 = RCC_CFGR_PPRE1_HCLK_NODIV,
 		.ppre2 = RCC_CFGR_PPRE2_HCLK_NODIV,
-		.voltage_scale = RANGE1,
+		.voltage_scale = PWR_SCALE1,
 		.flash_config = FLASH_ACR_LATENCY_1WS,
 		.apb1_frequency = 32000000,
 		.apb2_frequency = 32000000,
@@ -77,7 +77,7 @@ const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 		.hpre = RCC_CFGR_HPRE_SYSCLK_NODIV,
 		.ppre1 = RCC_CFGR_PPRE1_HCLK_NODIV,
 		.ppre2 = RCC_CFGR_PPRE2_HCLK_NODIV,
-		.voltage_scale = RANGE1,
+		.voltage_scale = PWR_SCALE1,
 		.flash_config = FLASH_ACR_LATENCY_0WS,
 		.apb1_frequency = 16000000,
 		.apb2_frequency = 16000000,
@@ -86,7 +86,7 @@ const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 		.hpre = RCC_CFGR_HPRE_SYSCLK_DIV4,
 		.ppre1 = RCC_CFGR_PPRE1_HCLK_NODIV,
 		.ppre2 = RCC_CFGR_PPRE2_HCLK_NODIV,
-		.voltage_scale = RANGE1,
+		.voltage_scale = PWR_SCALE1,
 		.flash_config = FLASH_ACR_LATENCY_0WS,
 		.apb1_frequency = 4000000,
 		.apb2_frequency = 4000000,
@@ -95,7 +95,7 @@ const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 		.hpre = RCC_CFGR_HPRE_SYSCLK_NODIV,
 		.ppre1 = RCC_CFGR_PPRE1_HCLK_NODIV,
 		.ppre2 = RCC_CFGR_PPRE2_HCLK_NODIV,
-		.voltage_scale = RANGE1,
+		.voltage_scale = PWR_SCALE1,
 		.flash_config = FLASH_ACR_LATENCY_0WS,
 		.apb1_frequency = 4194000,
 		.apb2_frequency = 4194000,
@@ -105,7 +105,7 @@ const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 		.hpre = RCC_CFGR_HPRE_SYSCLK_NODIV,
 		.ppre1 = RCC_CFGR_PPRE1_HCLK_NODIV,
 		.ppre2 = RCC_CFGR_PPRE2_HCLK_NODIV,
-		.voltage_scale = RANGE1,
+		.voltage_scale = PWR_SCALE1,
 		.flash_config = FLASH_ACR_LATENCY_0WS,
 		.apb1_frequency = 2097000,
 		.apb2_frequency = 2097000,
@@ -113,97 +113,97 @@ const clock_scale_t clock_config[CLOCK_CONFIG_END] = {
 	},
 };
 
-void rcc_osc_ready_int_clear(osc_t osc)
+void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYC;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYC;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYC;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYC;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYC;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CIR |= RCC_CIR_MSIRDYC;
 		break;
 	}
 }
 
-void rcc_osc_ready_int_enable(osc_t osc)
+void rcc_osc_ready_int_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR |= RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR |= RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR |= RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR |= RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR |= RCC_CIR_LSIRDYIE;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CIR |= RCC_CIR_MSIRDYIE;
 		break;
 	}
 }
 
-void rcc_osc_ready_int_disable(osc_t osc)
+void rcc_osc_ready_int_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CIR &= ~RCC_CIR_PLLRDYIE;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CIR &= ~RCC_CIR_HSERDYIE;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CIR &= ~RCC_CIR_HSIRDYIE;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CIR &= ~RCC_CIR_LSERDYIE;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CIR &= ~RCC_CIR_LSIRDYIE;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CIR &= ~RCC_CIR_MSIRDYIE;
 		break;
 	}
 }
 
-int rcc_osc_ready_int_flag(osc_t osc)
+int rcc_osc_ready_int_flag(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		return ((RCC_CIR & RCC_CIR_PLLRDYF) != 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		return ((RCC_CIR & RCC_CIR_HSERDYF) != 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		return ((RCC_CIR & RCC_CIR_HSIRDYF) != 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		return ((RCC_CIR & RCC_CIR_LSERDYF) != 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		return ((RCC_CIR & RCC_CIR_LSIRDYF) != 0);
 		break;
-	case MSI:
+	case RCC_MSI:
 		return ((RCC_CIR & RCC_CIR_MSIRDYF) != 0);
 		break;
 	}
@@ -222,46 +222,46 @@ int rcc_css_int_flag(void)
 	return ((RCC_CIR & RCC_CIR_CSSF) != 0);
 }
 
-void rcc_wait_for_osc_ready(osc_t osc)
+void rcc_wait_for_osc_ready(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CR & RCC_CR_PLLRDY) == 0);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CR & RCC_CR_HSERDY) == 0);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CR & RCC_CR_HSIRDY) == 0);
 		break;
-	case MSI:
+	case RCC_MSI:
 		while ((RCC_CR & RCC_CR_MSIRDY) == 0);
 		break;
-	case LSE:
+	case RCC_LSE:
 		while ((RCC_CSR & RCC_CSR_LSERDY) == 0);
 		break;
-	case LSI:
+	case RCC_LSI:
 		while ((RCC_CSR & RCC_CSR_LSIRDY) == 0);
 		break;
 	}
 }
 
-void rcc_wait_for_sysclk_status(osc_t osc)
+void rcc_wait_for_sysclk_status(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) !=
 				RCC_CFGR_SWS_SYSCLKSEL_PLLCLK);
 		break;
-	case HSE:
+	case RCC_HSE:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) !=
 				RCC_CFGR_SWS_SYSCLKSEL_HSECLK);
 		break;
-	case HSI:
+	case RCC_HSI:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) !=
 				RCC_CFGR_SWS_SYSCLKSEL_HSICLK);
 		break;
-	case MSI:
+	case RCC_MSI:
 		while ((RCC_CFGR & ((1 << 1) | (1 << 0))) !=
 				RCC_CFGR_SWS_SYSCLKSEL_MSICLK);
 		break;
@@ -271,49 +271,49 @@ void rcc_wait_for_sysclk_status(osc_t osc)
 	}
 }
 
-void rcc_osc_on(osc_t osc)
+void rcc_osc_on(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR |= RCC_CR_PLLON;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CR |= RCC_CR_MSION;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR |= RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR |= RCC_CSR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR |= RCC_CSR_LSION;
 		break;
 	}
 }
 
-void rcc_osc_off(osc_t osc)
+void rcc_osc_off(enum rcc_osc osc)
 {
 	switch (osc) {
-	case PLL:
+	case RCC_PLL:
 		RCC_CR &= ~RCC_CR_PLLON;
 		break;
-	case MSI:
+	case RCC_MSI:
 		RCC_CR &= ~RCC_CR_MSION;
 		break;
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEON;
 		break;
-	case HSI:
+	case RCC_HSI:
 		RCC_CR &= ~RCC_CR_HSION;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR &= ~RCC_CSR_LSEON;
 		break;
-	case LSI:
+	case RCC_LSI:
 		RCC_CSR &= ~RCC_CSR_LSION;
 		break;
 	}
@@ -329,37 +329,37 @@ void rcc_css_disable(void)
 	RCC_CR &= ~RCC_CR_CSSON;
 }
 
-void rcc_osc_bypass_enable(osc_t osc)
+void rcc_osc_bypass_enable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR |= RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR |= RCC_CSR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
-	case MSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
+	case RCC_MSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
 }
 
-void rcc_osc_bypass_disable(osc_t osc)
+void rcc_osc_bypass_disable(enum rcc_osc osc)
 {
 	switch (osc) {
-	case HSE:
+	case RCC_HSE:
 		RCC_CR &= ~RCC_CR_HSEBYP;
 		break;
-	case LSE:
+	case RCC_LSE:
 		RCC_CSR &= ~RCC_CSR_LSEBYP;
 		break;
-	case PLL:
-	case HSI:
-	case LSI:
-	case MSI:
+	case RCC_PLL:
+	case RCC_HSI:
+	case RCC_LSI:
+	case RCC_MSI:
 		/* Do nothing, only HSE/LSE allowed here. */
 		break;
 	}
@@ -446,7 +446,7 @@ void rcc_rtc_select_clock(uint32_t clock)
 	RCC_CSR |= (clock << RCC_CSR_RTCSEL_SHIFT);
 }
 
-void rcc_clock_setup_msi(const clock_scale_t *clock)
+void rcc_clock_setup_msi(const struct rcc_clock_scale *clock)
 {
 	/* Enable internal multi-speed oscillator. */
 
@@ -455,8 +455,8 @@ void rcc_clock_setup_msi(const clock_scale_t *clock)
 	reg |= (clock->msi_range << RCC_ICSCR_MSIRANGE_SHIFT);
 	RCC_ICSCR = reg;
 
-	rcc_osc_on(MSI);
-	rcc_wait_for_osc_ready(MSI);
+	rcc_osc_on(RCC_MSI);
+	rcc_wait_for_osc_ready(RCC_MSI);
 
 	/* Select MSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_MSICLK);
@@ -483,11 +483,11 @@ void rcc_clock_setup_msi(const clock_scale_t *clock)
 	rcc_apb2_frequency = clock->apb2_frequency;
 }
 
-void rcc_clock_setup_hsi(const clock_scale_t *clock)
+void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
@@ -514,15 +514,15 @@ void rcc_clock_setup_hsi(const clock_scale_t *clock)
 	rcc_apb2_frequency = clock->apb2_frequency;
 }
 
-void rcc_clock_setup_pll(const clock_scale_t *clock)
+void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 {
 	/* Turn on the appropriate source for the PLL */
 	if (clock->pll_source == RCC_CFGR_PLLSRC_HSE_CLK) {
-		rcc_osc_on(HSE);
-		rcc_wait_for_osc_ready(HSE);
+		rcc_osc_on(RCC_HSE);
+		rcc_wait_for_osc_ready(RCC_HSE);
 	} else {
-		rcc_osc_on(HSI);
-		rcc_wait_for_osc_ready(HSI);
+		rcc_osc_on(RCC_HSI);
+		rcc_wait_for_osc_ready(RCC_HSI);
 	}
 
 	/*
@@ -546,8 +546,8 @@ void rcc_clock_setup_pll(const clock_scale_t *clock)
 				  clock->pll_div);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
-	rcc_osc_on(PLL);
-	rcc_wait_for_osc_ready(PLL);
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);


### PR DESCRIPTION
The "stage 1" of @esden's overhaul of RCC naming. (See #410)  This all seems like a good idea, so I've finished it off for the rest of the stm32 series.

Yes, this is breaking for a lot of downstream users, but we're doing a lot of breakage right now already to get things more cleaned up, so now's a great time to get this in.  This got nothing but generally positive reviews months ago, so I'll probably run with this as the base for my adc v2 work, to give it some testing.