### PR TITLE
Improve the linker generation make files

### DIFF
--- a/ld/devices.data
+++ b/ld/devices.data
@@ -343,49 +343,49 @@ lpc17[78]x lpc17 RAM1_OFF=0x20000000 RAM2_OFF=0x20040000
 ################################################################################
 # the STM32 families
 
-stm32f0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0 -mthumb -DSTM32F0 -lopencm3_stm32f0 -msoft-float
-stm32f1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F1 -lopencm3_stm32f1 -msoft-float
-stm32f2 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F2 -lopencm3_stm32f2 -msoft-float
-stm32f3 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F3 -lopencm3_stm32f3 -mfloat-abi=hard -mfpu=fpv4-sp-d16
-stm32f4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F4 -lopencm3_stm32f4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+stm32f0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32f0 CPU=cortex-m0 FPU=soft
+stm32f1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32f1 CPU=cortex-m3 FPU=soft
+stm32f2 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32f2 CPU=cortex-m3 FPU=soft
+stm32f3 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32f3 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
+stm32f4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32f4 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 #stm32f7 is supported on GCC-arm-embedded 4.8 2014q4 
-stm32f7 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20010000 -mcpu=cortex-m7 -mthumb -DSTM32F7 -lopencm3_stm32f7 -mfloat-abi=hard -mfpu=fpv5-sp-d16
-stm32l0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0plus -mthumb -DSTM32L0 -lopencm3_stm32l0 -msoft-float
-stm32l1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32L1 -lopencm3_stm32l1 -msoft-float
-stm32l4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32L4 -lopencm3_stm32l4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
-stm32w stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
-stm32t stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
+stm32f7 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20010000 FAMILY=stm32f7 CPU=cortex-m7 FPU=hard-fpv5-sp-d16
+stm32l0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32l0 CPU=cortex-m0plus FPU=soft
+stm32l1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32l1 CPU=cortex-m3 FPU=soft
+stm32l4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32l4 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
+stm32w stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32w CPU=cortex-m3 FPU=soft
+stm32t stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 FAMILY=stm32t CPU=cortex-m3 FPU=soft
 
 ################################################################################
 # the SAM3 families
 
-sam3a sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000
-sam3n sam3 ROM_OFF=0x00400000 RAM_OFF=0x20000000
-sam3s sam3 ROM_OFF=0x00400000 RAM_OFF=0x20000000
-sam3u sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 NFCRAM=4K NFCRAM_OFF=0x20100000
-sam3x sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000
+sam3a sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 FAMILY=sam3a CPU=cortex-m3 FPU=soft
+sam3n sam3 ROM_OFF=0x00400000 RAM_OFF=0x20000000 FAMILY=sam3n CPU=cortex-m3 FPU=soft
+sam3s sam3 ROM_OFF=0x00400000 RAM_OFF=0x20000000 FAMILY=sam3s CPU=cortex-m3 FPU=soft
+sam3u sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 NFCRAM=4K NFCRAM_OFF=0x20100000 FAMILY=sam3u CPU=cortex-m3 FPU=soft
+sam3x sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 FAMILY=sam3x CPU=cortex-m3 FPU=soft
 
 ################################################################################
 # the lpc families
 
-lpc13 lpc ROM_OFF=0x00000000 RAM_OFF=0x10000000 RAM1_OFF=0x20000000
-lpc17 lpc ROM_OFF=0x00000000 RAM_OFF=0x10000000
+lpc13 lpc ROM_OFF=0x00000000 RAM_OFF=0x10000000 RAM1_OFF=0x20000000 FAMILY=lpc13xx CPU=cortex-m3 FPU=soft
+lpc17 lpc ROM_OFF=0x00000000 RAM_OFF=0x10000000 FAMILY=lpc17xx CPU=cortex-m3 FPU=soft
 
 ################################################################################
 # the efm32 Gecko families
 
-efm32zg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32tg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32g efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32lg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32gg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32wg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
+efm32zg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 FAMILY=efm32_zg CPU=cortex-m0plus FPU=soft
+efm32tg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 FAMILY=efm32tg CPU=cortex-m3 FPU=soft
+efm32g efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 FAMILY=efm32g CPU=cortex-m3 FPU=soft
+efm32lg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 FAMILY=efm32_lg CPU=cortex-m3 FPU=soft
+efm32gg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 FAMILY=efm32_gg CPU=cortex-m3 FPU=soft
+efm32wg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 FAMILY=efm32_wg CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 
 ################################################################################
 # Cortex LM3 families
 
-lm3fury lm3 ROM_OFF=0x00000000 RAM_OFF=0x20000000
-lm3sandstorm lm3 ROM_OFF=0x00000000 RAM_OFF=0x20000000
+lm3fury lm3 ROM_OFF=0x00000000 RAM_OFF=0x20000000 FAMILY=lm3 CPU=cortex-m3 FPU=soft
+lm3sandstorm lm3 ROM_OFF=0x00000000 RAM_OFF=0x20000000 FAMILY=lm3 CPU=cortex-m3 FPU=soft
 
 
 ################################################################################

--- a/mk/README
+++ b/mk/README
@@ -15,34 +15,31 @@ where you are defining variables (near the beginning of the file), and file
 <module>-rules.mk should be included in the rules part of makefile (somewhere
 near to the end of file).
 
-Example makefile using gcc compiler module:
+Example makefile using the gcc compiler module together with the linker script
+generator module:
 
 >>>>>>
-OBJS		+= foo.o bar.o
+DEVICE          =
+OPENCM3_DIR     =
+OBJS            += foo.o
 
-CFLAGS		+= -O0 -g
-CPPFLAGS	+= -MD -MP $(@F).d
-CPPFLAGS	+= $(DEFS)
-CPPFLAGS	+= $(INCS)
-LDFLAGS		+= --static --nostartfiles
-LDLIBS		+= -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
-# parameters for gcc module
-PREFIX		= arm-elf
+CFLAGS          += -Os -ggdb3
+CPPFLAGS	+= -MD
+LDFLAGS         += -static -nostartfiles
+LDLIBS          += -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
 
+include $(OPENCM3_DIR)/mk/genlink-config.mk
 include $(OPENCM3_DIR)/mk/gcc-config.mk
 
 .PHONY: clean all
 
-all: binary.images
-
-%.images: %.elf %.hex
-
-include $(OPENCM3_DIR)/mk/gcc-rules.mk
+all: binary.elf binary.hex
 
 clean:
-	$(Q)$(RM) -rf binary.* *.o *.d
+	$(Q)$(RM) -rf binary.* *.o
 
--include $(OBJS:.o=.d)
+include $(OPENCM3_DIR)/mk/genlink-rules.mk
+include $(OPENCM3_DIR)/mk/gcc-rules.mk
 <<<<<<
 
 
@@ -81,7 +78,8 @@ genlink
 
   This module adds an support for the user to the linker script generator. The
 linker script will be generated as the file $(DEVICE).ld in the project folder,
-and automatically used for the linking process.
+and automatically be used for the linking process.
+Additionally the matching library is added to the LDLIBS variable.
 
 Variables to control the build process (should be set in your makefile):
 ------------------------------------------------------------------------
@@ -92,9 +90,9 @@ OPENCM3_DIR	The root path of libopencm3 library.
 Output variables from this module:
 ----------------------------------
 
-DEFS		(appended)
- - Appended definitions specified in chip database file.
- ! Ensure that you have line 'CPPFLAGS += $(DEFS)' in your makefile.
+CPPFLAGS		(appended)
+ - Appends the chip family to the CPPFLAGS. For example -DSTM32F1
+ - Appends the include path for libopencm3
 
 ARCH_FLAGS	(replaced)
  - Architecture build flags for specified chip.
@@ -104,12 +102,16 @@ LDSCRIPT	(replaced)
  - Linker script generated file.
  * No needed to handle this variable if you use module <gcc> too.
 
-OPENCM3_LIBNAME	(replaced)
- - The right libopencm3 library base name to be linked with.
- ! Ensure that you have line 'LDLIBS += -l$(OPENCM3_LIBNAME)' in your makefile.
- ! Ensure that you have line 'LDFLAGS += -L$(OPENCM3_DIR)/lib' in your makefile.
- ! Ensure that you have rule '$(OPENCM3_DIR)/lib/lib$(OPENCM3_LIBNAME).a:'
-   to be the library archive succesfully built when needed.
+LDLIBS (appended)
+ - LDLIBS += -l$(OPENCM3_LIBNAME) is appended to link against the
+   matching library.
+
+LDFLAGS (appended)
+ - LDFLAGS += -L$(OPENCM3_DIR)/lib is appended to make sure the
+   matching library can be found.
+
+family,cpu,fpu (replaced)
+ - these are used internally to create the above variables
 
 Temporary variables that you should not use in your makefile:
 -------------------------------------------------------------

--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -18,17 +18,55 @@
 ##
 
 ifeq ($(DEVICE),)
-$(error no DEVICE specified for linker script generator)
+$(warning no DEVICE specified for linker script generator)
 endif
 
 LDSCRIPT	= $(DEVICE).ld
 
-GENLINK_DEFS	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="DEFS" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
-GENLINK_ARCH	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="ARCH" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
-GENLINK_LIB	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="LIB" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+family		:=$(shell awk -v PAT="$(DEVICE)" -v MODE="FAMILY" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+cpu		:=$(shell awk -v PAT="$(DEVICE)" -v MODE="CPU" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+fpu		:=$(shell awk -v PAT="$(DEVICE)" -v MODE="FPU" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
 
-DEFS		+= $(GENLINK_DEFS)
-ARCH_FLAGS	:= $(GENLINK_ARCH)
-OPENCM3_LIBNAME	:= $(strip $(subst -l,,$(GENLINK_LIB)))
+CPPFLAGS	+= $(shell echo "-D$(family)" | tr [:lower:] [:upper:] 2>/dev/null)
 
-GENFILES	+= $(LDSCRIPT)
+ARCH_FLAGS	:=-mcpu=$(cpu)
+ifeq ($(cpu),$(filter $(cpu),cortex-m0 cortex-m0plus cortex-m3 cortex-m4 cortex-m7))
+ARCH_FLAGS    +=-mthumb
+endif
+
+ifeq ($(fpu),soft)
+ARCH_FLAGS	+= -msoft-float
+else ifeq ($(fpu),hard-fpv4-sp-d16)
+ARCH_FLAGS	+= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+else ifeq ($(fpu),hard-fpv5-sp-d16)
+ARCH_FLAGS      += -mfloat-abi=hard -mfpu=fpv5-sp-d16
+else
+$(warning No match for the FPU flags)
+endif
+
+
+ifeq ($(family),)
+$(warning the device data file has no information about the library name matching your device)
+endif
+
+# only append to LDFLAGS if the library file exists to not break builds
+# where those are provided by different means
+ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(family).a))
+LDLIBS += -lopencm3_$(family)
+else
+$(warning $(OPENCM3_DIR)/lib/libopencm3_$(family).a library variant for the selected device does not exist.)
+endif
+
+# only append to LDLIBS if the directory exists
+ifneq (,$(wildcard $(OPENCM3_DIR)/lib))
+LDFLAGS += -L$(OPENCM3_DIR)/lib
+else
+$(warning $(OPENCM3_DIR)/lib as given be OPENCM3_DIR does not exist.)
+endif
+
+# only append include path to CPPFLAGS if the directory exists
+ifneq (,$(wildcard $(OPENCM3_DIR)/include))
+CPPFLAGS += -I$(OPENCM3_DIR)/lib
+else
+$(warning $(OPENCM3_DIR)/include as given be OPENCM3_DIR does not exist.)
+endif

--- a/mk/genlink-rules.mk
+++ b/mk/genlink-rules.mk
@@ -18,8 +18,5 @@
 ##
 
 $(LDSCRIPT):$(OPENCM3_DIR)/ld/linker.ld.S
-ifeq ($(GENLINK_DEFS),)
-	$(error unknown device $(DEVICE) for the linker. Cannot generate ldscript)
-endif
 	@printf "  GENLNK  $@\n"
-	$(Q)$(CPP) $(GENLINK_DEFS) -P -E $< > $@
+	$(Q)$(CPP) $(ARCH_FLAGS) $(shell awk -v PAT="$(basename $@)" -v MODE="DEFS" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null) -P -E $< > $@

--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -41,21 +41,34 @@ BEGIN {
 			PAT=$2;
 
 		for (i = 3; i <= NF; i = i + 1) {
-			if ($i ~ /^-l/) {
-				if ("LIB" ~ MODE)
-					printf "%s ",$i;
+			if ($i ~ /^FAMILY=/) {
+				if ("FAMILY" ~ MODE){
+					sub(/[^=]*=/,"",$i);
+					printf "%s",$i;
+					exit;
+				}
 			}
-			else if ($i ~ /^-m/) {
-				if ("ARCH" ~ MODE)
-					printf "%s ",$i;
+			else if ($i ~ /^CPU=/) {
+				if ("CPU" ~ MODE){
+					sub(/[^=]*=/,"",$i);
+					printf "%s",$i;
+					exit;
+				}
 			}
-			else if ($i ~ /^-D/) {
-				if ("DEFS" ~ MODE)
-					printf "%s ",$i;
+			else if ($i ~ /^FPU=/) {
+				if ("FPU" ~ MODE){
+					sub(/[^=]*=/,"",$i);
+					printf "%s",$i;
+					exit;
+				}
 			}
-			else {
+			else if ($i ~ /[[:upper:]]*=/) {
 				if ("DEFS" ~ MODE)
 					printf "-D_%s ",$i;
+			}
+			if ($i ~ /[[:upper:]]*=/) {
+				if ("VARS" ~ MODE)
+				printf "%s ",$i;
 			}
 		}
 


### PR DESCRIPTION
These changes make the example given in mk/README actually work.
Additionally the example now shows off the linkerscript generator.

The changes in the devices.data make the automatic selection of the
-lopencm3 linker option work for more devices.

I didn't see a good reason to not append to LDFLAGS and LDLIBS from
the genlinks.conf so put that there instead of setting them in the
READMEs example.