### PR TITLE
cm3/fpb: Fix overly strict ARMv7 check

### DIFF
--- a/include/libopencm3/cm3/fpb.h
+++ b/include/libopencm3/cm3/fpb.h
@@ -23,7 +23,7 @@
 /* Cortex-M3 Flash Patch and Breakpoint (FPB) unit */
 
 /* Those defined only on ARMv7 and above */
-#if !defined(__ARM_ARCH_7M__) || !defined(__ARM_ARCH_7EM__)
+#if !defined(__ARM_ARCH_7M__) && !defined(__ARM_ARCH_7EM__)
 #error "Flash Patch and Breakpoint not available in CM0"
 #endif
 


### PR DESCRIPTION
The check to see if the architecture is ARMv7 was negated incorrectly, reporting an error if either of `__ARM_ARCH_7M__` or `__ARM_ARCH_7EM__` is not defined instead of only triggering when both are undefined.

AFAICT,  `-mcpu=cortex-m3` only defines `__ARM_ARCH_7M__` and `-mcpu=cortex-m4` only defines `__ARM_ARCH_7EM__`, so this always errors out.

This commit makes the check consistent with the versions in `itm.h` and `tpiu.h`.