### PR TITLE
add common STM32 documentation to STM32F1

### DIFF
--- a/doc/stm32f1/Doxyfile
+++ b/doc/stm32f1/Doxyfile
@@ -27,8 +27,7 @@ EXCLUDE                = ../../include/libopencm3/stm32/f1/usb.h \
                          ../../include/libopencm3/stm32/common/crs_common_all.h
 
 EXCLUDE	+=	../../lib/stm32/common/crs_common_all.c \
-		../../lib/stm32/common/rtc_common_l1f024.c \
-		../../lib/stm32/common/
+		../../lib/stm32/common/rtc_common_l1f024.c
 
 EXCLUDE_PATTERNS       = *_common_*f24.h *_common_*f24.c \
                          *_common_*f234.h *_common_*f234.c \


### PR DESCRIPTION
The common STM32 functions are missing in the documentation for the STM32F1.
They were excluded is the Doxygen configuration.
This exclusion is hereby removed.