### PR TITLE
stm32: adc: Fix adc_power_off_async for already disabled adc

### DIFF
--- a/lib/stm32/common/adc_common_v2.c
+++ b/lib/stm32/common/adc_common_v2.c
@@ -116,7 +116,8 @@ void adc_power_off_async(uint32_t adc)
 		ADC_CR(adc) |= stops;
 		while (ADC_CR(adc) & checks);
 	}
-	ADC_CR(adc) |= ADC_CR_ADDIS;
+	if (ADC_CR(adc) & ADC_CR_ADEN)
+		ADC_CR(adc) |= ADC_CR_ADDIS;
 }
 
 /**


### PR DESCRIPTION
The ADDIS bit is only allowed to be set by software if the ADC is
already enabled (ADEN=1).

See page 259 of STM32F0x1/STM32F0x2/STM32F0x8 datasheet:
"Software is allowed to set ADDIS only when ADEN=1 and ADSTART=0 (which ensures that no
conversion is ongoing)"

ADSTART=0 is already ensured.

adc_power_off(..) without that fix lead to failing calibration with an already disabled ADC.

The example 

/examples/stm32/f0/stm32f0-discovery/adc/adc.c

is fixed by that as well. 


