### PR TITLE
Support CAN on stm32f0

### DIFF
--- a/lib/stm32/common/can_common_all.c
+++ b/lib/stm32/common/can_common_all.c
@@ -36,16 +36,7 @@ LGPL License Terms @ref lgpl_license
  */
 
 #include <libopencm3/stm32/can.h>
-
-#if defined(STM32F1)
-#	include <libopencm3/stm32/f1/rcc.h>
-#elif defined(STM32F2)
-#	include <libopencm3/stm32/f2/rcc.h>
-#elif defined(STM32F4)
-#	include <libopencm3/stm32/f4/rcc.h>
-#else
-#	error "stm32 family not defined."
-#endif
+#include <libopencm3/stm32/rcc.h>
 
 /* Timeout for CAN INIT acknowledge
  * this value is difficult to define.

--- a/lib/stm32/common/can_common_all.c
+++ b/lib/stm32/common/can_common_all.c
@@ -62,6 +62,12 @@ can_reg_base.
  */
 void can_reset(uint32_t canport)
 {
+#if defined(STM32F0)
+	(void) canport;
+
+	rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CANRST);
+	rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CANRST);
+#else
 	if (canport == CAN1) {
 		rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN1RST);
 		rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN1RST);
@@ -69,6 +75,7 @@ void can_reset(uint32_t canport)
 		rcc_peripheral_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN2RST);
 		rcc_peripheral_clear_reset(&RCC_APB1RSTR, RCC_APB1RSTR_CAN2RST);
 	}
+#endif
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -42,7 +42,7 @@ OBJS            += gpio_common_all.o gpio_common_f0234.o crc_common_all.o \
                    pwr_common_all.o iwdg_common_all.o rtc_common_l1f024.o \
                    dma_common_l1f013.o exti_common_all.o spi_common_all.o \
 		   spi_common_f03.o flash_common_f01.o dac_common_all.o \
-		   timer_common_all.o rcc_common_all.o
+		   timer_common_all.o rcc_common_all.o can_common_all.o
 OBJS		+= crs_common_all.o
 
 OBJS		+= usb.o usb_control.o usb_standard.o

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -35,7 +35,7 @@ TGT_CFLAGS      += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
 
-OBJS		= adc.o adc_common_v1.o can.o desig.o ethernet.o flash.o gpio.o \
+OBJS		= adc.o adc_common_v1.o desig.o ethernet.o flash.o gpio.o \
                   rcc.o rtc.o timer.o
 OBJS		+= mac.o mac_stm32fxx7.o phy.o phy_ksz8051mll.o
 
@@ -43,7 +43,7 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_l1f013.o \
                    gpio_common_all.o i2c_common_all.o iwdg_common_all.o \
                    pwr_common_all.o spi_common_all.o spi_common_l1f124.o \
                    timer_common_all.o usart_common_all.o usart_common_f124.o \
-                   rcc_common_all.o exti_common_all.o \
+                   rcc_common_all.o exti_common_all.o can_common_all.o \
                    flash_common_f01.o
 
 OBJS            += usb.o usb_control.o usb_standard.o usb_msc.o

--- a/lib/stm32/f4/Makefile
+++ b/lib/stm32/f4/Makefile
@@ -38,7 +38,7 @@ TGT_CFLAGS      += $(DEBUG_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
 
-OBJS		= adc.o adc_common_v1.o can.o desig.o gpio.o pwr.o rcc.o \
+OBJS		= adc.o adc_common_v1.o desig.o gpio.o pwr.o rcc.o \
 		  rtc.o crypto.o
 
 OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
@@ -48,7 +48,7 @@ OBJS            += crc_common_all.o dac_common_all.o dma_common_f24.o \
                    timer_common_f234.o timer_common_f24.o usart_common_all.o \
 		   usart_common_f124.o flash_common_f234.o flash_common_f24.o \
 		   hash_common_f24.o crypto_common_f24.o exti_common_all.o \
-		   rcc_common_all.o
+		   rcc_common_all.o can_common_all.o
 
 OBJS            += usb.o usb_standard.o usb_control.o usb_fx07_common.o \
 		   usb_f107.o usb_f207.o usb_msc.o


### PR DESCRIPTION
The stm32f0 family contains a bxCAN-controller which is compatible with the already existing code. The same seems to go for all other STM32 families, but I haven't been able to check that in detail.

This pull request moves the CAN code to the common/ hierarchy and enables it for the f0 build.