### PR TITLE
Add ISO IN transfer incomplete callback

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -103,6 +103,10 @@ extern void usbd_register_resume_callback(usbd_device *usbd_dev,
 extern void usbd_register_sof_callback(usbd_device *usbd_dev,
 				       void (*callback)(void));
 
+/** Registers an ISO IN Incomplete callback */
+extern void usbd_register_incomplete_callback(usbd_device *usbd_dev,
+				       void (*callback)(void));
+
 typedef void (*usbd_control_complete_callback)(usbd_device *usbd_dev,
 		struct usb_setup_data *req);
 

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -94,6 +94,11 @@ void usbd_register_sof_callback(usbd_device *usbd_dev, void (*callback)(void))
 	usbd_dev->user_callback_sof = callback;
 }
 
+void usbd_register_incomplete_callback(usbd_device *usbd_dev, void (*callback)(void))
+{
+	usbd_dev->user_callback_incomplete = callback;
+}
+
 void _usbd_reset(usbd_device *usbd_dev)
 {
 	usbd_dev->current_address = 0;

--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -335,6 +335,13 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 		REBASE(OTG_GINTSTS) = OTG_GINTSTS_WKUPINT;
 	}
 
+	if (intsts & OTG_GINTSTS_IISOIXFR) {
+		if (usbd_dev->user_callback_incomplete) {
+			usbd_dev->user_callback_incomplete();
+		}
+		REBASE(OTG_GINTSTS) = OTG_GINTSTS_IISOIXFR;
+	}
+
 	if (intsts & OTG_GINTSTS_SOF) {
 		if (usbd_dev->user_callback_sof) {
 			usbd_dev->user_callback_sof();

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -63,6 +63,7 @@ struct _usbd_device {
 	void (*user_callback_suspend)(void);
 	void (*user_callback_resume)(void);
 	void (*user_callback_sof)(void);
+	void (*user_callback_incomplete)(void);
 
 	struct usb_control_state {
 		enum {

--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -312,9 +312,13 @@ static int usb_standard_get_configuration(usbd_device *usbd_dev,
 	if (*len > 1) {
 		*len = 1;
 	}
-	const struct usb_config_descriptor *cfg =
-		&usbd_dev->config[usbd_dev->current_config - 1];
-	(*buf)[0] = cfg->bConfigurationValue;
+	if (usbd_dev->current_config > 0) {
+		const struct usb_config_descriptor *cfg =
+			&usbd_dev->config[usbd_dev->current_config - 1];
+		(*buf)[0] = cfg->bConfigurationValue;
+	} else {
+		(*buf)[0] = 0; // In Addressed state zero must be returned
+    	}
 
 	return 1;
 }


### PR DESCRIPTION
void usbd_register_incomplete_callback(usbd_device *usbd_dev, void (*callback)(void));

Invoked when IISOIXFR interrupt flag is set (TX FIFO not empty at the end of frame).