### PR TITLE
[cm3] reset that stm32-f4

### DIFF
--- a/lib/cm3/scb.c
+++ b/lib/cm3/scb.c
@@ -25,16 +25,22 @@
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
 void scb_reset_core(void)
 {
-	SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_VECTRESET;
-
+	__asm__ volatile ("dsb");
+	SCB->AIRCR  = (SCB_AIRCR_VECTKEY
+				| (SCB->AIRCR & SCB_AIRCR_PRIGROUP_MASK)
+				|  SCB_AIRCR_VECTRESET);
+	__asm__ volatile ("dsb");
 	while (1);
 }
 #endif
 
 void scb_reset_system(void)
 {
-	SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_SYSRESETREQ;
-
+	__asm__ volatile ("dsb");
+	SCB->AIRCR  = (SCB_AIRCR_VECTKEY
+				| (SCB->AIRCR & SCB_AIRCR_PRIGROUP_MASK)
+				|  SCB_AIRCR_SYSRESETREQ);
+	__asm__ volatile ("dsb");
 	while (1);
 }
 


### PR DESCRIPTION
i think preserving the priority-grouping allows a reset in the f4 cores.
i only tested scb_reset_core with exactly those lines and it worked.
this hopefully does not break any other implementation (positive thinking)