### PR TITLE
Drop "install" target and documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,6 @@ PREFIX		?= arm-none-eabi
 STYLECHECK      := scripts/checkpatch.pl
 STYLECHECKFLAGS := --no-tree -f --terse --mailback
 
-DESTDIR		?= /usr/local
-
-INCDIR		:= $(DESTDIR)/$(PREFIX)/include
-LIBDIR		:= $(DESTDIR)/$(PREFIX)/lib
-SHAREDIR	:= $(DESTDIR)/$(PREFIX)/share/libopencm3/scripts
-INSTALL		:= install
-
 space:=
 space+=
 SRCLIBDIR:= $(subst $(space),\$(space),$(realpath lib))
@@ -70,23 +63,6 @@ $(LIB_DIRS): $(IRQ_DEFN_FILES:=.genhdr)
 
 lib: $(LIB_DIRS)
 	$(Q)true
-
-install: lib
-	@printf "  INSTALL headers\n"
-	$(Q)$(INSTALL) -d $(INCDIR)/libopencm3
-	$(Q)$(INSTALL) -d $(INCDIR)/libopencmsis
-	$(Q)$(INSTALL) -d $(LIBDIR)
-	$(Q)$(INSTALL) -d $(SHAREDIR)
-	$(Q)cp -r include/libopencm3/* $(INCDIR)/libopencm3
-	$(Q)cp -r include/libopencmsis/* $(INCDIR)/libopencmsis
-	@printf "  INSTALL libs\n"
-	$(Q)$(INSTALL) -m 0644 lib/*.a $(LIBDIR)
-	@printf "  INSTALL ldscripts\n"
-	$(Q)$(INSTALL) -m 0644 lib/*.ld $(LIBDIR)
-	$(Q)$(INSTALL) -m 0644 lib/efm32/*/*.ld $(LIBDIR)
-	@printf "  INSTALL scripts\n"
-	$(Q)$(INSTALL) -m 0644 scripts/*.scr $(SHAREDIR)
-
 
 html doc:
 	$(Q)$(MAKE) -C doc html
@@ -130,4 +106,4 @@ genlinktests: $(LDTESTS:.data=.ldtest)
 	fi;
 
 
-.PHONY: build lib $(LIB_DIRS) install doc clean generatedheaders cleanheaders stylecheck genlinktests
+.PHONY: build lib $(LIB_DIRS) doc clean generatedheaders cleanheaders stylecheck genlinktests

--- a/README.md
+++ b/README.md
@@ -134,13 +134,9 @@ https://github.com/libopencm3/libopencm3-examples
 Installation
 ------------
 
-    $ make install
-
-This will install the library into `/usr/local`. (permissions permitting)
-
-If you want to install it elsewhere, use the following syntax:
-
-    $ make DESTDIR=/opt/libopencm3 install
+Simply pass -I and -L flags to your own project.  See the libopencm3-examples
+repository for an example of using this library as a git submodule, the most
+popular method of use.
 
 It is strongly advised that you do not attempt to install this library to any
 path inside your toolchain itself.  While this means you don't have to include
@@ -148,7 +144,6 @@ any `-I` or `-L` flags in your projects, it is _very_ easy to confuse a multilib
 linker from picking the right versions of libraries.  Common symptoms are
 hardfaults caused by branches into arm code.  You can use `arm-none-eabi-objdump`
 to check for this in your final elf.  You have been warned.
-
 
 Coding style and development guidelines
 ---------------------------------------


### PR DESCRIPTION
This has hurt many many many people over it's lifetime, by confusing their
multilib toolchains.  Simply drop it outright.  People who _really_ know what
they're doing are still perfectly entitled to "install" portions of this
project in suitable locations for their own use.