### PR TITLE
stm32-f7: check for binutils version

### DIFF
--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -58,14 +58,14 @@ Please use gcc-arm-embedded 4.8 2014q3 or newer. Skipping this sub-library.
 endef
 
 define MISSING_CPU2
-Your toolchain doesn't support -mcpu=cortex-m7.
-Please use binutils 2.26 or newer. Skipping this sub-library.
+Your toolchain doesn't support -mcpu=cortex-m7 because of a mismatch between
+gcc-arm-none-eabi and binutils-arm-none-eabi. You should report this bug to
+your distribution. It may be bug 1568437.
+Please use binutils 2.26 or newer. Not continuing.
 endef
 
 ifneq ($(shell $(CC) --help=target | grep -q '\<cortex-m7\>'; echo $$?),0)
   $(warning $(MISSING_CPU))
-else ifeq ($(shell $(AS) --version | grep -q '\<2.25\>'; echo $$?),0)
-  $(warning $(MISSING_CPU2))
 
 all clean:
 	@true
@@ -74,5 +74,11 @@ $(SRCLIBDIR)/$(LIBNAME).a:
 	@true
 
 else
+
+ifeq ($(shell $(AS) --version | grep -q '\<2.25\>'; echo $$?),0)
+  $(error $(MISSING_CPU2))
+
+else
   include ../../Makefile.include
+endif
 endif

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -25,7 +25,6 @@ PREFIX		?= arm-none-eabi
 
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
-AS		= $(PREFIX)-as
 
 # STM32F7 only supports single precision FPU
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
@@ -75,7 +74,7 @@ $(SRCLIBDIR)/$(LIBNAME).a:
 
 else
 
-ifeq ($(shell $(AS) --version | grep -q '\<2.25\>'; echo $$?),0)
+ifeq ($(shell $(AR) --version | grep -q '\<2.25\>'; echo $$?),0)
   $(error $(MISSING_CPU2))
 
 else

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -25,6 +25,7 @@ PREFIX		?= arm-none-eabi
 
 CC		= $(PREFIX)-gcc
 AR		= $(PREFIX)-ar
+AS		= $(PREFIX)-as
 
 # STM32F7 only supports single precision FPU
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
@@ -56,8 +57,15 @@ Your toolchain doesn't support -mcpu=cortex-m7.
 Please use gcc-arm-embedded 4.8 2014q3 or newer. Skipping this sub-library.
 endef
 
+define MISSING_CPU2
+Your toolchain doesn't support -mcpu=cortex-m7.
+Please use binutils 2.26 or newer. Skipping this sub-library.
+endef
+
 ifneq ($(shell $(CC) --help=target | grep -q '\<cortex-m7\>'; echo $$?),0)
   $(warning $(MISSING_CPU))
+else ifeq ($(shell $(AS) --version | grep -q '\<2.25\>'; echo $$?),0)
+  $(warning $(MISSING_CPU2))
 
 all clean:
 	@true


### PR DESCRIPTION
on ubuntu systems a gcc version that supports cortex-m7 may
be paired with binutils 2.25, which does not. Hopefully
nobody still has an even earlier version...

Fixes https://github.com/libopencm3/libopencm3/issues/649
