### PR TITLE
stm32f4: USB support for STM32F446, STMF32469

### DIFF
--- a/include/libopencm3/stm32/otg_common.h
+++ b/include/libopencm3/stm32/otg_common.h
@@ -44,6 +44,7 @@
 #define OTG_HPTXFSIZ			0x100
 #define OTG_DIEPTXF(x)			(0x104 + 4*((x)-1))
 
+#define OTG_CID_HAS_VBDEN	0x00002000
 /* Host-mode Control and Status Registers */
 #define OTG_HCFG			0x400
 #define OTG_HFIR			0x404
@@ -219,9 +220,14 @@
 #define OTG_GRXSTSP_BCNT_MASK		(0x7ff << 4)
 #define OTG_GRXSTSP_EPNUM_MASK		(0xf << 0)
 
-/* OTG general core configuration register (OTG_GCCFG) */
+/* OTG general core configuration register (OTG_GCCFG)
+ * Depending on the usb core, some bits have different
+ * meanings e.g. NOVBUSSENS (STM32F427) and VBDEN
+ * (STM32F46STM32F469)
+ */
 /* Bits 31:22 - Reserved */
-#define OTG_GCCFG_NOVBUSSENS		(1 << 21)
+#define OTG_GCCFG_NOVBUSSENS	(1 << 21)
+#define OTG_GCCFG_VBDEN			(1 << 21)
 #define OTG_GCCFG_SOFOUTEN		(1 << 20)
 #define OTG_GCCFG_VBUSBSEN		(1 << 19)
 #define OTG_GCCFG_VBUSASEN		(1 << 18)

--- a/lib/usb/usb_f107.c
+++ b/lib/usb/usb_f107.c
@@ -52,11 +52,7 @@ const struct _usbd_driver stm32f107_usb_driver = {
 /** Initialize the USB device controller hardware of the STM32. */
 static usbd_device *stm32f107_usbd_init(void)
 {
-	OTG_FS_GINTSTS = OTG_GINTSTS_MMIS;
-
 	OTG_FS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;
-	/* Enable VBUS sensing in device mode and power down the PHY. */
-	OTG_FS_GCCFG |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
 
 	/* Wait for AHB idle. */
 	while (!(OTG_FS_GRSTCTL & OTG_GRSTCTL_AHBIDL));
@@ -64,8 +60,21 @@ static usbd_device *stm32f107_usbd_init(void)
 	OTG_FS_GRSTCTL |= OTG_GRSTCTL_CSRST;
 	while (OTG_FS_GRSTCTL & OTG_GRSTCTL_CSRST);
 
+	if (OTG_FS_CID == OTG_CID_HAS_VBDEN) {
+		/* Enable VBUS detection in device mode and power up the PHY. */
+		OTG_FS_GCCFG |= OTG_GCCFG_VBDEN | OTG_GCCFG_PWRDWN;
+		/* Set the Soft Connect (STMF32446, STMF32469 comes up disconnected) */
+		OTG_FS_DCTL &= ~OTG_DCTL_SDIS;
+	} else {
+		/* Enable VBUS sensing in device mode and power up the PHY. */
+		OTG_FS_GCCFG |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
+	}
+
+
 	/* Force peripheral only mode. */
 	OTG_FS_GUSBCFG |= OTG_GUSBCFG_FDMOD | OTG_GUSBCFG_TRDT_MASK;
+
+	OTG_FS_GINTSTS = OTG_GINTSTS_MMIS;
 
 	/* Full speed device. */
 	OTG_FS_DCFG |= OTG_DCFG_DSPD;

--- a/lib/usb/usb_f107.c
+++ b/lib/usb/usb_f107.c
@@ -60,7 +60,7 @@ static usbd_device *stm32f107_usbd_init(void)
 	OTG_FS_GRSTCTL |= OTG_GRSTCTL_CSRST;
 	while (OTG_FS_GRSTCTL & OTG_GRSTCTL_CSRST);
 
-	if (OTG_FS_CID == OTG_CID_HAS_VBDEN) {
+	if (OTG_FS_CID >= OTG_CID_HAS_VBDEN) {
 		/* Enable VBUS detection in device mode and power up the PHY. */
 		OTG_FS_GCCFG |= OTG_GCCFG_VBDEN | OTG_GCCFG_PWRDWN;
 		/* Set the Soft Connect (STMF32446, STMF32469 comes up disconnected) */


### PR DESCRIPTION
This supersedes https://github.com/libopencm3/libopencm3/pull/676 

This has been tested on STM32F469 and STM32F427
