### PR TITLE
STM32 USART: Support for usart_rx_data_ready()

### DIFF
--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -128,6 +128,7 @@ void usart_enable_error_interrupt(uint32_t usart);
 void usart_disable_error_interrupt(uint32_t usart);
 bool usart_get_flag(uint32_t usart, uint32_t flag);
 bool usart_get_interrupt_source(uint32_t usart, uint32_t flag);
+bool usart_rx_data_ready(uint32_t usart);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f0/usart.h
+++ b/include/libopencm3/stm32/f0/usart.h
@@ -336,6 +336,7 @@ void usart_enable_error_interrupt(uint32_t usart);
 void usart_disable_error_interrupt(uint32_t usart);
 bool usart_get_flag(uint32_t usart, uint32_t flag);
 bool usart_get_interrupt_source(uint32_t usart, uint32_t flag);
+bool usart_rx_data_ready(uint32_t usart);
 
 END_DECLS
 

--- a/lib/stm32/common/usart_common_f124.c
+++ b/lib/stm32/common/usart_common_f124.c
@@ -81,6 +81,20 @@ void usart_wait_send_ready(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Poll for Received Data Available
+ *
+ * Returns true if receive data buffer holds a valid received data word.
+ *
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+ * usart_reg_base
+ * @returns bool, true if data buffer can be read, false otherwise.
+ */
+bool usart_rx_data_ready(uint32_t usart)
+{
+	return ((USART_SR(usart) & USART_SR_RXNE) != 0);
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Received Data Available
 
 Blocks until the receive data buffer holds a valid received data word.

--- a/lib/stm32/f0/usart.c
+++ b/lib/stm32/f0/usart.c
@@ -207,6 +207,20 @@ void usart_wait_send_ready(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Poll for Received Data Available
+ *
+ * Returns true if receive data buffer holds a valid received data word.
+ *
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+ * usart_reg_base
+ * @returns bool, true if data buffer can be read, false otherwise.
+ */
+bool usart_rx_data_ready(uint32_t usart)
+{
+	return ((USART_ISR(usart) & USART_ISR_RXNE) != 0);
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Received Data Available
  *
  * Blocks until the receive data buffer holds a valid received data word.

--- a/lib/stm32/f3/usart.c
+++ b/lib/stm32/f3/usart.c
@@ -78,6 +78,20 @@ void usart_wait_send_ready(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Poll for Received Data Available
+ *
+ * Returns true if receive data buffer holds a valid received data word.
+ *
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+ * usart_reg_base
+ * @returns bool, true if data buffer can be read, false otherwise.
+ */
+bool usart_rx_data_ready(uint32_t usart)
+{
+	return ((USART_ISR(usart) & USART_ISR_RXNE) != 0);
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Wait for Received Data Available
  *
  * Blocks until the receive data buffer holds a valid received data word.


### PR DESCRIPTION
In our opinion, uart/usart needs a mechanism to poll for new data in the RX buffer before issuing a read. 

In a OS context, the scheduler needs to kick in when the device does not have anything to read, until the next IRQ from the serial port, so the usart_wait_recv_ready() is not usable as it blocks on a tight loop instead.