### PR TITLE
Make scripts/genlink.awk compatible with mawk by quoting metachars

### DIFF
--- a/scripts/genlink.awk
+++ b/scripts/genlink.awk
@@ -31,9 +31,9 @@ BEGIN {
 	gsub(/\r$/,"");
 
 	tmp = "^"$1"$";
-	gsub(/?/, ".", tmp);
-	gsub(/*/, ".*", tmp);
-	gsub(/+/, ".+", tmp);
+	gsub(/[?]/, ".", tmp);
+	gsub(/[*]/, ".*", tmp);
+	gsub(/[+]/, ".+", tmp);
 	tolower(tmp);
 
 	if (PAT ~ tmp) {


### PR DESCRIPTION
Trying to build project with opencm3 on ubuntu fails on ld sctipt generation because of mawk:
```
$ awk -v PAT="${DEVICE}" -v MODE="DEFS" -f ${OPENCM3_DIR}/scripts/genlink.awk ${OPENCM3_DIR}/ld/devices.data
mawk: libopencm3/scripts/genlink.awk: line 34: regular expression compile failed (missing operand)
?
mawk: libopencm3/scripts/genlink.awk: line 35: regular expression compile failed (missing operand)
*
mawk: libopencm3/scripts/genlink.awk: line 36: regular expression compile failed (missing operand)
+

```

mawk is default awk on ubuntu