### PR TITLE
stm32f1: adc: standardize temperature sensor API

### DIFF
--- a/include/libopencm3/stm32/f1/adc.h
+++ b/include/libopencm3/stm32/f1/adc.h
@@ -407,8 +407,8 @@ BEGIN_DECLS
 
 void adc_start_conversion_direct(uint32_t adc);
 void adc_set_dual_mode(uint32_t mode);
-void adc_enable_temperature_sensor(uint32_t adc);
-void adc_disable_temperature_sensor(uint32_t adc);
+void adc_enable_temperature_sensor(void);
+void adc_disable_temperature_sensor(void);
 void adc_enable_external_trigger_regular(uint32_t adc, uint32_t trigger);
 void adc_enable_external_trigger_injected(uint32_t adc, uint32_t trigger);
 void adc_reset_calibration(uint32_t adc);

--- a/lib/stm32/f1/adc.c
+++ b/lib/stm32/f1/adc.c
@@ -199,13 +199,11 @@ void adc_set_dual_mode(uint32_t mode)
 This enables both the sensor and the reference voltage measurements on channels
 16 and 17.
 
-@param[in] adc Unsigned int32. ADC block register address base @ref
-adc_reg_base.
 */
 
-void adc_enable_temperature_sensor(uint32_t adc)
+void adc_enable_temperature_sensor()
 {
-	ADC_CR2(adc) |= ADC_CR2_TSVREFE;
+	ADC_CR2(ADC1) |= ADC_CR2_TSVREFE;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -213,14 +211,11 @@ void adc_enable_temperature_sensor(uint32_t adc)
 
 Disabling this will reduce power consumption from the sensor and the reference
 voltage measurements.
-
-@param[in] adc Unsigned int32. ADC block register address base @ref
-adc_reg_base.
 */
 
-void adc_disable_temperature_sensor(uint32_t adc)
+void adc_disable_temperature_sensor()
 {
-	ADC_CR2(adc) &= ~ADC_CR2_TSVREFE;
+	ADC_CR2(ADC1) &= ~ADC_CR2_TSVREFE;
 }
 
 


### PR DESCRIPTION
The TSVREFE bit is defined to only be present on ADC1, so drop the
pointless adc argument.  This has the added benefit of makeing the
API consistent with all other STM32 adc parts.