### PR TITLE
stm32f4: rcc: fix setup of main system clock with pllp

### DIFF
--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -672,7 +672,7 @@ void rcc_set_main_pll_hsi(uint32_t pllm, uint32_t plln, uint32_t pllp,
 	RCC_PLLCFGR = 0 | /* HSI */
 		((pllm & RCC_PLLCFGR_PLLM_MASK) << RCC_PLLCFGR_PLLM_SHIFT) |
 		((plln & RCC_PLLCFGR_PLLN_MASK) << RCC_PLLCFGR_PLLN_SHIFT) |
-		((((pllp & RCC_PLLCFGR_PLLP_MASK) >> 1) - 1) << RCC_PLLCFGR_PLLP_SHIFT) |
+		((((pllp >> 1) - 1) & RCC_PLLCFGR_PLLP_MASK) << RCC_PLLCFGR_PLLP_SHIFT) |
 		((pllq & RCC_PLLCFGR_PLLQ_MASK) << RCC_PLLCFGR_PLLQ_SHIFT) |
 		((pllr & RCC_PLLCFGR_PLLR_MASK) << RCC_PLLCFGR_PLLR_SHIFT);
 }
@@ -696,7 +696,7 @@ void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 	RCC_PLLCFGR = RCC_PLLCFGR_PLLSRC | /* HSE */
 		((pllm & RCC_PLLCFGR_PLLM_MASK) << RCC_PLLCFGR_PLLM_SHIFT) |
 		((plln & RCC_PLLCFGR_PLLN_MASK) << RCC_PLLCFGR_PLLN_SHIFT) |
-		((((pllp & RCC_PLLCFGR_PLLP_MASK) >> 1) - 1) << RCC_PLLCFGR_PLLP_SHIFT) |
+		((((pllp >> 1) - 1) & RCC_PLLCFGR_PLLP_MASK) << RCC_PLLCFGR_PLLP_SHIFT) |
 		((pllq & RCC_PLLCFGR_PLLQ_MASK) << RCC_PLLCFGR_PLLQ_SHIFT) |
 		((pllr & RCC_PLLCFGR_PLLR_MASK) << RCC_PLLCFGR_PLLR_SHIFT);
 }


### PR DESCRIPTION
Fixes: 57c2b00a69f97205313e1c7ab8116ee1893b231e

There was an issue with the pllp value calculation where the masking was done
in the wrong place. The pllp value was always equivalent to 2 (the bits were
always set to 0b00) which could result in an undesired system clock frequency.