### PR TITLE
Fix broken mutex_trylock()

### DIFF
--- a/lib/cm3/sync.c
+++ b/lib/cm3/sync.c
@@ -51,7 +51,7 @@ void mutex_lock(mutex_t *m)
 /* returns 1 if the lock was acquired */
 uint32_t mutex_trylock(mutex_t *m)
 {
-	uint32_t status = 0;
+	uint32_t status = 1;
 
 	/* If the mutex is unlocked. */
 	if (__ldrex(m) == MUTEX_UNLOCKED) {


### PR DESCRIPTION
Implemented zyp's fix for broken mutex. If it's 1 (= failure) by default, the function works fine.

irc log for reference
```
<zyp> strex returns 1 if it fails, 0 if it's successful
<zyp> but if the mutex is already locked, line 57 skips the status update and status gets remains at the initial value which means successful, which is wrong
<zyp> changing line 54 to status = 1 should do the trick
```