### PR TITLE
STM32F2: make control usb stack more robust.

### DIFF
--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -262,7 +262,7 @@ void _usbd_control_out(usbd_device *usbd_dev, uint8_t ea)
 		 */
 		if (usb_control_request_dispatch(usbd_dev,
 					&(usbd_dev->control_state.req))) {
-			/* Got to status stage on success. */
+			/* Go to status stage on success. */
 			usbd_ep_write_packet(usbd_dev, 0, NULL, 0);
 			usbd_dev->control_state.state = STATUS_IN;
 		} else {

--- a/tests/gadget-zero/test_gadget0.py
+++ b/tests/gadget-zero/test_gadget0.py
@@ -233,7 +233,8 @@ class TestControlTransfer_Reads(unittest.TestCase):
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
         self.assertIsNotNone(self.cfg, "Config 2 should exist")
         self.dev.set_configuration(self.cfg);
-        self.req = uu.CTRL_IN | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
+        self.req     = uu.CTRL_IN  | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
+        self.req_out = uu.CTRL_OUT | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
 
     def inner_t(self, wVal, read_len):
         wVal = int(wVal)
@@ -265,6 +266,25 @@ class TestControlTransfer_Reads(unittest.TestCase):
         inner(ep0_size - 7)
         inner(ep0_size + 11)
         inner(ep0_size * 4 + 11)
+
+    def test_loopback(self) :
+        """
+        Can we request x control in when we tell the device to produce x?
+        :return:
+        """
+        def inner(x):
+            x = int(x)
+            buf_out = array.array('b')
+            for i in range(0,x) : buf_out.append(48 + (x+i) % 10)
+            self.dev.ctrl_transfer(self.req_out, 10, 0, 0, buf_out)
+            buf_in = self.dev.ctrl_transfer(self.req, 11, 0, 0, x)
+            self.assertEqual(len(buf_in), x,  "Should have read as much as we asked for")
+            self.assertEqual(buf_in, buf_out,
+                             "Buffers don't match!\n - buf_out : %r\n - buf_in  : %r" %(
+                             buf_out.tostring(), buf_in.tostring()))
+        
+        ep0_size = self.dev.bMaxPacketSize0
+        for i in range(4, ep0_size) : inner(i)
 
     def test_waytoobig(self):
         """
@@ -369,3 +389,7 @@ class TestUnaligned(unittest.TestCase):
     def test_unaligned(self):
         self.set_unaligned()
         self.do_readwrite()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/gadget-zero/test_gadget0.py
+++ b/tests/gadget-zero/test_gadget0.py
@@ -6,12 +6,22 @@ import logging
 
 import unittest
 
+VENDOR_ID=0xcafe
+PRODUCT_ID=0xcafe
+
 #DUT_SERIAL = "stm32f429i-disco"
 DUT_SERIAL = "stm32f4disco"
 #DUT_SERIAL = "stm32f103-generic"
 #DUT_SERIAL = "stm32l1-generic"
 #DUT_SERIAL = "stm32f072disco"
 #DUT_SERIAL = "stm32l053disco"
+
+GZ_REQ_SET_PATTERN=1
+GZ_REQ_PRODUCE=2
+GZ_REQ_SET_ALIGNED=3
+GZ_REQ_SET_UNALIGNED=4
+GZ_REQ_WRITE_LOOPBACK_BUFFER=10
+GZ_REQ_READ_LOOPBACK_BUFFER=11
 
 class find_by_serial(object):
     def __init__(self, serial):
@@ -25,7 +35,7 @@ class TestGadget0(unittest.TestCase):
     # TODO - parameterize this with serial numbers so we can find
     # gadget 0 code for different devices.  (or use different PIDs?)
     def setUp(self):
-        self.dev = usb.core.find(idVendor=0xcafe, idProduct=0xcafe, custom_match=find_by_serial(DUT_SERIAL))
+        self.dev = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID, custom_match=find_by_serial(DUT_SERIAL))
         self.assertIsNotNone(self.dev, "Couldn't find locm3 gadget0 device")
         self.longMessage = True
 
@@ -77,7 +87,7 @@ class TestConfigSourceSink(unittest.TestCase):
     """
 
     def setUp(self):
-        self.dev = usb.core.find(idVendor=0xcafe, idProduct=0xcafe, custom_match=find_by_serial(DUT_SERIAL))
+        self.dev = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID, custom_match=find_by_serial(DUT_SERIAL))
         self.assertIsNotNone(self.dev, "Couldn't find locm3 gadget0 device")
 
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
@@ -121,7 +131,7 @@ class TestConfigSourceSink(unittest.TestCase):
             self.assertEqual(written, len(data), "should have written all bytes plz")
 
     def test_read_zeros(self):
-        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, 0x1, 0)
+        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, GZ_REQ_SET_PATTERN, 0)
         self.ep_in.read(self.ep_in.wMaxPacketSize)  # Clear out any prior pattern data
         # unless, you know _exactly_ how much will be written by the device, always read
         # an integer multiple of max packet size, to avoid overflows.
@@ -136,9 +146,9 @@ class TestConfigSourceSink(unittest.TestCase):
     def test_read_sequence(self):
         # switching to the mod63 pattern requires resynching carefully to read out any zero frames already
         # queued, but still make sure we start the sequence at zero.
-        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, 0x1, 1)
+        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, GZ_REQ_SET_PATTERN, 1)
         self.ep_in.read(self.ep_in.wMaxPacketSize)  # Potentially queued zeros, or would have been safe.
-        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, 0x1, 1)
+        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, GZ_REQ_SET_PATTERN, 1)
         self.ep_in.read(self.ep_in.wMaxPacketSize)  # definitely right pattern now, but need to restart at zero.
         read_size = self.ep_in.wMaxPacketSize * 3
         data = self.dev.read(self.ep_in, read_size)
@@ -155,10 +165,10 @@ class TestConfigSourceSink(unittest.TestCase):
             self.assertEqual(oo, len(dd), "should have written full packet")
 
     def test_control_known(self):
-        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, 0x1, 0)
-        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, 0x1, 1)
-        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, 0x1, 99)
-        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, 0x1, 0)
+        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, GZ_REQ_SET_PATTERN, 0)
+        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, GZ_REQ_SET_PATTERN, 1)
+        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, GZ_REQ_SET_PATTERN, 99)
+        self.dev.ctrl_transfer(uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE, GZ_REQ_SET_PATTERN, 0)
 
     def test_control_unknown(self):
         try:
@@ -176,7 +186,7 @@ class TestConfigSourceSinkPerformance(unittest.TestCase):
     """
 
     def setUp(self):
-        self.dev = usb.core.find(idVendor=0xcafe, idProduct=0xcafe, custom_match=find_by_serial(DUT_SERIAL))
+        self.dev = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID, custom_match=find_by_serial(DUT_SERIAL))
         self.assertIsNotNone(self.dev, "Couldn't find locm3 gadget0 device")
 
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
@@ -227,7 +237,7 @@ class TestControlTransfer_Reads(unittest.TestCase):
     """
 
     def setUp(self):
-        self.dev = usb.core.find(idVendor=0xcafe, idProduct=0xcafe, custom_match=find_by_serial(DUT_SERIAL))
+        self.dev = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID, custom_match=find_by_serial(DUT_SERIAL))
         self.assertIsNotNone(self.dev, "Couldn't find locm3 gadget0 device")
 
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
@@ -239,14 +249,14 @@ class TestControlTransfer_Reads(unittest.TestCase):
     def inner_t(self, wVal, read_len):
         wVal = int(wVal)
         read_len = int(read_len)
-        q = self.dev.ctrl_transfer(self.req, 2, wVal, 0, read_len)
+        q = self.dev.ctrl_transfer(self.req, GZ_REQ_PRODUCE, wVal, 0, read_len)
         self.assertEqual(len(q), wVal, "Should have read as much as we asked for?")
 
     def tearDown(self):
         uu.dispose_resources(self.dev)
 
     def test_basic(self):
-        x = self.dev.ctrl_transfer(self.req, 2, 32, 0, 32)
+        x = self.dev.ctrl_transfer(self.req, GZ_REQ_PRODUCE, 32, 0, 32)
         self.assertEqual(32, len(x))
 
     def test_matching_sizes(self):
@@ -256,7 +266,7 @@ class TestControlTransfer_Reads(unittest.TestCase):
         """
         def inner(x):
             x = int(x)
-            q = self.dev.ctrl_transfer(self.req, 2, x, 0, x)
+            q = self.dev.ctrl_transfer(self.req, GZ_REQ_PRODUCE, x, 0, x)
             self.assertEqual(len(q), x, "Should have read as much as we asked for")
 
         ep0_size = self.dev.bMaxPacketSize0
@@ -276,8 +286,8 @@ class TestControlTransfer_Reads(unittest.TestCase):
             x = int(x)
             buf_out = array.array('b')
             for i in range(0,x) : buf_out.append(48 + (x+i) % 10)
-            self.dev.ctrl_transfer(self.req_out, 10, 0, 0, buf_out)
-            buf_in = self.dev.ctrl_transfer(self.req, 11, 0, 0, x)
+            self.dev.ctrl_transfer(self.req_out, GZ_REQ_WRITE_LOOPBACK_BUFFER, 0, 0, buf_out)
+            buf_in = self.dev.ctrl_transfer(self.req, GZ_REQ_READ_LOOPBACK_BUFFER, 0, 0, x)
             self.assertEqual(len(buf_in), x,  "Should have read as much as we asked for")
             self.assertEqual(buf_in, buf_out,
                              "Buffers don't match!\n - buf_out : %r\n - buf_in  : %r" %(
@@ -292,7 +302,7 @@ class TestControlTransfer_Reads(unittest.TestCase):
         (Don't make them too, big, or libusb will reject you outright, see MAX_CTRL_BUFFER_LENGTH in libusb sources)
         """
         try:
-            self.dev.ctrl_transfer(self.req, 2, 10 * self.dev.bMaxPacketSize0, 0, 10 * self.dev.bMaxPacketSize0)
+            self.dev.ctrl_transfer(self.req, GZ_REQ_PRODUCE, 10 * self.dev.bMaxPacketSize0, 0, 10 * self.dev.bMaxPacketSize0)
             self.fail("Should have got a stall")
         except usb.core.USBError as e:
             # Note, this might not be as portable as we'd like.
@@ -334,7 +344,7 @@ class TestControlTransfer_Reads(unittest.TestCase):
         tell the device to produce more than we ask for.
         Note, this doesn't test the usb stack, it tests the application code behaves.
         """
-        q = self.dev.ctrl_transfer(self.req, 2, 100, 0, 10)
+        q = self.dev.ctrl_transfer(self.req, GZ_REQ_PRODUCE, 100, 0, 10)
         self.assertEqual(len(q), 10, "In this case, should have gotten wLen back")
 
 
@@ -347,7 +357,7 @@ class TestUnaligned(unittest.TestCase):
     """
 
     def setUp(self):
-        self.dev = usb.core.find(idVendor=0xcafe, idProduct=0xcafe, custom_match=find_by_serial(DUT_SERIAL))
+        self.dev = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID, custom_match=find_by_serial(DUT_SERIAL))
         self.assertIsNotNone(self.dev, "Couldn't find locm3 gadget0 device")
 
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
@@ -364,11 +374,11 @@ class TestUnaligned(unittest.TestCase):
 
     def set_unaligned(self):
         # GZ_REQ_SET_UNALIGNED
-        x = self.dev.ctrl_transfer(self.req, 4, 0, 0)
+        x = self.dev.ctrl_transfer(self.req, GZ_REQ_SET_UNALIGNED, 0, 0)
 
     def set_aligned(self):
         # GZ_REQ_SET_ALIGNED
-        x = self.dev.ctrl_transfer(self.req, 3, 0, 0)
+        x = self.dev.ctrl_transfer(self.req, GZ_REQ_SET_ALIGNED, 0, 0)
 
     def do_readwrite(self):
         """

--- a/tests/gadget-zero/test_gadget0.py
+++ b/tests/gadget-zero/test_gadget0.py
@@ -191,7 +191,7 @@ class TestConfigSourceSinkPerformance(unittest.TestCase):
 
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
         self.assertIsNotNone(self.cfg, "Config 2 should exist")
-        self.dev.set_configuration(self.cfg);
+        self.dev.set_configuration(self.cfg)
         self.intf = self.cfg[(0, 0)]
         # heh, kinda gross...
         self.ep_out = [ep for ep in self.intf if uu.endpoint_direction(ep.bEndpointAddress) == uu.ENDPOINT_OUT][0]
@@ -242,7 +242,7 @@ class TestControlTransfer_Reads(unittest.TestCase):
 
         self.cfg = uu.find_descriptor(self.dev, bConfigurationValue=2)
         self.assertIsNotNone(self.cfg, "Config 2 should exist")
-        self.dev.set_configuration(self.cfg);
+        self.dev.set_configuration(self.cfg)
         self.req     = uu.CTRL_IN  | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
         self.req_out = uu.CTRL_OUT | uu.CTRL_TYPE_VENDOR | uu.CTRL_RECIPIENT_INTERFACE
 

--- a/tests/gadget-zero/usb-gadget0.c
+++ b/tests/gadget-zero/usb-gadget0.c
@@ -52,11 +52,15 @@
 #define INTEL_COMPLIANCE_WRITE 0x5b
 #define INTEL_COMPLIANCE_READ 0x5c
 
+#define GZ_INTR_CMD_DELAY	0
+
 /* USB configurations */
 #define GZ_CFG_SOURCESINK	2
 #define GZ_CFG_LOOPBACK		3
+#define GZ_CFG_INTERRUPT	4
 
 #define BULK_EP_MAXPACKET	64
+#define INTERRUPT_EP_MAXPACKET	64
 
 static const struct usb_device_descriptor dev = {
 	.bLength = USB_DT_DEVICE_SIZE,
@@ -77,7 +81,7 @@ static const struct usb_device_descriptor dev = {
 	.iManufacturer = 1,
 	.iProduct = 2,
 	.iSerialNumber = 3,
-	.bNumConfigurations = 2,
+	.bNumConfigurations = 3,
 };
 
 static const struct usb_endpoint_descriptor endp_bulk[] = {
@@ -95,6 +99,25 @@ static const struct usb_endpoint_descriptor endp_bulk[] = {
 		.bEndpointAddress = 0x82,
 		.bmAttributes = USB_ENDPOINT_ATTR_BULK,
 		.wMaxPacketSize = BULK_EP_MAXPACKET,
+		.bInterval = 1,
+	}
+};
+
+static const struct usb_endpoint_descriptor endp_interrupt[] = {
+	{
+		.bLength = USB_DT_ENDPOINT_SIZE,
+		.bDescriptorType = USB_DT_ENDPOINT,
+		.bEndpointAddress = 0x01,
+		.bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
+		.wMaxPacketSize = INTERRUPT_EP_MAXPACKET,
+		.bInterval = 1,
+	},
+	{
+		.bLength = USB_DT_ENDPOINT_SIZE,
+		.bDescriptorType = USB_DT_ENDPOINT,
+		.bEndpointAddress = 0x81,
+		.bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
+		.wMaxPacketSize = INTERRUPT_EP_MAXPACKET,
 		.bInterval = 1,
 	}
 };
@@ -125,6 +148,19 @@ static const struct usb_interface_descriptor iface_loopback[] = {
 	}
 };
 
+static const struct usb_interface_descriptor iface_interrupt[] = {
+	{
+		.bLength = USB_DT_INTERFACE_SIZE,
+		.bDescriptorType = USB_DT_INTERFACE,
+		.bInterfaceNumber = 0,
+		.bAlternateSetting = 0,
+		.bNumEndpoints = 2,
+		.bInterfaceClass = USB_CLASS_VENDOR,
+		.iInterface = 0,
+		.endpoint = endp_interrupt,
+	}
+};
+
 static const struct usb_interface ifaces_sourcesink[] = {
 	{
 		.num_altsetting = 1,
@@ -136,6 +172,13 @@ static const struct usb_interface ifaces_loopback[] = {
 	{
 		.num_altsetting = 1,
 		.altsetting = iface_loopback,
+	}
+};
+
+static const struct usb_interface ifaces_interrupt[] = {
+	{
+		.num_altsetting = 1,
+		.altsetting = iface_interrupt,
 	}
 };
 
@@ -161,6 +204,17 @@ static const struct usb_config_descriptor config[] = {
 		.bmAttributes = 0x80,
 		.bMaxPower = 0x32,
 		.interface = ifaces_loopback,
+	},
+	{
+		.bLength = USB_DT_CONFIGURATION_SIZE,
+		.bDescriptorType = USB_DT_CONFIGURATION,
+		.wTotalLength = 0,
+		.bNumInterfaces = 1,
+		.bConfigurationValue = GZ_CFG_INTERRUPT,
+		.iConfiguration = 6, /* string index */
+		.bmAttributes = 0x80,
+		.bMaxPower = 0x32,
+		.interface = ifaces_interrupt,
 	}
 };
 
@@ -170,7 +224,8 @@ static const char *usb_strings[] = {
 	"Gadget-Zero",
 	serial,
 	"source and sink data",
-	"loop input to output"
+	"loop input to output",
+	"interrupt"
 };
 
 /* Buffer to be used for control requests. */
@@ -252,6 +307,29 @@ static void gadget0_tx_cb_loopback(usbd_device *usbd_dev, uint8_t ep)
 	(void) usbd_dev;
 	ER_DPRINTF("loop tx %x\n", ep);
 	/* TODO - unimplemented - consult linux source on proper behaviour */
+}
+
+static void gadget0_rx_cb_interrupt(usbd_device *usbd_dev, uint8_t ep)
+{
+	static uint8_t buf[INTERRUPT_EP_MAXPACKET];
+	int len = usbd_ep_read_packet(usbd_dev, ep, buf, INTERRUPT_EP_MAXPACKET);
+	uint32_t delay;
+
+	ER_DPRINTF("interrupt rx %x %d\n", ep, len);
+
+	if (len == 0)
+		return;
+	switch (buf[0]) {
+	case GZ_INTR_CMD_DELAY:
+		if (len < 5) {
+			return;
+		}
+		memcpy(&delay, buf+1, sizeof(uint32_t));
+		while (delay--) {
+			__asm__ ("nop");
+		}
+		ER_DPRINTF("delayed\n");
+	}
 }
 
 static int gadget0_control_request(usbd_device *usbd_dev,
@@ -347,6 +425,16 @@ static void gadget0_set_config(usbd_device *usbd_dev, uint16_t wValue)
 		usbd_ep_setup(usbd_dev, 0x82, USB_ENDPOINT_ATTR_BULK, BULK_EP_MAXPACKET,
 			gadget0_tx_cb_loopback);
 		break;
+	case GZ_CFG_INTERRUPT:
+		usbd_ep_setup(usbd_dev, 0x01, USB_ENDPOINT_ATTR_INTERRUPT, INTERRUPT_EP_MAXPACKET,
+			gadget0_rx_cb_interrupt);
+		usbd_ep_setup(usbd_dev, 0x81, USB_ENDPOINT_ATTR_INTERRUPT, INTERRUPT_EP_MAXPACKET, 0);
+		usbd_register_control_callback(
+			usbd_dev,
+			USB_REQ_TYPE_VENDOR | USB_REQ_TYPE_INTERFACE,
+			USB_REQ_TYPE_TYPE | USB_REQ_TYPE_RECIPIENT,
+			gadget0_control_request);
+		break;
 	default:
 		ER_DPRINTF("set configuration unknown: %d\n", wValue);
 	}
@@ -361,7 +449,7 @@ usbd_device *gadget0_init(const usbd_driver *driver, const char *userserial)
 		usb_strings[2] = userserial;
 	}
 	our_dev = usbd_init(driver, &dev, config,
-		usb_strings, 5,
+		usb_strings, 6,
 		usbd_control_buffer, sizeof(usbd_control_buffer));
 
 	usbd_register_set_config_callback(our_dev, gadget0_set_config);


### PR DESCRIPTION
These patches aim to fix the problems of #668.  There are 3 parts:
1. If we detect there is a packet in the TxFIFO (TSIZ0.pktcnt is not zero) when a SETUP is received, then this packet is discarded by flushing the FIFO.  It doesn't hurt, since the packet was definitely for a different request that is no longer requested.  It is necessary since otherwise the control port doesn't answer the new setup packet.
2. We first check for DIEPINT before checking for RXFLVL.  This is necessary, because the usb_control statemachine requires that we first call usb_control_in on setup_read transactions before calling usb_control_out.
3. We keep better track of rxbcnt (I didn't have the problem but we should fix it nonetheless).  I also removed the FIXME delay loop as I think it is no longer necessary.

I didn't implement the idea of not answering a SETUP packet if there is another SETUP in the queue.  The idea of @zyp (to poll but not pop GRXSTSR) does not work.  There is still the SETUP_DONE packet in the RXFIFO.  Also, I don't want to change to much.  So the current implementation will still answer the wrong SETUP packet in the case where usbd_poll is called after a timeout.
