### PR TITLE
STM32: RTC: Adds RTC initialize function for setting dividers, date/time regs

### DIFF
--- a/include/libopencm3/stm32/common/rtc_common_l1f024.h
+++ b/include/libopencm3/stm32/common/rtc_common_l1f024.h
@@ -327,6 +327,8 @@ specific memorymap.h header before including this header file.*/
 
 BEGIN_DECLS
 
+uint32_t rtc_get_bcd_date(void);
+uint32_t rtc_get_bcd_time(void);
 void rtc_set_prescaler(uint32_t sync, uint32_t async);
 void rtc_wait_for_synchro(void);
 void rtc_lock(void);

--- a/include/libopencm3/stm32/f4/rtc.h
+++ b/include/libopencm3/stm32/f4/rtc.h
@@ -36,6 +36,7 @@ LGPL License Terms @ref lgpl_license
 BEGIN_DECLS
 
 void rtc_enable_wakeup_timer(void);
+void rtc_initialize(uint32_t sync, uint32_t async, uint32_t date, uint32_t time);
 void rtc_disable_wakeup_timer(void);
 void rtc_enable_wakeup_timer_interrupt(void);
 void rtc_disable_wakeup_timer_interrupt(void);

--- a/lib/stm32/common/rtc_common_l1f024.c
+++ b/lib/stm32/common/rtc_common_l1f024.c
@@ -28,6 +28,28 @@
 #include <libopencm3/stm32/rtc.h>
 
 /*---------------------------------------------------------------------------*/
+/** @brief Get BCD date.
+
+This returns the current date stored as a BCD value from the RTC.
+*/
+
+uint32_t rtc_get_bcd_date(void)
+{
+    return RTC_DR;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Get BCD time.
+
+This returns the current time stored as a BCD value from the RTC.
+*/
+
+uint32_t rtc_get_bcd_time(void)
+{
+    return RTC_TR;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief Set RTC prescalars.
 
 This sets the RTC synchronous and asynchronous prescalars.


### PR DESCRIPTION
Uses process described in AN3371 to configure RTCCLK dividers and load a BCD encoded date and time into the respective RTC registers

Note, the RTC domain is initially asynchronous wrt the core.  The app note simply says to wait until the synchronization flag is set (RTC_ISR_INTF) to configure it.  This is accomplished via a (blocking) while loop.  Those needing to set the RTC from a real-time context will probably want to run this via interrupt.

Also adds some one-liner getter functions to return the current BCD date/time