### PR TITLE
tests: extract serials to optional local config

### DIFF
--- a/tests/gadget-zero/.gitignore
+++ b/tests/gadget-zero/.gitignore
@@ -1,0 +1,1 @@
+openocd.*.local.cfg

--- a/tests/gadget-zero/openocd.common.cfg
+++ b/tests/gadget-zero/openocd.common.cfg
@@ -1,0 +1,10 @@
+# Shared openocd script helpers
+
+# put things like "hla_serial 'asdfadfa'" in openocd.<board>.local.cfg to support
+# multiple simultaneously connected boards.
+proc optional_local { LOCAL_FILE } {
+    if { [ file exists $LOCAL_FILE ] } {
+        puts "Loading custom local settings from $LOCAL_FILE"
+        source $LOCAL_FILE
+    }
+}

--- a/tests/gadget-zero/openocd.stm32f072disco.cfg
+++ b/tests/gadget-zero/openocd.stm32f072disco.cfg
@@ -2,8 +2,8 @@ source [find interface/stlink-v2.cfg]
 set WORKAREASIZE 0x4000
 source [find target/stm32f0x.cfg]
 
-# serial of my f072 disco board.
-hla_serial "Q?o\x06PgHW#$\x16?"
+source openocd.common.cfg
+optional_local "openocd.stm32f072disco.local.cfg"
 
 # no trace on cm0
 #tpiu config internal swodump.stm32f4disco.log uart off 168000000

--- a/tests/gadget-zero/openocd.stm32f103-generic.cfg
+++ b/tests/gadget-zero/openocd.stm32f103-generic.cfg
@@ -4,8 +4,8 @@ source [find interface/stlink-v2.cfg]
 set WORKAREASIZE 0x2000
 source [find target/stm32f1x.cfg]
 
-# Serial of my l1 disco used as stlink here.
-hla_serial "S?l\x06H?WQ%\x10\x18?"
+source openocd.common.cfg
+optional_local "openocd.stm32f103-generic.local.cfg"
 
 tpiu config internal swodump.stm32f103-generic.log uart off 72000000
 

--- a/tests/gadget-zero/openocd.stm32f429i-disco.cfg
+++ b/tests/gadget-zero/openocd.stm32f429i-disco.cfg
@@ -2,8 +2,8 @@ source [find interface/stlink-v2.cfg]
 set WORKAREASIZE 0x4000
 source [find target/stm32f4x.cfg]
 
-# serial of "your" f429i disco board.
-hla_serial "xxxxxW?k\x06IgHV0H\x10?"
+source openocd.common.cfg
+optional_local "openocd.stm32f429i-disco.local.cfg"
 
 tpiu config internal swodump.stm32f429i-disco.log uart off 168000000
 

--- a/tests/gadget-zero/openocd.stm32f4disco.cfg
+++ b/tests/gadget-zero/openocd.stm32f4disco.cfg
@@ -2,8 +2,8 @@ source [find interface/stlink-v2.cfg]
 set WORKAREASIZE 0x4000
 source [find target/stm32f4x.cfg]
 
-# serial of my f4 disco board.
-hla_serial "W?k\x06IgHV0H\x10?"
+source openocd.common.cfg
+optional_local "openocd.stm32f4disco.local.cfg"
 
 tpiu config internal swodump.stm32f4disco.log uart off 168000000
 

--- a/tests/gadget-zero/openocd.stm32l053disco.cfg
+++ b/tests/gadget-zero/openocd.stm32l053disco.cfg
@@ -2,8 +2,8 @@ source [find interface/stlink-v2-1.cfg]
 set WORKAREASIZE 0x1000
 source [find target/stm32l0.cfg]
 
-# serial of my l053 disco board.
-hla_serial "0670FF484849785087085514"
+source openocd.common.cfg
+optional_local "openocd.stm32l053disco.local.cfg"
 
 # no trace on cm0
 #tpiu config internal swodump.stm32f4disco.log uart off 168000000

--- a/tests/gadget-zero/openocd.stm32l1-generic.cfg
+++ b/tests/gadget-zero/openocd.stm32l1-generic.cfg
@@ -3,10 +3,8 @@ source [find interface/stlink-v2-1.cfg]
 set WORKAREASIZE 0x2000
 source [find target/stm32l1.cfg]
 
-hla_serial "066DFF495351885087171826" # My l4 disco
-
-# Serial of my l1 disco used as stlink here.
-#hla_serial "S?l\x06H?WQ%\x10\x18?"   # My l1 disco
+source openocd.common.cfg
+optional_local "openocd.stm32l1-generic.local.cfg"
 
 tpiu config internal swodump.stm32l1-generic.log uart off 32000000
 


### PR DESCRIPTION
Instead of having committed files containing a single developer's serials, use
optional includes to include a local config file for each board.

If you have only a single board connected, simply:

$ make -f Makefile.<board> clean all flash

If you have multiple boards connected, make sure to fill in the appropriate
hla_serial in your openocd.<board>.local.cfg file, and then run the same
commands.