### PR TITLE
STM32 desig.c cleanup and Arch ARM GCC 5.3.0 bug workaround

### DIFF
--- a/include/libopencm3/stm32/desig.h
+++ b/include/libopencm3/stm32/desig.h
@@ -41,7 +41,7 @@ uint16_t desig_get_flash_size(void);
  * Note: ST specifies that bits 31..16 are _also_ reserved for future use
  * @param result pointer to at least 3xuint32_ts (96 bits)
  */
-void desig_get_unique_id(uint32_t result[]);
+void desig_get_unique_id(uint32_t *result);
 
 /**
  * Read the full 96 bit unique identifier and return it as a

--- a/lib/stm32/desig.c
+++ b/lib/stm32/desig.c
@@ -24,25 +24,26 @@ uint16_t desig_get_flash_size(void)
 	return DESIG_FLASH_SIZE;
 }
 
-void desig_get_unique_id(uint32_t result[])
+void desig_get_unique_id(uint32_t *result)
 {
-	result[0] = DESIG_UNIQUE_ID2;
-	result[1] = DESIG_UNIQUE_ID1;
-	result[2] = DESIG_UNIQUE_ID0;
+	*result++ = DESIG_UNIQUE_ID2;
+	*result++ = DESIG_UNIQUE_ID1;
+	*result = DESIG_UNIQUE_ID0;
 }
 
 void desig_get_unique_id_as_string(char *string,
 				   unsigned int string_len)
 {
 	int i, len;
-	uint8_t device_id[12];
-	static const char chars[] = "0123456789ABCDEF";
+	uint32_t dev_id_buf[3];
+	uint8_t *device_id = (uint8_t*)dev_id_buf;
+	const char chars[] = "0123456789ABCDEF";
 
-	desig_get_unique_id((uint32_t *)device_id);
+	desig_get_unique_id(dev_id_buf);
 
 	/* Each byte produces two characters */
-	len = (2 * sizeof(device_id) < string_len) ?
-		2 * sizeof(device_id) : string_len - 1;
+	len = (2 * sizeof(dev_id_buf) < string_len) ?
+		2 * sizeof(dev_id_buf) : string_len - 1;
 
 	for (i = 0; i < len; i += 2) {
 		string[i]     = chars[(device_id[i / 2] >> 4) & 0x0F];


### PR DESCRIPTION
This is a take it or close it kind of thing, but I'm just documenting what I had to do to get on with my stuff.

The archlinux arm gcc gives a "internal compiler error: in expand_expr_addr_expr_1, at expr.c:7736"
with that array version :(