### PR TITLE
mk/genlink: change devices.data format to remove gcc specific options

### DIFF
--- a/ld/devices.data
+++ b/ld/devices.data
@@ -333,75 +333,63 @@ sam3xnfc sam3x NFCRAM=4K NFCRAM_OFF=0x20100000
 # the lpc family groups
 
 
-lpc13u lpc13 USBRAM_OFF=0x20004000
+lpc13u lpc13xx USBRAM_OFF=0x20004000
 
-lpc17[56]x lpc17 RAM1_OFF=0x2007C000 RAM2_OFF=0x20080000
-lpc17[78]x lpc17 RAM1_OFF=0x20000000 RAM2_OFF=0x20040000
+lpc17[56]x lpc17xx RAM1_OFF=0x2007C000 RAM2_OFF=0x20080000
+lpc17[78]x lpc17xx RAM1_OFF=0x20000000 RAM2_OFF=0x20040000
 
 ################################################################################
 ################################################################################
 ################################################################################
 # the STM32 families
 
-stm32f0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0 -mthumb -DSTM32F0 -lopencm3_stm32f0 -msoft-float
-stm32f1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F1 -lopencm3_stm32f1 -msoft-float
-stm32f2 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32F2 -lopencm3_stm32f2 -msoft-float
-stm32f3 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F3 -lopencm3_stm32f3 -mfloat-abi=hard -mfpu=fpv4-sp-d16
-stm32f4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32F4 -lopencm3_stm32f4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+stm32f0 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m0 FPU=soft
+stm32f1 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+stm32f2 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+stm32f3 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
+stm32f4 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 #stm32f7 is supported on GCC-arm-embedded 4.8 2014q4 
-stm32f7 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20010000 -mcpu=cortex-m7 -mthumb -DSTM32F7 -lopencm3_stm32f7 -mfloat-abi=hard -mfpu=fpv5-sp-d16
-stm32l0 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m0plus -mthumb -DSTM32L0 -lopencm3_stm32l0 -msoft-float
-stm32l1 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb -DSTM32L1 -lopencm3_stm32l1 -msoft-float
-stm32l4 stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m4 -mthumb -DSTM32L4 -lopencm3_stm32l4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
-stm32w stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
-stm32t stm32 ROM_OFF=0x08000000 RAM_OFF=0x20000000 -mcpu=cortex-m3 -mthumb
+stm32f7 END ROM_OFF=0x08000000 RAM_OFF=0x20010000 CPU=cortex-m7 FPU=hard-fpv5-sp-d16
+stm32l0 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m0plus FPU=soft
+stm32l1 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+stm32l4 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
+stm32w END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+stm32t END ROM_OFF=0x08000000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
 
 ################################################################################
 # the SAM3 families
 
-sam3a sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000
-sam3n sam3 ROM_OFF=0x00400000 RAM_OFF=0x20000000
-sam3s sam3 ROM_OFF=0x00400000 RAM_OFF=0x20000000
-sam3u sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 NFCRAM=4K NFCRAM_OFF=0x20100000
-sam3x sam3 ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000
+sam3a END ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 CPU=cortex-m3 FPU=soft
+sam3n END ROM_OFF=0x00400000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+sam3s END ROM_OFF=0x00400000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+sam3u END ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 NFCRAM=4K NFCRAM_OFF=0x20100000 CPU=cortex-m3 FPU=soft
+sam3x END ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 CPU=cortex-m3 FPU=soft
 
 ################################################################################
 # the lpc families
 
-lpc13 lpc ROM_OFF=0x00000000 RAM_OFF=0x10000000 RAM1_OFF=0x20000000
-lpc17 lpc ROM_OFF=0x00000000 RAM_OFF=0x10000000
+lpc13xx END ROM_OFF=0x00000000 RAM_OFF=0x10000000 RAM1_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+lpc17xx END ROM_OFF=0x00000000 RAM_OFF=0x10000000 CPU=cortex-m3 FPU=soft
 
 ################################################################################
 # the efm32 Gecko families
 
-efm32zg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32tg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32g efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32lg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32gg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
-efm32wg efm32 ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000
+efm32zg END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex-m0plus FPU=soft
+efm32tg END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex-m3 FPU=soft
+efm32g END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex-m3 FPU=soft
+efm32lg END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex-m3 FPU=soft
+efm32gg END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex-m3 FPU=soft
+efm32wg END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 
 ################################################################################
 # Cortex LM3 families
 
-lm3fury lm3 ROM_OFF=0x00000000 RAM_OFF=0x20000000
-lm3sandstorm lm3 ROM_OFF=0x00000000 RAM_OFF=0x20000000
+lm3fury lm3s
+lm3sandstorm lm3s
+lm3s END ROM_OFF=0x00000000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
 
 
 ################################################################################
 # Cortex R4F families
 
-rm46l rm4 ROM_OFF=0x00000000 RAM_OFF=0x08000000 RAM1_OFF=0x08400000
-
-################################################################################
-################################################################################
-################################################################################
-# the architectures
-
-stm32 END
-sam3 END
-lpc END
-efm32 END
-lm3 END
-rm4 END
-
+rm46l END ROM_OFF=0x00000000 RAM_OFF=0x08000000 RAM1_OFF=0x08400000

--- a/ld/devices.data
+++ b/ld/devices.data
@@ -126,6 +126,7 @@ stm32f401?d* stm32f4 ROM=384K RAM=96K
 stm32f401?e* stm32f4 ROM=512K RAM=96K
 stm32f4[01][57]?e* stm32f4ccm ROM=512K RAM=128K CCM=64K
 stm32f4[01][57]?g* stm32f4ccm ROM=1024K RAM=128K CCM=64K
+stm32f411re stm32f4 ROM=512K RAM=128K
 stm32f4[23][79]?g* stm32f4ccm ROM=1024K RAM=192K CCM=64K
 stm32f4[23][79]?i* stm32f4ccm ROM=2048K RAM=192K CCM=64K
 
@@ -222,6 +223,39 @@ lpc1786* lpc178x ROM=256K RAM=64K RAM1=16K
 lpc1787* lpc178x ROM=512K RAM=64K RAM1=16K RAM2=16K
 lpc1788* lpc178x ROM=512K RAM=64K RAM1=16K RAM2=16K
 
+lpc4370* lpc43xx RAM=128K RAM1=72K RAM2=32K RAM3=16K
+lpc4350* lpc43xx RAM=128K RAM1=72K RAM2=32K RAM3=16K
+lpc4330* lpc43xx RAM=128K RAM1=72K RAM2=32K RAM3=16K
+lpc4320* lpc43xx RAM=96K RAM1=40K RAM2=32K RAM3=16K
+lpc4310* lpc43xx RAM=96K RAM1=40K RAM2=16K
+lpc43S70* lpc43xx RAM=128K RAM1=72K RAM2=32K RAM3=16K
+lpc43S50* lpc43xx RAM=128K RAM1=72K RAM2=32K RAM3=16K
+lpc43S30* lpc43xx RAM=128K RAM1=72K RAM2=32K RAM3=16K
+lpc43S20* lpc43xx RAM=96K RAM1=40K RAM2=32K RAM3=16K
+lpc43S10* lpc43xx RAM=96K RAM1=40K RAM2=16K
+lpc4367* lpc43xx ROM=512K ROM1=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4357* lpc43xx ROM=512K ROM1=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4355* lpc43xx ROM=384K ROM1=384K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4353* lpc43xx ROM=256K ROM1=256K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4352* lpc43xx ROM=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4350* lpc43xx RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4337* lpc43xx ROM=512K ROM1=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4335* lpc43xx ROM=384K ROM1=384K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4333* lpc43xx ROM=256K ROM1=256K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4332* lpc43xx ROM=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4330* lpc43xx RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4327* lpc43xx ROM=512K ROM1=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4325* lpc43xx ROM=384K ROM1=384K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4323* lpc43xx ROM=256K ROM1=256K RAM=32K RAM1=40K RAM2=16K
+lpc4322* lpc43xx ROM=512K RAM=32K RAM1=40K RAM2=16K
+lpc4317* lpc43xx ROM=512K ROM1=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4315* lpc43xx ROM=384K ROM1=384K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc4313* lpc43xx ROM=256K ROM1=256K RAM=32K RAM1=40K RAM2=16K
+lpc4312* lpc43xx ROM=512K RAM=32K RAM1=40K RAM2=16K
+lpc43S67* lpc43xx ROM=512K ROM1=512K RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc43S57* lpc43xx RAM=32K RAM1=40K RAM2=32K RAM3=16K
+lpc43S37* lpc43xx RAM=32K RAM1=40K RAM2=32K RAM3=16K
+
 ################################################################################
 # the efm32 chips
 
@@ -308,12 +342,21 @@ lm3s1601 lm3fury ROM=128K RAM=32K
 lm3s1607 lm3fury ROM=128K RAM=32K
 lm3s1608 lm3fury ROM=128K RAM=32K
 lm3s1620 lm3fury ROM=128K RAM=32K
+lm3s3748 lm3fury ROM=128K RAM=64K
 lm3s8962 lm3fury ROM=256K RAM=64K
+
+lm4f120xl lm4f ROM=128K RAM=32K
+
 
 ################################################################################
 # the TI cortex R4F chips
 
 rm46l852* rm46l ROM=1280K RAM=192K
+
+################################################################################
+# the vf610
+
+vf610 vf6xx RAM=256K RAM1=256K RAM_OFF=0x1f000000 RAM1_OFF=0x3f040000
 
 ################################################################################
 ################################################################################
@@ -332,11 +375,14 @@ sam3xnfc sam3x NFCRAM=4K NFCRAM_OFF=0x20100000
 ################################################################################
 # the lpc family groups
 
-
+lpc13 lpc13xx
 lpc13u lpc13xx USBRAM_OFF=0x20004000
 
 lpc17[56]x lpc17xx RAM1_OFF=0x2007C000 RAM2_OFF=0x20080000
 lpc17[78]x lpc17xx RAM1_OFF=0x20000000 RAM2_OFF=0x20040000
+
+lpc43xx_m0 lpc43xx CPU=cortex-m0 FPU=soft
+lpc43xx_m4 lpc43xx CPU=cortex-m4 FPU=hard-fp4-sp-d16
 
 ################################################################################
 ################################################################################
@@ -370,6 +416,9 @@ sam3x END ROM_OFF=0x00080000 RAM_OFF=0x20000000 RAM1_OFF=0x20080000 CPU=cortex-m
 
 lpc13xx END ROM_OFF=0x00000000 RAM_OFF=0x10000000 RAM1_OFF=0x20000000 CPU=cortex-m3 FPU=soft
 lpc17xx END ROM_OFF=0x00000000 RAM_OFF=0x10000000 CPU=cortex-m3 FPU=soft
+lpc43xx + ROM_OFF=0x1A000000 ROM1_OFF=0x1B000000 RAM_OFF=0x10000000 RAM1_OFF=0x10080000
+lpc43xx + RAM2_OFF=0x20000000 RAM3_OFF=0x20008000
+lpc43xx END CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 
 ################################################################################
 # the efm32 Gecko families
@@ -382,14 +431,20 @@ efm32gg END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex
 efm32wg END ROM_OFF=0x00000000 RAM_OFF=0x20000000 RAM1_OFF=0x10000000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 
 ################################################################################
-# Cortex LM3 families
+# Cortex LM3 and LM4 families
 
 lm3fury lm3s
 lm3sandstorm lm3s
 lm3s END ROM_OFF=0x00000000 RAM_OFF=0x20000000 CPU=cortex-m3 FPU=soft
+lm4f END ROM_OFF=0x00000000 RAM_OFF=0x20000000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 
 
 ################################################################################
 # Cortex R4F families
 
 rm46l END ROM_OFF=0x00000000 RAM_OFF=0x08000000 RAM1_OFF=0x08400000
+
+################################################################################
+# VF6xx families
+
+vf6xx END CPU=cortex-m4 FPU=hard-fpv4-sp-d16

--- a/mk/README
+++ b/mk/README
@@ -103,7 +103,7 @@ LDSCRIPT	(replaced)
  * No needed to handle this variable if you use module <gcc> too.
 
 LDLIBS (appended)
- - LDLIBS += -l$(OPENCM3_LIBNAME) is appended to link against the
+ - LDLIBS += -lopencm3_$(family) is appended to link against the
    matching library.
 
 LDFLAGS (appended)

--- a/mk/README
+++ b/mk/README
@@ -15,34 +15,31 @@ where you are defining variables (near the beginning of the file), and file
 <module>-rules.mk should be included in the rules part of makefile (somewhere
 near to the end of file).
 
-Example makefile using gcc compiler module:
+Example makefile using the gcc compiler module together with the linker script
+generator module:
 
 >>>>>>
-OBJS		+= foo.o bar.o
+DEVICE          =
+OPENCM3_DIR     =
+OBJS            += foo.o
 
-CFLAGS		+= -O0 -g
-CPPFLAGS	+= -MD -MP $(@F).d
-CPPFLAGS	+= $(DEFS)
-CPPFLAGS	+= $(INCS)
-LDFLAGS		+= --static --nostartfiles
-LDLIBS		+= -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
-# parameters for gcc module
-PREFIX		= arm-elf
+CFLAGS          += -Os -ggdb3
+CPPFLAGS	+= -MD
+LDFLAGS         += -static -nostartfiles
+LDLIBS          += -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
 
+include $(OPENCM3_DIR)/mk/genlink-config.mk
 include $(OPENCM3_DIR)/mk/gcc-config.mk
 
 .PHONY: clean all
 
-all: binary.images
-
-%.images: %.elf %.hex
-
-include $(OPENCM3_DIR)/mk/gcc-rules.mk
+all: binary.elf binary.hex
 
 clean:
-	$(Q)$(RM) -rf binary.* *.o *.d
+	$(Q)$(RM) -rf binary.* *.o
 
--include $(OBJS:.o=.d)
+include $(OPENCM3_DIR)/mk/genlink-rules.mk
+include $(OPENCM3_DIR)/mk/gcc-rules.mk
 <<<<<<
 
 
@@ -81,7 +78,8 @@ genlink
 
   This module adds an support for the user to the linker script generator. The
 linker script will be generated as the file $(DEVICE).ld in the project folder,
-and automatically used for the linking process.
+and automatically be used for the linking process.
+Additionally the matching library is added to the LDLIBS variable.
 
 Variables to control the build process (should be set in your makefile):
 ------------------------------------------------------------------------
@@ -92,9 +90,9 @@ OPENCM3_DIR	The root path of libopencm3 library.
 Output variables from this module:
 ----------------------------------
 
-DEFS		(appended)
- - Appended definitions specified in chip database file.
- ! Ensure that you have line 'CPPFLAGS += $(DEFS)' in your makefile.
+CPPFLAGS		(appended)
+ - Appends the chip family to the CPPFLAGS. For example -DSTM32F1
+ - Appends the include path for libopencm3
 
 ARCH_FLAGS	(replaced)
  - Architecture build flags for specified chip.
@@ -104,12 +102,16 @@ LDSCRIPT	(replaced)
  - Linker script generated file.
  * No needed to handle this variable if you use module <gcc> too.
 
-OPENCM3_LIBNAME	(replaced)
- - The right libopencm3 library base name to be linked with.
- ! Ensure that you have line 'LDLIBS += -l$(OPENCM3_LIBNAME)' in your makefile.
- ! Ensure that you have line 'LDFLAGS += -L$(OPENCM3_DIR)/lib' in your makefile.
- ! Ensure that you have rule '$(OPENCM3_DIR)/lib/lib$(OPENCM3_LIBNAME).a:'
-   to be the library archive succesfully built when needed.
+LDLIBS (appended)
+ - LDLIBS += -l$(OPENCM3_LIBNAME) is appended to link against the
+   matching library.
+
+LDFLAGS (appended)
+ - LDFLAGS += -L$(OPENCM3_DIR)/lib is appended to make sure the
+   matching library can be found.
+
+family,cpu,fpu (replaced)
+ - these are used internally to create the above variables
 
 Temporary variables that you should not use in your makefile:
 -------------------------------------------------------------

--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -59,7 +59,7 @@ else
 ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(genlink_subfamily).a))
 LDLIBS += -lopencm3_$(genlink_subfamily)
 else
-$(warning $(OPENCM3_DIR)/lib/libopencm3_$(genlink_subfamily).a library variant for the selected device does not exist.)
+$(warning $(OPENCM3_DIR)/lib/libopencm3_$(genlink_family).a library variant for the selected device does not exist.)
 endif
 endif
 

--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -18,17 +18,61 @@
 ##
 
 ifeq ($(DEVICE),)
-$(error no DEVICE specified for linker script generator)
+$(warning no DEVICE specified for linker script generator)
 endif
 
 LDSCRIPT	= $(DEVICE).ld
 
-GENLINK_DEFS	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="DEFS" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
-GENLINK_ARCH	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="ARCH" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
-GENLINK_LIB	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="LIB" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+genlink_family		:=$(shell awk -v PAT="$(DEVICE)" -v MODE="FAMILY" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+genlink_subfamily	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="SUBFAMILY" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+genlink_cpu		:=$(shell awk -v PAT="$(DEVICE)" -v MODE="CPU" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+genlink_fpu		:=$(shell awk -v PAT="$(DEVICE)" -v MODE="FPU" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
+genlink_cppflags	:=$(shell awk -v PAT="$(DEVICE)" -v MODE="CPPFLAGS" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null)
 
-DEFS		+= $(GENLINK_DEFS)
-ARCH_FLAGS	:= $(GENLINK_ARCH)
-OPENCM3_LIBNAME	:= $(strip $(subst -l,,$(GENLINK_LIB)))
+CPPFLAGS	+= $(genlink_cppflags)
 
-GENFILES	+= $(LDSCRIPT)
+ARCH_FLAGS	:=-mcpu=$(genlink_cpu)
+ifeq ($(genlink_cpu),$(filter $(genlink_cpu),cortex-m0 cortex-m0plus cortex-m3 cortex-m4 cortex-m7))
+ARCH_FLAGS    +=-mthumb
+endif
+
+ifeq ($(genlink_fpu),soft)
+ARCH_FLAGS	+= -msoft-float
+else ifeq ($(genlink_fpu),hard-fpv4-sp-d16)
+ARCH_FLAGS	+= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+else ifeq ($(genlink_fpu),hard-fpv5-sp-d16)
+ARCH_FLAGS      += -mfloat-abi=hard -mfpu=fpv5-sp-d16
+else
+$(warning No match for the FPU flags)
+endif
+
+
+ifeq ($(genlink_family),)
+$(warning the device data file has no information about the library name matching your device)
+endif
+
+# only append to LDFLAGS if the library file exists to not break builds
+# where those are provided by different means
+ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(genlink_family).a))
+LDLIBS += -lopencm3_$(genlink_family)
+else
+ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(genlink_subfamily).a))
+LDLIBS += -lopencm3_$(genlink_subfamily)
+else
+$(warning $(OPENCM3_DIR)/lib/libopencm3_$(genlink_subfamily).a library variant for the selected device does not exist.)
+endif
+endif
+
+# only append to LDLIBS if the directory exists
+ifneq (,$(wildcard $(OPENCM3_DIR)/lib))
+LDFLAGS += -L$(OPENCM3_DIR)/lib
+else
+$(warning $(OPENCM3_DIR)/lib as given be OPENCM3_DIR does not exist.)
+endif
+
+# only append include path to CPPFLAGS if the directory exists
+ifneq (,$(wildcard $(OPENCM3_DIR)/include))
+CPPFLAGS += -I$(OPENCM3_DIR)/include
+else
+$(warning $(OPENCM3_DIR)/include as given be OPENCM3_DIR does not exist.)
+endif

--- a/mk/genlink-rules.mk
+++ b/mk/genlink-rules.mk
@@ -18,8 +18,5 @@
 ##
 
 $(LDSCRIPT):$(OPENCM3_DIR)/ld/linker.ld.S
-ifeq ($(GENLINK_DEFS),)
-	$(error unknown device $(DEVICE) for the linker. Cannot generate ldscript)
-endif
 	@printf "  GENLNK  $@\n"
-	$(Q)$(CPP) $(GENLINK_DEFS) -P -E $< > $@
+	$(Q)$(CPP) $(ARCH_FLAGS) $(shell awk -v PAT="$(basename $@)" -v MODE="DEFS" -f $(OPENCM3_DIR)/scripts/genlink.awk $(OPENCM3_DIR)/ld/devices.data 2>/dev/null) -P -E $< > $@

--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -23,8 +23,6 @@
 
 BEGIN {
 	PAT = tolower(PAT);
-	if (length(MODE) == 0)
-		MODE = ".*";
 }
 !/^#/{
 	#remove cr on windows
@@ -41,37 +39,37 @@ BEGIN {
 			PAT=$2;
                 for (i = 3; i <= NF; i = i + 1) {
 			if ($i ~ /^CPU=/) {
-				if ("CPU" ~ MODE){
+				if ("CPU" == MODE){
 					sub(/[^=]*=/,"",$i);
 					printf "%s",$i;
 					exit;
 				}
 			}
 			else if ($i ~ /^FPU=/) {
-				if ("FPU" ~ MODE){
+				if ("FPU" == MODE){
 					sub(/[^=]*=/,"",$i);
 					printf "%s",$i;
 					exit;
 				}
 			}
 			else if ($i ~ /[[:upper:]]*=/) {
-				if ("DEFS" ~ MODE)
+				if ("DEFS" == MODE)
 					printf "-D_%s ",$i;
 			}
 		}
 		if (PAT=="END"){
-			if ("FAMILY" ~ MODE)
+			if ("FAMILY" == MODE)
 				printf "%s",family;
-			else if ("SUBFAMILY" ~ MODE)
+			else if ("SUBFAMILY" == MODE)
 				printf "%s",subfamily;
 			exit;
 		}
 		else{
 			subfamily = family;
 			family = PAT;
-	                if ("CPPFLAGS" ~ MODE)
+	                if ("CPPFLAGS" == MODE)
 				printf "-D%s ",toupper(PAT);
-			else if("DEFS" ~ MODE)
+			else if("DEFS" == MODE)
 				printf "-D%s ",toupper(PAT);
 		}
 	}

--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -23,6 +23,7 @@
 
 BEGIN {
 	PAT = tolower(PAT);
+	family = PAT;
 }
 !/^#/{
 	#remove cr on windows
@@ -35,6 +36,8 @@ BEGIN {
 	tolower(tmp);
 
 	if (PAT ~ tmp) {
+		if ("CPPFLAGS" == MODE)
+			printf "-D%s ",toupper(PAT);
 		if ($2 != "+")
 			PAT=$2;
                 for (i = 3; i <= NF; i = i + 1) {
@@ -67,9 +70,7 @@ BEGIN {
 		else{
 			subfamily = family;
 			family = PAT;
-	                if ("CPPFLAGS" == MODE)
-				printf "-D%s ",toupper(PAT);
-			else if("DEFS" == MODE)
+	                if("DEFS" == MODE)
 				printf "-D%s ",toupper(PAT);
 		}
 	}

--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -58,10 +58,6 @@ BEGIN {
 				if ("DEFS" ~ MODE)
 					printf "-D_%s ",$i;
 			}
-			if ($i ~ /[[:upper:]]*=/) {
-				if ("VARS" ~ MODE)
-				printf "%s ",$i;
-			}
 		}
 		if (PAT=="END"){
 			if ("FAMILY" ~ MODE)

--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -39,27 +39,44 @@ BEGIN {
 	if (PAT ~ tmp) {
 		if ($2 != "+")
 			PAT=$2;
-
-		for (i = 3; i <= NF; i = i + 1) {
-			if ($i ~ /^-l/) {
-				if ("LIB" ~ MODE)
-					printf "%s ",$i;
+                for (i = 3; i <= NF; i = i + 1) {
+			if ($i ~ /^CPU=/) {
+				if ("CPU" ~ MODE){
+					sub(/[^=]*=/,"",$i);
+					printf "%s",$i;
+					exit;
+				}
 			}
-			else if ($i ~ /^-m/) {
-				if ("ARCH" ~ MODE)
-					printf "%s ",$i;
+			else if ($i ~ /^FPU=/) {
+				if ("FPU" ~ MODE){
+					sub(/[^=]*=/,"",$i);
+					printf "%s",$i;
+					exit;
+				}
 			}
-			else if ($i ~ /^-D/) {
-				if ("DEFS" ~ MODE)
-					printf "%s ",$i;
-			}
-			else {
+			else if ($i ~ /[[:upper:]]*=/) {
 				if ("DEFS" ~ MODE)
 					printf "-D_%s ",$i;
 			}
+			if ($i ~ /[[:upper:]]*=/) {
+				if ("VARS" ~ MODE)
+				printf "%s ",$i;
+			}
 		}
-
-		if (PAT=="END")
+		if (PAT=="END"){
+			if ("FAMILY" ~ MODE)
+				printf "%s",family;
+			else if ("SUBFAMILY" ~ MODE)
+				printf "%s",subfamily;
 			exit;
+		}
+		else{
+			subfamily = family;
+			family = PAT;
+	                if ("CPPFLAGS" ~ MODE)
+				printf "-D%s ",toupper(PAT);
+			else if("DEFS" ~ MODE)
+				printf "-D%s ",toupper(PAT);
+		}
 	}
 }


### PR DESCRIPTION
As discussed with karlp on irc the devices.data file should not contain
gcc specific command line options.

For that reason the command line options for gcc are now generated from
the variables FAMILY,CPU,FPU by the rules in the mk directory.

This breaks the genlink tests.