### PR TITLE
usb: dwc_otg: enable clocks automatically.

### DIFF
--- a/lib/usb/usb_f107.c
+++ b/lib/usb/usb_f107.c
@@ -52,6 +52,7 @@ const struct _usbd_driver stm32f107_usb_driver = {
 /** Initialize the USB device controller hardware of the STM32. */
 static usbd_device *stm32f107_usbd_init(void)
 {
+	rcc_periph_clock_enable(RCC_OTGFS);
 	OTG_FS_GINTSTS = OTG_GINTSTS_MMIS;
 
 	OTG_FS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;

--- a/lib/usb/usb_f207.c
+++ b/lib/usb/usb_f207.c
@@ -52,6 +52,7 @@ const struct _usbd_driver stm32f207_usb_driver = {
 /** Initialize the USB device controller hardware of the STM32. */
 static usbd_device *stm32f207_usbd_init(void)
 {
+	rcc_periph_clock_enable(RCC_OTGHS);
 	OTG_HS_GINTSTS = OTG_GINTSTS_MMIS;
 
 	OTG_HS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;


### PR DESCRIPTION
ST usbfs-v1, v2, EFM32 USB, lm4f usb all automatically enable the clock
in their _init routine.  Do the same for the dwc_otg drivers to be
consistent.
