### PR TITLE
[cm3] reset that stm32-f4

### DIFF
--- a/lib/cm3/scb.c
+++ b/lib/cm3/scb.c
@@ -25,16 +25,26 @@
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
 void scb_reset_core(void)
 {
-	SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_VECTRESET;
-
+	__asm__ volatile ("dsb");
+	SCB_AIRCR = (SCB_AIRCR_VECTKEY
+#if defined(SCB_AIRCR_PRIGROUP_MASK)
+			  | (SCB_AIRCR & SCB_AIRCR_PRIGROUP_MASK)
+#endif
+			  |  SCB_AIRCR_VECTRESET);
+	__asm__ volatile ("dsb");
 	while (1);
 }
 #endif
 
 void scb_reset_system(void)
 {
-	SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_SYSRESETREQ;
-
+	__asm__ volatile ("dsb");
+	SCB_AIRCR  = (SCB_AIRCR_VECTKEY
+#if defined(SCB_AIRCR_PRIGROUP_MASK)
+			   | (SCB_AIRCR & SCB_AIRCR_PRIGROUP_MASK)
+#endif
+			   |  SCB_AIRCR_SYSRESETREQ);
+	__asm__ volatile ("dsb");
 	while (1);
 }
 


### PR DESCRIPTION
this fix addresses what was discussed in this old thread [[libopencm3-devel] system reset?](https://sourceforge.net/p/libopencm3/mailman/libopencm3-devel/thread/CAHTjPirViWhJud35%2BM6VyUKxV5TrG1E1Nt24uPT3LLj6EFXUAw%40mail.gmail.com/#msg31887448)

FIXES
- changing the priority grouping in the SCB_AIRCR register along with setting the the SYSRESETREQ flag keeps the cpu from resetting
- the additional dsb instruction synchronises the memory accesses before/during the system reset
- __i did not test this for VECTRESET but assumed it would be the same__