### PR TITLE
stm32(x07) .usbd - add otg_FS device driver

### DIFF
--- a/include/libopencm3/stm32/otg_common.h
+++ b/include/libopencm3/stm32/otg_common.h
@@ -490,4 +490,137 @@
 
 
 
+
+//*******************************************************************
+//          this OTG IO structures imported from CMSIS
+/**
+ * @brief __USB_OTG_Core_register
+ */
+typedef struct {
+    uint32_t GOTGCTL;       /*!<  USB_OTG Control and Status Register    000h*/
+    uint32_t GOTGINT;       /*!<  USB_OTG Interrupt Register             004h*/
+    uint32_t GAHBCFG;       /*!<  Core AHB Configuration Register    008h*/
+    uint32_t GUSBCFG;       /*!<  Core USB Configuration Register    00Ch*/
+    uint32_t GRSTCTL;       /*!<  Core Reset Register                010h*/
+    uint32_t GINTSTS;       /*!<  Core Interrupt Register            014h*/
+    uint32_t GINTMSK;       /*!<  Core Interrupt Mask Register       018h*/
+    uint32_t GRXSTSR;       /*!<  Receive Sts Q Read Register        01Ch*/
+    uint32_t GRXSTSP;       /*!<  Receive Sts Q Read & POP Register  020h*/
+    uint32_t GRXFSIZ;       /* Receive FIFO Size Register         024h*/
+    uint32_t DIEPTXF0_HNPTXFSIZ; /*!<  EP0 / Non Periodic Tx FIFO Size Register 028h*/
+    uint32_t HNPTXSTS;      /*!<  Non Periodic Tx FIFO/Queue Sts reg 02Ch*/
+    uint32_t Reserved30[2]; /* Reserved                           030h*/
+    uint32_t GCCFG;         /* General Purpose IO Register        038h*/
+    uint32_t CID;           /* User ID Register                   03Ch*/
+    uint32_t Reserved40[48];/* Reserved                      040h-0FFh*/
+    uint32_t HPTXFSIZ;      /* Host Periodic Tx FIFO Size Reg     100h*/
+    uint32_t DIEPTXF[0x0F]; /* dev Periodic Transmit FIFO */
+} OTG_global_regs;
+typedef volatile OTG_global_regs OTG_global_io;
+
+#define OTGx_GLOBAL(base)   (*(OTG_global_io*)(base+OTG_GOTGCTL))
+
+
+/** 
+ * @brief __device_Registers
+ */
+typedef struct {
+    uint32_t DCFG;          /* dev Configuration Register   800h*/
+    uint32_t DCTL;          /* dev Control Register         804h*/
+    uint32_t DSTS;          /* dev Status Register (RO)     808h*/
+    uint32_t Reserved0C;    /* Reserved                     80Ch*/
+    uint32_t DIEPMSK;       /* dev IN Endpoint Mask         810h*/
+    uint32_t DOEPMSK;       /* dev OUT Endpoint Mask        814h*/
+    uint32_t DAINT;         /* dev All Endpoints Itr Reg    818h*/
+    uint32_t DAINTMSK;      /* dev All Endpoints Itr Mask   81Ch*/
+    uint32_t Reserved20;    /* Reserved                     820h*/
+    uint32_t Reserved9;     /* Reserved                     824h*/
+    uint32_t DVBUSDIS;      /* dev VBUS discharge Register  828h*/
+    uint32_t DVBUSPULSE;    /* dev VBUS Pulse Register      82Ch*/
+    uint32_t DTHRCTL;       /* dev thr                      830h*/
+    uint32_t DIEPEMPMSK;    /* dev empty msk             834h*/
+    uint32_t DEACHINT;      /* dedicated EP interrupt       838h*/
+    uint32_t DEACHMSK;      /* dedicated EP msk             83Ch*/
+    uint32_t Reserved40;    /* dedicated EP mask           840h*/
+    uint32_t DINEP1MSK;     /* dedicated EP mask           844h*/
+    uint32_t Reserved44[15];/* Reserved                 844-87Ch*/
+    uint32_t DOUTEP1MSK;    /* dedicated EP msk            884h*/
+} OTG_device_regs;
+typedef volatile OTG_device_regs OTG_device_io;
+
+#define OTGx_DEVICE(base)   (*(OTG_device_io*)(base+OTG_DCFG))
+
+/** 
+ * @brief __IN_Endpoint-Specific_Register
+ */
+typedef struct {
+    uint32_t DIEPCTL;       /* dev IN Endpoint Control Reg 900h + (ep_num * 20h) + 00h*/
+    uint32_t Reserved04;    /* Reserved                       900h + (ep_num * 20h) + 04h*/
+    uint32_t DIEPINT;       /* dev IN Endpoint Itr Reg     900h + (ep_num * 20h) + 08h*/
+    uint32_t Reserved0C;    /* Reserved                       900h + (ep_num * 20h) + 0Ch*/
+    uint32_t DIEPTSIZ;      /* IN Endpoint Txfer Size   900h + (ep_num * 20h) + 10h*/
+    uint32_t DIEPDMA;       /* IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h*/
+    uint32_t DTXFSTS;       /*IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h*/
+    uint32_t Reserved18;    /* Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch*/
+} OTG_IEP_regs;
+typedef volatile OTG_IEP_regs OTG_IEP_io;
+
+#define OTGx_IEPn(base, n)  (*(OTG_IEP_io*)((base)+OTG_DIEPCTL(n)))
+
+/**
+ * @brief __OUT_Endpoint-Specific_Registers
+ */
+typedef struct {
+    uint32_t DOEPCTL;       /* dev OUT Endpoint Control Reg  B00h + (ep_num * 20h) + 00h*/
+    uint32_t Reserved04;    /* Reserved                      B00h + (ep_num * 20h) + 04h*/
+    uint32_t DOEPINT;       /* dev OUT Endpoint Itr Reg      B00h + (ep_num * 20h) + 08h*/
+    uint32_t Reserved0C;    /* Reserved                      B00h + (ep_num * 20h) + 0Ch*/
+    uint32_t DOEPTSIZ;      /* dev OUT Endpoint Txfer Size   B00h + (ep_num * 20h) + 10h*/
+    uint32_t DOEPDMA;       /* dev OUT Endpoint DMA Address  B00h + (ep_num * 20h) + 14h*/
+    uint32_t Reserved18[2]; /* Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch*/
+} OTG_OEP_regs;
+typedef volatile OTG_OEP_regs OTG_OEP_io;
+
+#define OTGx_OEPn(base, n)  (*(OTG_OEP_io*)((base)+OTG_OIEPCTL(n)))
+
+/** 
+ * @brief __Host_Mode_Register_Structures
+ */
+typedef struct {
+    uint32_t HCFG;          /* Host Configuration Register    400h*/
+    uint32_t HFIR;          /* Host Frame Interval Register   404h*/
+    uint32_t HFNUM;         /* Host Frame Nbr/Frame Remaining 408h*/
+    uint32_t Reserved40C;   /* Reserved                       40Ch*/
+    uint32_t HPTXSTS;       /* Host Periodic Tx FIFO/ Queue Status 410h*/
+    uint32_t HAINT;         /* Host All Channels Interrupt Register 414h*/
+    uint32_t HAINTMSK;      /* Host All Channels Interrupt Mask 418h*/
+} OTG_host_regs;
+typedef volatile OTG_host_regs OTG_host_io;
+
+#define OTGx_HOST(base)     (*(OTG_host_io*)(base+OTG_HCFG))
+
+/** 
+ * @brief __Host_Channel_Specific_Registers
+ */
+typedef struct {
+    uint32_t HCCHAR;
+    uint32_t HCSPLT;        // HS only
+    uint32_t HCINT;
+    uint32_t HCINTMSK;
+    uint32_t HCTSIZ;
+    uint32_t HCDMA;         // HS only
+    uint32_t Reserved[2];
+} OTG_host_channel_regs;
+typedef volatile OTG_host_channel_regs OTG_host_channel_io;
+
+#define OTGx_HCn(base, n)   (*(OTG_host_channel_io*)((base)+OTG_HCCHAR(n)))
+
+/* Power and clock gating control and status register */
+#define OTGx_PCGCCTL(base)	MMIO32((base)+OTG_PCGCCTL)
+
+/* Data FIFO */
+#define OTGx_FIFO(base, x)  (base + OTG_FIFO(x))
+
+
+
 #endif

--- a/include/libopencm3/stm32/otg_fs.h
+++ b/include/libopencm3/stm32/otg_fs.h
@@ -30,6 +30,15 @@
 #include <libopencm3/stm32/otg_common.h>
 
 /***********************************************************************/
+//              OTG IO structures
+#define	OTG_FS_GLOBAL   OTGx_GLOBAL(USB_OTG_FS_BASE)
+#define	OTG_FS_DEVICE   OTGx_DEVICE(USB_OTG_FS_BASE)
+#define	OTG_FS_IEPn(n)  OTGx_IEPn(USB_OTG_FS_BASE, n)
+#define	OTG_FS_OEPn(n)  OTGx_OEPn(USB_OTG_FS_BASE, n)
+#define	OTG_FS_HOST     OTGx_HOST(USB_OTG_FS_BASE)
+#define	OTG_FS_HCn(n)   OTGx_HCn(USB_OTG_FS_BASE, n)
+
+/***********************************************************************/
 
 /* Core Global Control and Status Registers */
 #define OTG_FS_GOTGCTL		MMIO32(USB_OTG_FS_BASE + OTG_GOTGCTL)

--- a/include/libopencm3/stm32/otg_hs.h
+++ b/include/libopencm3/stm32/otg_hs.h
@@ -41,6 +41,15 @@
 
 
 /***********************************************************************/
+//              OTG IO structures
+#define	OTG_HS_GLOBAL   OTG_GLOBAL(USB_OTG_HS_BASE)
+#define	OTG_HS_DEVICE   OTG_DEVICE(USB_OTG_HS_BASE)
+#define	OTG_HS_IEPn(n)  OTG_IEPn(USB_OTG_HS_BASE, n)
+#define	OTG_HS_OEPn(n)  OTG_OEPn(USB_OTG_HS_BASE, n)
+#define	OTG_HS_HOST     OTG_HOST(USB_OTG_HS_BASE)
+#define	OTG_HS_HCn(n)   OTG_HCn(USB_OTG_HS_BASE, n)
+
+/***********************************************************************/
 
 /* Core Global Control and Status Registers */
 #define OTG_HS_GOTGCTL		MMIO32(USB_OTG_HS_BASE + OTG_GOTGCTL)

--- a/include/libopencm3/stm32/otg_hs.h
+++ b/include/libopencm3/stm32/otg_hs.h
@@ -42,12 +42,12 @@
 
 /***********************************************************************/
 //              OTG IO structures
-#define	OTG_HS_GLOBAL   OTG_GLOBAL(USB_OTG_HS_BASE)
-#define	OTG_HS_DEVICE   OTG_DEVICE(USB_OTG_HS_BASE)
-#define	OTG_HS_IEPn(n)  OTG_IEPn(USB_OTG_HS_BASE, n)
-#define	OTG_HS_OEPn(n)  OTG_OEPn(USB_OTG_HS_BASE, n)
-#define	OTG_HS_HOST     OTG_HOST(USB_OTG_HS_BASE)
-#define	OTG_HS_HCn(n)   OTG_HCn(USB_OTG_HS_BASE, n)
+#define	OTG_HS_GLOBAL   OTGx_GLOBAL(USB_OTG_HS_BASE)
+#define	OTG_HS_DEVICE   OTGx_DEVICE(USB_OTG_HS_BASE)
+#define	OTG_HS_IEPn(n)  OTGx_IEPn(USB_OTG_HS_BASE, n)
+#define	OTG_HS_OEPn(n)  OTGx_OEPn(USB_OTG_HS_BASE, n)
+#define	OTG_HS_HOST     OTGx_HOST(USB_OTG_HS_BASE)
+#define	OTG_HS_HCn(n)   OTGx_HCn(USB_OTG_HS_BASE, n)
 
 /***********************************************************************/
 

--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -54,7 +54,9 @@ typedef struct _usbd_device usbd_device;
 
 extern const usbd_driver st_usbfs_v1_usb_driver;
 extern const usbd_driver stm32f107_usb_driver;
-extern const usbd_driver stm32f207_usb_driver;
+extern const usbd_driver stm32f207_usbd_hs_driver;
+extern const usbd_driver stm32f207_usbd_fs_driver;
+#define stm32f207_usb_driver	stm32f207_usbd_hs_driver
 extern const usbd_driver st_usbfs_v2_usb_driver;
 #define otgfs_usb_driver stm32f107_usb_driver
 #define otghs_usb_driver stm32f207_usb_driver

--- a/lib/usb/usb_f207.c
+++ b/lib/usb/usb_f207.c
@@ -21,6 +21,7 @@
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/tools.h>
 #include <libopencm3/stm32/otg_hs.h>
+#include <libopencm3/stm32/otg_fs.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/usb/usbd.h>
 #include "usb_private.h"
@@ -29,12 +30,14 @@
 /* Receive FIFO size in 32-bit words. */
 #define RX_FIFO_SIZE 512
 
-static usbd_device *stm32f207_usbd_init(void);
+static struct _usbd_device usbd_hs_dev;
+static struct _usbd_device usbd_fs_dev;
 
-static struct _usbd_device usbd_dev;
+static usbd_device *stm32f207_fs_usbd_init(void);
+static usbd_device *stm32f207_hs_usbd_init(void);
 
-const struct _usbd_driver stm32f207_usb_driver = {
-	.init = stm32f207_usbd_init,
+const struct _usbd_driver stm32f207_usbd_hs_driver = {
+    .init = stm32f207_hs_usbd_init,
 	.set_address = stm32fx07_set_address,
 	.ep_setup = stm32fx07_ep_setup,
 	.ep_reset = stm32fx07_endpoints_reset,
@@ -50,43 +53,75 @@ const struct _usbd_driver stm32f207_usb_driver = {
 	.rx_fifo_size = RX_FIFO_SIZE,
 };
 
+const struct _usbd_driver stm32f207_usbd_fs_driver = {
+    .init = stm32f207_fs_usbd_init,
+    .set_address = stm32fx07_set_address,
+    .ep_setup = stm32fx07_ep_setup,
+    .ep_reset = stm32fx07_endpoints_reset,
+    .ep_stall_set = stm32fx07_ep_stall_set,
+    .ep_stall_get = stm32fx07_ep_stall_get,
+    .ep_nak_set = stm32fx07_ep_nak_set,
+    .ep_write_packet = stm32fx07_ep_write_packet,
+    .ep_read_packet = stm32fx07_ep_read_packet,
+    .poll = stm32fx07_poll,
+    .disconnect = stm32fx07_disconnect,
+    .base_address = USB_OTG_FS_BASE,
+    .set_address_before_status = 1,
+    .rx_fifo_size = RX_FIFO_SIZE,
+};
+
 /** Initialize the USB device controller hardware of the STM32. */
-static usbd_device *stm32f207_usbd_init(void)
+usbd_device *stm32f207_usbd_init_dev(usbd_device* dev)
 {
-	rcc_periph_clock_enable(RCC_OTGHS);
-	OTG_HS_GINTSTS = OTG_GINTSTS_MMIS;
+    const usbd_driver *driver = dev->driver;
+    uint32_t base = driver->base_address;
 
-	OTG_HS_GUSBCFG |= OTG_GUSBCFG_PHYSEL;
-	/* Enable VBUS sensing in device mode and power down the PHY. */
-	OTG_HS_GCCFG |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
+    OTGx_GLOBAL(base).GINTSTS = OTG_GINTSTS_MMIS;
+    OTGx_GLOBAL(base).GUSBCFG   |= OTG_GUSBCFG_PHYSEL;
+    /* Enable VBUS sensing in device mode and power down the PHY. */
+    OTGx_GLOBAL(base).GCCFG     |= OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
 
-	/* Wait for AHB idle. */
-	while (!(OTG_HS_GRSTCTL & OTG_GRSTCTL_AHBIDL));
-	/* Do core soft reset. */
-	OTG_HS_GRSTCTL |= OTG_GRSTCTL_CSRST;
-	while (OTG_HS_GRSTCTL & OTG_GRSTCTL_CSRST);
+    /* Wait for AHB idle. */
+    while ((OTGx_GLOBAL(base).GRSTCTL & OTG_GRSTCTL_AHBIDL) == 0);
+    /* Do core soft reset. */
+    OTGx_GLOBAL(base).GRSTCTL |= OTG_GRSTCTL_CSRST;
+    while ((OTGx_GLOBAL(base).GRSTCTL & OTG_GRSTCTL_CSRST) != 0);
 
-	/* Force peripheral only mode. */
-	OTG_HS_GUSBCFG |= OTG_GUSBCFG_FDMOD | OTG_GUSBCFG_TRDT_MASK;
+    /* Force peripheral only mode. */
+    OTGx_GLOBAL(base).GUSBCFG |= OTG_GUSBCFG_FDMOD | OTG_GUSBCFG_TRDT_MASK;
 
-	/* Full speed device. */
-	OTG_HS_DCFG |= OTG_DCFG_DSPD;
+    /* Full speed device. */
+    OTGx_DEVICE(base).DCFG |= OTG_DCFG_DSPD;
 
-	/* Restart the PHY clock. */
-	OTG_HS_PCGCCTL = 0;
+    /* Restart the PHY clock. */
+    OTGx_PCGCCTL(base) = 0;
 
-	OTG_HS_GRXFSIZ = stm32f207_usb_driver.rx_fifo_size;
-	usbd_dev.fifo_mem_top = stm32f207_usb_driver.rx_fifo_size;
+    OTGx_GLOBAL(base).GRXFSIZ   = driver->rx_fifo_size;
+    dev->fifo_mem_top           = driver->rx_fifo_size;
 
-	/* Unmask interrupts for TX and RX. */
-	OTG_HS_GAHBCFG |= OTG_GAHBCFG_GINT;
-	OTG_HS_GINTMSK = OTG_GINTMSK_ENUMDNEM |
-			 OTG_GINTMSK_RXFLVLM |
-			 OTG_GINTMSK_IEPINT |
-			 OTG_GINTMSK_USBSUSPM |
-			 OTG_GINTMSK_WUIM;
-	OTG_HS_DAINTMSK = 0xF;
-	OTG_HS_DIEPMSK = OTG_DIEPMSK_XFRCM;
+    /* Unmask interrupts for TX and RX. */
+    OTGx_GLOBAL(base).GAHBCFG |= OTG_GAHBCFG_GINT;
+    OTGx_GLOBAL(base).GINTMSK = OTG_GINTMSK_ENUMDNEM |
+             OTG_GINTMSK_RXFLVLM |
+             OTG_GINTMSK_IEPINT |
+             OTG_GINTMSK_USBSUSPM |
+             OTG_GINTMSK_WUIM;
+    OTGx_DEVICE(base).DAINTMSK = 0xF;
+    OTGx_DEVICE(base).DIEPMSK = OTG_DIEPMSK_XFRCM;
 
-	return &usbd_dev;
+    return dev;
+}
+
+static 
+usbd_device *stm32f207_fs_usbd_init(void)
+{
+    usbd_fs_dev.driver = &stm32f207_usbd_fs_driver;
+    return stm32f207_usbd_init_dev(&usbd_fs_dev);
+}
+
+static 
+usbd_device *stm32f207_hs_usbd_init(void)
+{
+    usbd_hs_dev.driver = &stm32f207_usbd_hs_driver;
+    return stm32f207_usbd_init_dev(&usbd_hs_dev);
 }


### PR DESCRIPTION
this patch introduce stm32f207_usbd_hs_driver and stm32f207_usbd_fs_driver, allow to use both OTG cores.
also it provideOTG_xxx_io structures like CMSIS ones, and provides for FS and HS devices io structures OTG_xS_GLOBAL/DEVICE/HOST/IEPn/OEPn/HCn

