### PR TITLE
stm32f7: fix build failure when CFLAGS is set

### DIFF
--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -29,7 +29,7 @@ AR		= $(PREFIX)-ar
 # STM32F7 only supports single precision FPU
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
 
-CFLAGS		= -Os -g \
+TGT_CFLAGS	= -Os -g \
 		  -Wall -Wextra -Wimplicit-function-declaration \
 		  -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wundef -Wshadow \


### PR DESCRIPTION
The Makefile for the stm32f7 library still used CFLAGS instead of TGT_CFLAGS, leading to a build failure when passing CFLAGS as a make option.