### PR TITLE
STM32F1: RTC: rtc_awake_from_off() clears CR register incorrectly.

### DIFF
--- a/lib/stm32/f1/rtc.c
+++ b/lib/stm32/f1/rtc.c
@@ -96,10 +96,15 @@ void rtc_awake_from_off(enum rcc_osc clock_source)
 	/* Set the clock source */
 	rcc_set_rtc_clock_source(clock_source);
 
-	/* Clear the RTC Registers */
-	rtc_enter_config_mode();
+	/* Clear the RTC Control Register */
 	RTC_CRH = 0;
-	RTC_CRL = 0x20;
+	RTC_CRL = 0;
+
+	/* Enable the RTC. */
+	rcc_enable_rtc_clock();
+
+	/* Clear the Registers */
+	rtc_enter_config_mode();
 	RTC_PRLH = 0;
 	RTC_PRLL = 0;
 	RTC_CNTH = 0;
@@ -108,16 +113,9 @@ void rtc_awake_from_off(enum rcc_osc clock_source)
 	RTC_ALRL = 0xFFFF;
 	rtc_exit_config_mode();
 
-	/* Enable the RTC. */
-	rcc_enable_rtc_clock();
-
 	/* Wait for the RSF bit in RTC_CRL to be set by hardware. */
 	RTC_CRL &= ~RTC_CRL_RSF;
 	while ((reg32 = (RTC_CRL & RTC_CRL_RSF)) == 0);
-
-	/* Wait for the last write operation to finish. */
-	/* TODO: Necessary? */
-	while ((reg32 = (RTC_CRL & RTC_CRL_RTOFF)) == 0);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
It sets bit 5 (manual says "read only") and clears bit 4 which takes the RTC
out of config mode. The RTC registers are not cleared as a result.
Probably not necessary to clear any registers, but this at least will do it.
