### PR TITLE
tests: gadget 0: added test for unaligned buffer read/writes.

### DIFF
--- a/tests/gadget-zero/usb-gadget0.c
+++ b/tests/gadget-zero/usb-gadget0.c
@@ -45,6 +45,8 @@
  */
 #define GZ_REQ_SET_PATTERN	1
 #define GZ_REQ_PRODUCE		2
+#define GZ_REQ_SET_ALIGNED	3
+#define GZ_REQ_SET_UNALIGNED	4
 #define INTEL_COMPLIANCE_WRITE 0x5b
 #define INTEL_COMPLIANCE_READ 0x5c
 
@@ -52,6 +54,7 @@
 #define GZ_CFG_SOURCESINK	2
 #define GZ_CFG_LOOPBACK		3
 
+#define BULK_EP_MAXPACKET	64
 
 static const struct usb_device_descriptor dev = {
 	.bLength = USB_DT_DEVICE_SIZE,
@@ -81,7 +84,7 @@ static const struct usb_endpoint_descriptor endp_bulk[] = {
 		.bDescriptorType = USB_DT_ENDPOINT,
 		.bEndpointAddress = 0x01,
 		.bmAttributes = USB_ENDPOINT_ATTR_BULK,
-		.wMaxPacketSize = 64,
+		.wMaxPacketSize = BULK_EP_MAXPACKET,
 		.bInterval = 1,
 	},
 	{
@@ -89,7 +92,7 @@ static const struct usb_endpoint_descriptor endp_bulk[] = {
 		.bDescriptorType = USB_DT_ENDPOINT,
 		.bEndpointAddress = 0x82,
 		.bmAttributes = USB_ENDPOINT_ATTR_BULK,
-		.wMaxPacketSize = 64,
+		.wMaxPacketSize = BULK_EP_MAXPACKET,
 		.bInterval = 1,
 	}
 };
@@ -176,42 +179,60 @@ static usbd_device *our_dev;
 static struct {
 	uint8_t pattern;
 	int pattern_counter;
+	int test_unaligned;	/* If 0 (default), use 16-bit aligned buffers. This should not be declared as bool */
 } state = {
 	.pattern = 0,
 	.pattern_counter = 0,
+	.test_unaligned = 0,
 };
 
 static void gadget0_ss_out_cb(usbd_device *usbd_dev, uint8_t ep)
 {
 	(void) ep;
+	uint16_t x;
 	/* TODO - if you're really keen, perf test this. tiva implies it matters */
 	/* char buf[64] __attribute__ ((aligned(4))); */
-	char buf[64];
+	uint8_t buf[BULK_EP_MAXPACKET + 1] __attribute__ ((aligned(2)));
+	uint8_t *dest;
+
 	trace_send_blocking8(0, 'O');
-	uint16_t x = usbd_ep_read_packet(usbd_dev, ep, buf, sizeof(buf));
+	if (state.test_unaligned) {
+		dest = buf + 1;
+	} else {
+		dest = buf;
+	}
+	x = usbd_ep_read_packet(usbd_dev, ep, dest, BULK_EP_MAXPACKET);
 	trace_send_blocking8(1, x);
 }
 
 static void gadget0_ss_in_cb(usbd_device *usbd_dev, uint8_t ep)
 {
 	(void) usbd_dev;
+	uint8_t buf[BULK_EP_MAXPACKET + 1] __attribute__ ((aligned(2)));
+	uint8_t *src;
+
 	trace_send_blocking8(0, 'I');
-	uint8_t buf[64];
+	if (state.test_unaligned) {
+		src = buf + 1;
+	} else {
+		src = buf;
+	}
+
 	switch (state.pattern) {
 	case 0:
-		memset(buf, 0, sizeof(buf));
+		memset(src, 0, BULK_EP_MAXPACKET);
 		break;
 	case 1:
-		for (unsigned i = 0; i < sizeof(buf); i++) {
-			buf[i] = state.pattern_counter++ % 63;
+		for (unsigned i = 0; i < BULK_EP_MAXPACKET; i++) {
+			src[i] = state.pattern_counter++ % 63;
 		}
 		break;
 	}
 
-	uint16_t x = usbd_ep_write_packet(usbd_dev, ep, buf, sizeof(buf));
+	uint16_t x = usbd_ep_write_packet(usbd_dev, ep, src, BULK_EP_MAXPACKET);
 	/* As we are calling write in the callback, this should never fail */
 	trace_send_blocking8(2, x);
-	if (x != sizeof(buf)) {
+	if (x != BULK_EP_MAXPACKET) {
 		ER_DPRINTF("failed to write?: %d\n", x);
 	}
 	/*assert(x == sizeof(buf));*/
@@ -255,6 +276,12 @@ static int gadget0_control_request(usbd_device *usbd_dev,
 	case INTEL_COMPLIANCE_READ:
 		ER_DPRINTF("unimplemented!");
 		return USBD_REQ_NOTSUPP;
+	case GZ_REQ_SET_UNALIGNED:
+		state.test_unaligned = 1;
+		return USBD_REQ_HANDLED;
+	case GZ_REQ_SET_ALIGNED:
+		state.test_unaligned = 0;
+		return USBD_REQ_HANDLED;
 	case GZ_REQ_PRODUCE:
 		ER_DPRINTF("fake loopback of %d\n", req->wValue);
 		if (req->wValue > sizeof(usbd_control_buffer)) {
@@ -279,6 +306,7 @@ static void gadget0_set_config(usbd_device *usbd_dev, uint16_t wValue)
 	ER_DPRINTF("set cfg %d\n", wValue);
 	switch (wValue) {
 	case GZ_CFG_SOURCESINK:
+		state.test_unaligned = 0;
 		usbd_ep_setup(usbd_dev, 0x01, USB_ENDPOINT_ATTR_BULK, 64,
 			gadget0_ss_out_cb);
 		usbd_ep_setup(usbd_dev, 0x82, USB_ENDPOINT_ATTR_BULK, 64,


### PR DESCRIPTION
[STATUS - this is ready to merge to the best of my knowledge]

This adds a test to the gadget0 framework to test unaligned vs aligned buffer access in the usb stack, and the corresponding fix.
Without the fix, this fails on stm32F072, which is expected (all F0 / L0 mcus should fail) but not normal. Note that once the unaligned test fails, the target is in HardFault and needs to be reset.

See issues #401, #460.

I am only able to test on a F072 target, it would be nice if someone could test on something other than F0* / L0*, for example F1 which should not exhibit the issue.

The fix is copied from Kuldeep's tree; I haven't modified the st_usbfs_copy_to_pm() function however,  since it's already a bytewise copy.