### PR TITLE
stm32:CMSIS:gpio, rcc - compatibiluty vs CMSIS library 

### DIFF
--- a/include/libopencm3/cm3/memorymap.h
+++ b/include/libopencm3/cm3/memorymap.h
@@ -21,7 +21,11 @@
 #define LIBOPENCM3_CM3_MEMORYMAP_H
 
 #ifndef __CMSIS_USE
-#if defined(__CM3_CMSIS_VERSION_MAIN) || defined(__CM4_CMSIS_VERSION_MAIN)
+#if defined(__STM32F0xx_CMSIS_DEVICE_VERSION) \
+            || defined(__STM32F1xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F2xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F3xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F4xx_CMSIS_DEVICE_VERSION)
 #define __CMSIS_USE	1
 #else
 #define __CMSIS_USE	0

--- a/include/libopencm3/cm3/memorymap.h
+++ b/include/libopencm3/cm3/memorymap.h
@@ -20,6 +20,14 @@
 #ifndef LIBOPENCM3_CM3_MEMORYMAP_H
 #define LIBOPENCM3_CM3_MEMORYMAP_H
 
+#ifndef __CMSIS_USE
+#if defined(__CM3_CMSIS_VERSION_MAIN) || defined(__CM4_CMSIS_VERSION_MAIN)
+#define __CMSIS_USE	1
+#else
+#define __CMSIS_USE	0
+#endif
+#endif
+
 /* --- ARM Cortex-M0, M3 and M4 specific definitions ----------------------- */
 
 /* Private peripheral bus - Internal */
@@ -39,7 +47,9 @@
 
 /* PPBI_BASE + 0x3000 (0xE000 3000 - 0xE000 DFFF): Reserved */
 
+#if !(__CMSIS_USE)
 #define SCS_BASE                        (PPBI_BASE + 0xE000)
+#endif
 
 /* PPBI_BASE + 0xF000 (0xE000 F000 - 0xE003 FFFF): Reserved */
 
@@ -59,6 +69,7 @@
 /* SYS_TICK: System Timer */
 #define SYS_TICK_BASE                   (SCS_BASE + 0x0010)
 
+#if !(__CMSIS_USE)
 /* NVIC: Nested Vector Interrupt Controller */
 #define NVIC_BASE                       (SCS_BASE + 0x0100)
 
@@ -67,6 +78,8 @@
 
 /* MPU: Memory protection unit */
 #define MPU_BASE                        (SCS_BASE + 0x0D90)
+
+#endif// !(__CMSIS_USE)
 
 /* Those defined only on CM0*/
 #if defined(__ARM_ARCH_6M__)

--- a/include/libopencm3/stm32/common/gpio_common_f234.h
+++ b/include/libopencm3/stm32/common/gpio_common_f234.h
@@ -40,24 +40,44 @@ specific memorymap.h header before including this header file.*/
 
 #include <libopencm3/stm32/common/gpio_common_all.h>
 
+#if defined(__CM3_CMSIS_VERSION_MAIN) || defined(__CM4_CMSIS_VERSION_MAIN)
+#define __CMSIS_USE	1
+#else
+#define __CMSIS_USE	0
+#endif
+
+#if defined(HAL_MODULE_ENABLED) || defined(HAL_GPIO_MODULE_ENABLED)
+#define __HAL_USE	1
+#else
+#define __HAL_USE	0
+#endif
+
 /* GPIO port base addresses (for convenience) */
 /** @defgroup gpio_port_id GPIO Port IDs
 @ingroup gpio_defines
 
 @{*/
+#if !(__CMSIS_USE)
 #define GPIOA				GPIO_PORT_A_BASE
 #define GPIOB				GPIO_PORT_B_BASE
 #define GPIOC				GPIO_PORT_C_BASE
 #define GPIOD				GPIO_PORT_D_BASE
 #define GPIOE				GPIO_PORT_E_BASE
 #define GPIOF				GPIO_PORT_F_BASE
+#define GPIOA_BASE  GPIO_PORT_A_BASE
+#define GPIOB_BASE  GPIO_PORT_B_BASE
+#define GPIOC_BASE  GPIO_PORT_C_BASE
+#define GPIOD_BASE  GPIO_PORT_D_BASE
+#define GPIOE_BASE  GPIO_PORT_E_BASE
+#define GPIOF_BASE  GPIO_PORT_F_BASE
+#endif
 
 /**@}*/
 
 /* --- GPIO registers for STM32F2, STM32F3 and STM32F4 --------------------- */
 
 /* Port mode register (GPIOx_MODER) */
-#define GPIO_MODER(port)		MMIO32((port) + 0x00)
+#define GPIO_MODER(port)		MMIO32(((uint32_t)port) + 0x00)
 #define GPIOA_MODER			GPIO_MODER(GPIOA)
 #define GPIOB_MODER			GPIO_MODER(GPIOB)
 #define GPIOC_MODER			GPIO_MODER(GPIOC)
@@ -66,7 +86,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_MODER			GPIO_MODER(GPIOF)
 
 /* Port output type register (GPIOx_OTYPER) */
-#define GPIO_OTYPER(port)		MMIO32((port) + 0x04)
+#define GPIO_OTYPER(port)		MMIO32(((uint32_t)port) + 0x04)
 #define GPIOA_OTYPER			GPIO_OTYPER(GPIOA)
 #define GPIOB_OTYPER			GPIO_OTYPER(GPIOB)
 #define GPIOC_OTYPER			GPIO_OTYPER(GPIOC)
@@ -75,7 +95,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_OTYPER			GPIO_OTYPER(GPIOF)
 
 /* Port output speed register (GPIOx_OSPEEDR) */
-#define GPIO_OSPEEDR(port)		MMIO32((port) + 0x08)
+#define GPIO_OSPEEDR(port)		MMIO32(((uint32_t)port) + 0x08)
 #define GPIOA_OSPEEDR			GPIO_OSPEEDR(GPIOA)
 #define GPIOB_OSPEEDR			GPIO_OSPEEDR(GPIOB)
 #define GPIOC_OSPEEDR			GPIO_OSPEEDR(GPIOC)
@@ -84,7 +104,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_OSPEEDR			GPIO_OSPEEDR(GPIOF)
 
 /* Port pull-up/pull-down register (GPIOx_PUPDR) */
-#define GPIO_PUPDR(port)		MMIO32((port) + 0x0c)
+#define GPIO_PUPDR(port)		MMIO32(((uint32_t)port) + 0x0c)
 #define GPIOA_PUPDR			GPIO_PUPDR(GPIOA)
 #define GPIOB_PUPDR			GPIO_PUPDR(GPIOB)
 #define GPIOC_PUPDR			GPIO_PUPDR(GPIOC)
@@ -93,7 +113,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_PUPDR			GPIO_PUPDR(GPIOF)
 
 /* Port input data register (GPIOx_IDR) */
-#define GPIO_IDR(port)			MMIO32((port) + 0x10)
+#define GPIO_IDR(port)			MMIO32(((uint32_t)port) + 0x10)
 #define GPIOA_IDR			GPIO_IDR(GPIOA)
 #define GPIOB_IDR			GPIO_IDR(GPIOB)
 #define GPIOC_IDR			GPIO_IDR(GPIOC)
@@ -102,7 +122,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_IDR			GPIO_IDR(GPIOF)
 
 /* Port output data register (GPIOx_ODR) */
-#define GPIO_ODR(port)			MMIO32((port) + 0x14)
+#define GPIO_ODR(port)			MMIO32(((uint32_t)port) + 0x14)
 #define GPIOA_ODR			GPIO_ODR(GPIOA)
 #define GPIOB_ODR			GPIO_ODR(GPIOB)
 #define GPIOC_ODR			GPIO_ODR(GPIOC)
@@ -111,7 +131,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_ODR			GPIO_ODR(GPIOF)
 
 /* Port bit set/reset register (GPIOx_BSRR) */
-#define GPIO_BSRR(port)			MMIO32((port) + 0x18)
+#define GPIO_BSRR(port)			MMIO32(((uint32_t)port) + 0x18)
 #define GPIOA_BSRR			GPIO_BSRR(GPIOA)
 #define GPIOB_BSRR			GPIO_BSRR(GPIOB)
 #define GPIOC_BSRR			GPIO_BSRR(GPIOC)
@@ -120,7 +140,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_BSRR			GPIO_BSRR(GPIOF)
 
 /* Port configuration lock register (GPIOx_LCKR) */
-#define GPIO_LCKR(port)			MMIO32((port) + 0x1c)
+#define GPIO_LCKR(port)			MMIO32(((uint32_t)port) + 0x1c)
 #define GPIOA_LCKR			GPIO_LCKR(GPIOA)
 #define GPIOB_LCKR			GPIO_LCKR(GPIOB)
 #define GPIOC_LCKR			GPIO_LCKR(GPIOC)
@@ -129,7 +149,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_LCKR			GPIO_LCKR(GPIOF)
 
 /* Alternate function low register (GPIOx_AFRL) */
-#define GPIO_AFRL(port)			MMIO32((port) + 0x20)
+#define GPIO_AFRL(port)			MMIO32(((uint32_t)port) + 0x20)
 #define GPIOA_AFRL			GPIO_AFRL(GPIOA)
 #define GPIOB_AFRL			GPIO_AFRL(GPIOB)
 #define GPIOC_AFRL			GPIO_AFRL(GPIOC)
@@ -138,7 +158,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_AFRL			GPIO_AFRL(GPIOF)
 
 /* Alternate function high register (GPIOx_AFRH) */
-#define GPIO_AFRH(port)			MMIO32((port) + 0x24)
+#define GPIO_AFRH(port)			MMIO32(((uint32_t)port) + 0x24)
 #define GPIOA_AFRH			GPIO_AFRH(GPIOA)
 #define GPIOB_AFRH			GPIO_AFRH(GPIOB)
 #define GPIOC_AFRH			GPIO_AFRH(GPIOC)
@@ -153,10 +173,14 @@ specific memorymap.h header before including this header file.*/
 /** @defgroup gpio_mode GPIO Pin Direction and Analog/Digital Mode
 @ingroup gpio_defines
 @{*/
+#if !(__HAL_USE)
 #define GPIO_MODE_INPUT			0x0
+#endif
 #define GPIO_MODE_OUTPUT		0x1
 #define GPIO_MODE_AF			0x2
+#if !(__HAL_USE)
 #define GPIO_MODE_ANALOG		0x3
+#endif
 /**@}*/
 
 /* --- GPIOx_OTYPER values ------------------------------------------------- */
@@ -210,7 +234,7 @@ specific memorymap.h header before including this header file.*/
 
 /* --- GPIOx_LCKR values --------------------------------------------------- */
 
-#define GPIO_LCKK			(1 << 16)
+//#define GPIO_LCKK			(1ul << 16)
 /* GPIOx_LCKR[15:0]: LCKy: Port x lock bit y (y = 0..15) */
 
 /* --- GPIOx_AFRL/H values ------------------------------------------------- */

--- a/include/libopencm3/stm32/common/gpio_common_f234.h
+++ b/include/libopencm3/stm32/common/gpio_common_f234.h
@@ -40,11 +40,17 @@ specific memorymap.h header before including this header file.*/
 
 #include <libopencm3/stm32/common/gpio_common_all.h>
 
-#if defined(__CM3_CMSIS_VERSION_MAIN) || defined(__CM4_CMSIS_VERSION_MAIN)
+#if defined(__STM32F0xx_CMSIS_DEVICE_VERSION) \
+            || defined(__STM32F1xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F2xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F3xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F4xx_CMSIS_DEVICE_VERSION)
 #define __CMSIS_USE	1
 #else
 #define __CMSIS_USE	0
 #endif
+
+
 
 #if defined(HAL_MODULE_ENABLED) || defined(HAL_GPIO_MODULE_ENABLED)
 #define __HAL_USE	1
@@ -57,7 +63,7 @@ specific memorymap.h header before including this header file.*/
 @ingroup gpio_defines
 
 @{*/
-#if !(__CMSIS_USE)
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define GPIOA				GPIO_PORT_A_BASE
 #define GPIOB				GPIO_PORT_B_BASE
 #define GPIOC				GPIO_PORT_C_BASE

--- a/include/libopencm3/stm32/common/gpio_common_f24.h
+++ b/include/libopencm3/stm32/common/gpio_common_f24.h
@@ -45,7 +45,7 @@ specific memorymap.h header before including this header file.*/
 @ingroup gpio_defines
 
 @{*/
-#if !(__CMSIS_USE)
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define GPIOG				GPIO_PORT_G_BASE
 #define GPIOH				GPIO_PORT_H_BASE
 #define GPIOI				GPIO_PORT_I_BASE

--- a/include/libopencm3/stm32/common/gpio_common_f24.h
+++ b/include/libopencm3/stm32/common/gpio_common_f24.h
@@ -45,11 +45,18 @@ specific memorymap.h header before including this header file.*/
 @ingroup gpio_defines
 
 @{*/
+#if !(__CMSIS_USE)
 #define GPIOG				GPIO_PORT_G_BASE
 #define GPIOH				GPIO_PORT_H_BASE
 #define GPIOI				GPIO_PORT_I_BASE
 #define GPIOJ				GPIO_PORT_J_BASE
 #define GPIOK				GPIO_PORT_K_BASE
+#define GPIOG_BASE  GPIO_PORT_G_BASE
+#define GPIOH_BASE  GPIO_PORT_H_BASE
+#define GPIOI_BASE  GPIO_PORT_I_BASE
+#define GPIOJ_BASE  GPIO_PORT_J_BASE
+#define GPIOK_BASE  GPIO_PORT_K_BASE
+#endif
 /**@}*/
 
 /* --- GPIO registers for STM32F2, STM32F3 and STM32F4 --------------------- */

--- a/include/libopencm3/stm32/f4/memorymap.h
+++ b/include/libopencm3/stm32/f4/memorymap.h
@@ -24,6 +24,7 @@
 
 /* --- STM32F4 specific peripheral definitions ----------------------------- */
 
+#if !(__CMSIS_USE)
 /* Memory map for all busses */
 #define PERIPH_BASE			(0x40000000U)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)
@@ -98,6 +99,7 @@
 #define LTDC_BASE			(PERIPH_BASE_APB2 + 0x6800)
 #define DSI_BASE			(PERIPH_BASE_APB2 + 0x6C00)
 /* PERIPH_BASE_APB2 + 0x7400 (0x4001 7400 - 0x4001 FFFF): Reserved */
+#endif
 
 /* AHB1 */
 #define GPIO_PORT_A_BASE		(PERIPH_BASE_AHB1 + 0x0000)
@@ -112,6 +114,7 @@
 #define GPIO_PORT_J_BASE		(PERIPH_BASE_AHB1 + 0x2400)
 #define GPIO_PORT_K_BASE		(PERIPH_BASE_AHB1 + 0x2800)
 /* PERIPH_BASE_AHB1 + 0x2C00 (0x4002 2C00 - 0x4002 2FFF): Reserved */
+#if !(__CMSIS_USE)
 #define CRC_BASE			(PERIPH_BASE_AHB1 + 0x3000)
 /* PERIPH_BASE_AHB1 + 0x3400 (0x4002 3400 - 0x4002 37FF): Reserved */
 #define RCC_BASE			(PERIPH_BASE_AHB1 + 0x3800)
@@ -157,6 +160,7 @@
 
 /* PPIB */
 #define DBGMCU_BASE			(PPBI_BASE + 0x00042000)
+#endif
 
 /* Device Electronic Signature */
 #define DESIG_FLASH_SIZE_BASE		(0x1FFF7A22U)

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -45,6 +45,11 @@
 #ifndef LIBOPENCM3_RCC_H
 #define LIBOPENCM3_RCC_H
 
+#if defined(__CM3_CMSIS_VERSION_MAIN) || defined(__CM4_CMSIS_VERSION_MAIN)
+#define __CMSIS_USED	1
+#else
+#define __CMSIS_USED	0
+#endif
 /* --- RCC registers ------------------------------------------------------- */
 
 #define RCC_CR					MMIO32(RCC_BASE + 0x00)
@@ -85,23 +90,26 @@
 #define RCC_DCKCFGR				MMIO32(RCC_BASE + 0x8C)
 
 /* --- RCC_CR values ------------------------------------------------------- */
-
-#define RCC_CR_PLLSAIRDY			(1 << 29)
-#define RCC_CR_PLLSAION				(1 << 28)
-#define RCC_CR_PLLI2SRDY			(1 << 27)
-#define RCC_CR_PLLI2SON				(1 << 26)
-#define RCC_CR_PLLRDY				(1 << 25)
-#define RCC_CR_PLLON				(1 << 24)
-#define RCC_CR_CSSON				(1 << 19)
-#define RCC_CR_HSEBYP				(1 << 18)
-#define RCC_CR_HSERDY				(1 << 17)
-#define RCC_CR_HSEON				(1 << 16)
+#define RCC_CR_PLLSAIRDY    (1ul << 29)
+#define RCC_CR_PLLSAION     (1ul << 28)
+#if !(__CMSIS_USED)
+#define RCC_CR_PLLI2SRDY    (1ul << 27)
+#define RCC_CR_PLLI2SON     (1ul << 26)
+#define RCC_CR_PLLRDY       (1ul << 25)
+#define RCC_CR_PLLON        (1ul << 24)
+#define RCC_CR_CSSON        (1ul << 19)
+#define RCC_CR_HSEBYP       (1ul << 18)
+#define RCC_CR_HSERDY       (1ul << 17)
+#define RCC_CR_HSEON        (1ul << 16)
+#endif
 /* HSICAL: [15:8] */
 /* HSITRIM: [7:3] */
 #define RCC_CR_HSITRIM_SHIFT			3
 #define RCC_CR_HSITRIM_MASK			0x1f
+#if !(__CMSIS_USED)
 #define RCC_CR_HSIRDY				(1 << 1)
 #define RCC_CR_HSION				(1 << 0)
+#endif
 
 /* --- RCC_PLLCFGR values -------------------------------------------------- */
 
@@ -111,7 +119,9 @@
 /* PLLQ: [27:24] */
 #define RCC_PLLCFGR_PLLQ_SHIFT			24
 #define RCC_PLLCFGR_PLLQ_MASK			0xf
+#if !(__CMSIS_USED)
 #define RCC_PLLCFGR_PLLSRC			(1 << 22)
+#endif
 /* PLLP: [17:16] */
 #define RCC_PLLCFGR_PLLP_SHIFT			16
 #define RCC_PLLCFGR_PLLP_MASK			0x3
@@ -144,7 +154,9 @@
 #define RCC_CFGR_MCOPRE_DIV_5			0x7
 
 /* I2SSRC: I2S clock selection */
-#define RCC_CFGR_I2SSRC				(1 << 23)
+#if !(__CMSIS_USED)
+#define RCC_CFGR_I2SSRC				(1ul << 23)
+#endif
 
 /* MCO1: Microcontroller clock output 1 */
 #define RCC_CFGR_MCO1_SHIFT			21
@@ -187,17 +199,22 @@
 /* SWS: System clock switch status */
 #define RCC_CFGR_SWS_SHIFT			2
 #define RCC_CFGR_SWS_MASK			0x3
+#if !(__CMSIS_USED)
 #define RCC_CFGR_SWS_HSI			0x0
 #define RCC_CFGR_SWS_HSE			0x1
 #define RCC_CFGR_SWS_PLL			0x2
+#endif
 
 /* SW: System clock switch */
 #define RCC_CFGR_SW_SHIFT			0
+#if !(__CMSIS_USED)
 #define RCC_CFGR_SW_HSI				0x0
 #define RCC_CFGR_SW_HSE				0x1
 #define RCC_CFGR_SW_PLL				0x2
+#endif
 
 /* --- RCC_CIR values ------------------------------------------------------ */
+#if !(__CMSIS_USED)
 
 /* Clock security system interrupt clear bit */
 #define RCC_CIR_CSSC				(1 << 23)
@@ -538,6 +555,7 @@
 #define RCC_SSCGR_MODPER_SHIFT			0
 #define RCC_SSCGR_MODPER_MASK			0x1fff
 
+#endif
 /* --- RCC_PLLI2SCFGR values ----------------------------------------------- */
 
 /* RCC_PLLI2SCFGR[30:28]: PLLI2SR */


### PR DESCRIPTION
this patch allows to mix code use HAL and opencm3 includes.
                !!! HAL library MUST be included BEFORE libopencm3, to avoid conflicts
                !!! prefer use GPIOx_BASE for opencm3 routines parameters instead of GPIOx to avoid type conflicts