### PR TITLE
eeprom: drop support from linker scripts.

### DIFF
--- a/ld/linker.ld.S
+++ b/ld/linker.ld.S
@@ -130,13 +130,6 @@ SECTIONS
 		_ebss = .;
 	} >ram
 
-#if defined(_EEP)
-	.eep : {
-		*(.eeprom*)
-		. = ALIGN(4);
-	} >eep
-#endif
-
 #if defined(_CCM)
 	.ccm : {
 		*(.ccmram*)

--- a/lib/stm32/l1/libopencm3_stm32l1.ld
+++ b/lib/stm32/l1/libopencm3_stm32l1.ld
@@ -92,11 +92,6 @@ SECTIONS
 		_ebss = .;
 	} >ram
 
-	.eeprom (NOLOAD) : {
-		. = ALIGN(4);
-		*(.eeprom*)
-	} >eep
-
 	/*
 	 * The .eh_frame section appears to be used for C++ exception handling.
 	 * You may need to fix this if you're using C++.


### PR DESCRIPTION
While the NOLOAD variant sometimes worked with some toolchains, the
version in the generator scripts could never work, as neither the
startup code, nor gdb know how to load those sections properly.

Originally added in: eb18cc19cb392a69f8675c42776c644d1003ed89

The original scripts allowed you to place variables in eeprom space for
reading only.  However, the last toolchain that generated working code
with this linker script was the gcc-arm-none-eabi-4_9-2014q4 release.
Subsequent releases treat the directives differently, and can lose track
of where variables are.  One known symptom is constants getting bad
addresses, so for instance, "printf("asdfad")" will end up passing the
wrong address of the string constant into the eventual _write() call.

This commit removes the problematic directives until a more fully
correct system can be found that more properly followers the linker
script rules.