### PR TITLE
Return configuration = 0 in Addressed state. 

### DIFF
--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -312,9 +312,13 @@ static int usb_standard_get_configuration(usbd_device *usbd_dev,
 	if (*len > 1) {
 		*len = 1;
 	}
-	const struct usb_config_descriptor *cfg =
-		&usbd_dev->config[usbd_dev->current_config - 1];
-	(*buf)[0] = cfg->bConfigurationValue;
+	if (usbd_dev->current_config > 0) {
+		const struct usb_config_descriptor *cfg =
+			&usbd_dev->config[usbd_dev->current_config - 1];
+		(*buf)[0] = cfg->bConfigurationValue;
+	} else {
+		(*buf)[0] = 0; // In Addressed state zero must be returned
+    	}
 
 	return 1;
 }


### PR DESCRIPTION
Return configuration = 0 in Addressed state in usb_standard_get_configuration(). This enables passing of USB-IF Chapter 9 tests.