### PR TITLE
Cortex : changed interrupt handling functions to use uint32_t (GH issue #475)

### DIFF
--- a/include/libopencm3/cm3/cortex.h
+++ b/include/libopencm3/cm3/cortex.h
@@ -113,13 +113,13 @@ static inline bool cm_is_masked_faults(void)
  * interrupts will be disabled. The result of this function can be used for
  * restoring previous state of the mask.
  *
- * @param[in] mask bool New state of the interrupt mask
- * @returns bool old state of the interrupt mask
+ * @param[in] mask uint32_t New state of the interrupt mask
+ * @returns uint32_t old state of the interrupt mask
  */
 __attribute__((always_inline))
-static inline bool cm_mask_interrupts(bool mask)
+static inline uint32_t cm_mask_interrupts(uint32_t mask)
 {
-	register bool old;
+	register uint32_t old;
 	__asm__ __volatile__("MRS %0, PRIMASK"  : "=r" (old));
 	__asm__ __volatile__(""  : : : "memory");
 	__asm__ __volatile__("MSR PRIMASK, %0" : : "r" (mask));
@@ -133,13 +133,13 @@ static inline bool cm_mask_interrupts(bool mask)
  * the HardFault interrupt will be disabled. The result of this function can be
  * used for restoring previous state of the mask.
  *
- * @param[in] mask bool New state of the HardFault interrupt mask
- * @returns bool old state of the HardFault interrupt mask
+ * @param[in] mask uint32_t New state of the HardFault interrupt mask
+ * @returns uint32_t old state of the HardFault interrupt mask
  */
 __attribute__((always_inline))
-static inline bool cm_mask_faults(bool mask)
+static inline uint32_t cm_mask_faults(uint32_t mask)
 {
-	register bool old;
+	register uint32_t old;
 	__asm__ __volatile__ ("MRS %0, FAULTMASK"  : "=r" (old));
 	__asm__ __volatile__ (""  : : : "memory");
 	__asm__ __volatile__ ("MSR FAULTMASK, %0" : : "r" (mask));
@@ -159,7 +159,7 @@ static inline bool cm_mask_faults(bool mask)
 
 #if !defined(__DOXYGEN__)
 /* Do not populate this definition outside */
-static inline bool __cm_atomic_set(bool *val)
+static inline uint32_t __cm_atomic_set(uint32_t *val)
 {
 	return cm_mask_interrupts(*val);
 }
@@ -218,7 +218,7 @@ static inline bool __cm_atomic_set(bool *val)
 #define CM_ATOMIC_BLOCK()
 #else /* defined(__DOXYGEN__) */
 #define CM_ATOMIC_BLOCK()						\
-	for (bool __CM_SAVER(true), __my = true; __my; __my = false)
+	for (uint32_t __CM_SAVER(true), __my = true; __my; __my = false)
 #endif /* defined(__DOXYGEN__) */
 
 /*---------------------------------------------------------------------------*/
@@ -271,7 +271,7 @@ static inline bool __cm_atomic_set(bool *val)
 #if defined(__DOXYGEN__)
 #define CM_ATOMIC_CONTEXT()
 #else /* defined(__DOXYGEN__) */
-#define CM_ATOMIC_CONTEXT()	bool __CM_SAVER(true)
+#define CM_ATOMIC_CONTEXT()	uint32_t __CM_SAVER(true)
 #endif /* defined(__DOXYGEN__) */
 
 /**@}*/


### PR DESCRIPTION
Cortex : changed interrupt handling functions to use uint32_t instead of bool.

This is more in line with the actual hardware (u32 registers), and will still work if PRIMASK or FAULTMASK ever have more than 1 bit defined.
The functions cm_is_masked_interrupts() and cm_is_masked_faults() are unchanged, since returning 'bool' fits with the function naming.
Fixes most of github issue #475 . What remains "unfixed" is the absence of functions to simply get the u32 value of PRIMASK and FAULTMASK registers.