### PR TITLE
Testgadget0 stm32f429i

### DIFF
--- a/tests/gadget-zero/Makefile.stm32f429i-disco
+++ b/tests/gadget-zero/Makefile.stm32f429i-disco
@@ -1,0 +1,43 @@
+##
+## This file is part of the libopencm3 project.
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BOARD = stm32f429i-disco
+PROJECT = usb-gadget0-$(BOARD)
+BUILD_DIR = bin-$(BOARD)
+
+SHARED_DIR = ../shared
+
+CFILES = main-$(BOARD).c
+CFILES += usb-gadget0.c trace.c trace_stdio.c
+
+VPATH += $(SHARED_DIR)
+
+INCLUDES += $(patsubst %,-I%, . $(SHARED_DIR))
+
+OPENCM3_DIR=../..
+
+### This section can go to an arch shared rules eventually...
+LDSCRIPT = ../../lib/stm32/f4/stm32f405x6.ld
+OPENCM3_LIB = opencm3_stm32f4
+OPENCM3_DEFS = -DSTM32F4
+FP_FLAGS ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+ARCH_FLAGS = -mthumb -mcpu=cortex-m4 $(FP_FLAGS)
+#OOCD_INTERFACE = stlink-v2
+#OOCD_TARGET = stm32f4x
+OOCD_FILE = openocd.stm32f4disco.cfg
+
+include ../rules.mk

--- a/tests/gadget-zero/test_gadget0.py
+++ b/tests/gadget-zero/test_gadget0.py
@@ -6,6 +6,7 @@ import logging
 
 import unittest
 
+#DUT_SERIAL = "stm32f429i-disco"
 DUT_SERIAL = "stm32f4disco"
 #DUT_SERIAL = "stm32f103-generic"
 #DUT_SERIAL = "stm32l1-generic"
@@ -225,7 +226,8 @@ class TestControlTransfer_Reads(unittest.TestCase):
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
         self.assertIsNotNone(self.cfg, "Config 2 should exist")
         self.dev.set_configuration(self.cfg);
-        self.req = uu.CTRL_IN | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
+        self.req     = uu.CTRL_IN  | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
+        self.req_out = uu.CTRL_OUT | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
 
     def inner_t(self, wVal, read_len):
         wVal = int(wVal)
@@ -257,6 +259,26 @@ class TestControlTransfer_Reads(unittest.TestCase):
         inner(ep0_size - 7)
         inner(ep0_size + 11)
         inner(ep0_size * 4 + 11)
+
+    def test_loopback(self) :
+        """
+        Can we request x control in when we tell the device to produce x?
+        :return:
+        """
+        def inner(x):
+            x = int(x)
+            buf_out = array.array('b')
+            for i in range(0,x) : buf_out.append(48 + (x+i) % 10)
+            self.dev.ctrl_transfer(self.req_out, 3, x, 0, buf_out)
+            buf_in = self.dev.ctrl_transfer(self.req, 4, x, 0, x)
+            self.assertEqual(len(buf_in), x,  "Should have read as much as we asked for")
+            self.assertEqual(buf_in, buf_out,
+                             "Buffers don't match!\n - buf_out : %r\n - buf_in  : %r" %(
+							     buf_out.tostring(), buf_in.tostring()))
+        
+        ep0_size = self.dev.bMaxPacketSize0
+        for i in range(4, ep0_size) : inner(i)
+		
 
     def test_waytoobig(self):
         """
@@ -309,4 +331,7 @@ class TestControlTransfer_Reads(unittest.TestCase):
         q = self.dev.ctrl_transfer(self.req, 2, 100, 0, 10)
         self.assertEqual(len(q), 10, "In this case, should have gotten wLen back")
 
+
+if __name__ == '__main__':
+    unittest.main()
 

--- a/tests/gadget-zero/usb-gadget0.c
+++ b/tests/gadget-zero/usb-gadget0.c
@@ -43,8 +43,11 @@
 /*
  * USB Vendor:Interface control requests.
  */
-#define GZ_REQ_SET_PATTERN	1
-#define GZ_REQ_PRODUCE		2
+#define GZ_REQ_SET_PATTERN				1
+#define GZ_REQ_PRODUCE					2
+#define GZ_REQ_WRITE_LOOPBACK_BUFFER	3
+#define GZ_REQ_READ_LOOPBACK_BUFFER		4
+
 #define INTEL_COMPLIANCE_WRITE 0x5b
 #define INTEL_COMPLIANCE_READ 0x5c
 
@@ -220,6 +223,7 @@ static void gadget0_ss_in_cb(usbd_device *usbd_dev, uint8_t ep)
 static void gadget0_rx_cb_loopback(usbd_device *usbd_dev, uint8_t ep)
 {
 	(void) usbd_dev;
+	(void) ep;
 	ER_DPRINTF("loop rx %x\n", ep);
 	/* TODO - unimplemented - consult linux source on proper behaviour */
 }
@@ -227,6 +231,7 @@ static void gadget0_rx_cb_loopback(usbd_device *usbd_dev, uint8_t ep)
 static void gadget0_tx_cb_loopback(usbd_device *usbd_dev, uint8_t ep)
 {
 	(void) usbd_dev;
+	(void) ep;
 	ER_DPRINTF("loop tx %x\n", ep);
 	/* TODO - unimplemented - consult linux source on proper behaviour */
 }
@@ -239,8 +244,9 @@ static int gadget0_control_request(usbd_device *usbd_dev,
 {
 	(void) usbd_dev;
 	(void) complete;
-	(void) buf;
-	(void) len;
+	static uint8_t loopback_buffer[sizeof(usbd_control_buffer)];
+	//(void) buf;
+	//(void) len;
 	ER_DPRINTF("ctrl breq: %x, bmRT: %x, windex :%x, wlen: %x, wval :%x\n",
 		req->bRequest, req->bmRequestType, req->wIndex, req->wLength,
 		req->wValue);
@@ -269,6 +275,37 @@ static int gadget0_control_request(usbd_device *usbd_dev,
 		} else {
 			*len = req->wValue;
 		}
+		return USBD_REQ_HANDLED;
+	case GZ_REQ_WRITE_LOOPBACK_BUFFER:
+		if (req->wValue > sizeof(usbd_control_buffer)) {
+			ER_DPRINTF("Can't store more than out control buffer! %d > %d\n",
+				req->wValue, sizeof(usbd_control_buffer));
+			return USBD_REQ_NOTSUPP;
+		}
+		/* Don't store more than asked for! */
+		if (req->wValue > req->wLength) {
+			memcpy(loopback_buffer, *buf, req->wLength);
+			ER_DPRINTF("Truncated stored loopback data to match wLen\n");
+		} else {
+			memcpy(loopback_buffer, *buf, req->wValue);
+		}
+		ER_DPRINTF("Stored loopback data of %d\n", req->wValue);
+		return USBD_REQ_HANDLED;
+	case GZ_REQ_READ_LOOPBACK_BUFFER:
+		ER_DPRINTF("loopback of %d\n", req->wValue);
+		if (req->wValue > sizeof(usbd_control_buffer)) {
+			ER_DPRINTF("Can't write more than out control buffer! %d > %d\n",
+				req->wValue, sizeof(usbd_control_buffer));
+			return USBD_REQ_NOTSUPP;
+		}
+		/* Don't produce more than asked for! */
+		if (req->wValue > req->wLength) {
+			ER_DPRINTF("Truncating reply to match wLen\n");
+			*len = req->wLength;
+		} else {
+			*len = req->wValue;
+		}
+		memcpy(*buf,loopback_buffer,*len);
 		return USBD_REQ_HANDLED;
 	}
 	return USBD_REQ_NEXT_CALLBACK;


### PR DESCRIPTION
Contents
- Adds test-support for gadget0 for the stm32f429i-disco board
- Adds a (failing) test case - control-loopback ("1 word lost in the beginning of control out transfer")
- Adds an interrupt driven usb version for stm32f429i, because there the test fails more often (felt)
- Fixes the new rcc timing names for stmf4 and stmf429

Output on windows with libusbK(device crashes at the EEE..-part)
```
$ python test_gadget0.py
.........ss.F.....EEEEEEE

>>> removed Errors (they don't appear on linux) <<<

======================================================================
FAIL: test_loopback (__main__.TestControlTransfer_Reads)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_gadget0.py", line 279, in test_loopback
    for i in range(5,ep0_size) : inner(i)
  File "test_gadget0.py", line 277, in inner
    self.assertEqual(buf_in, buf_out, "Buffers don't match!\n - buf_out : %r\n - buf_in  : %r"%(buf_out.tostring(),buf_in.tostring()))
AssertionError: Buffers don't match!
 - buf_out : '5678901234567890123456789012345678901234567'
 - buf_in  : '9012345678901234567890123456789012345676\x00\x00\xa7'

----------------------------------------------------------------------
```

PS: Could we remove the "# serial of my f4 disco board." line from openocd.stm32f4disco.cfg?