### PR TITLE
*usb:usbd_init:aligns - notice  and aserted about parameters align

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -84,10 +84,10 @@ extern const usbd_driver efm32lg_usb_driver;
  * @return the usb device initialized for use. (currently cannot fail).
  */
 extern usbd_device * usbd_init(const usbd_driver *driver,
-			       const struct usb_device_descriptor *dev,
-			       const struct usb_config_descriptor *conf,
+			       const struct usb_device_descriptor *dev,     //MUST alined(4)
+			       const struct usb_config_descriptor *conf,    //MUST alined(4)
 			       const char **strings, int num_strings,
-			       uint8_t *control_buffer,
+			       uint8_t *control_buffer,                     //MUST alined(4)
 			       uint16_t control_buffer_size);
 
 /** Registers a reset callback */

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -36,6 +36,7 @@ LGPL License Terms @ref lgpl_license
 /**@{*/
 
 #include <string.h>
+#include <assert.h>
 #include <libopencm3/usb/usbd.h>
 #include "usb_private.h"
 
@@ -46,6 +47,9 @@ usbd_device *usbd_init(const usbd_driver *driver,
 		       uint8_t *control_buffer, uint16_t control_buffer_size)
 {
 	usbd_device *usbd_dev;
+	assert( ((uintptr_t)dev & 3) == 0);
+	assert( ((uintptr_t)conf & 3) == 0);
+	assert( ((uintptr_t)control_buffer & 3) == 0);
 
 	usbd_dev = driver->init();
 


### PR DESCRIPTION
*Desribe :since xxx_descriptor structures are packed compiler may place it unaligned.
        at least keil ARM compiler do thus. therefore this check helps find it early
        at debuging stage.