### PR TITLE
!usbd_register_set_config_callback - no handler copy 

### DIFF
--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -46,7 +46,10 @@ int usbd_register_set_config_callback(usbd_device *usbd_dev,
 
 	for (i = 0; i < MAX_USER_SET_CONFIG_CALLBACK; i++) {
 		if (usbd_dev->user_callback_set_config[i]) {
-			continue;
+			if (usbd_dev->user_callback_set_config[i] != callback)
+				continue;
+			else
+				return 0;
 		}
 
 		usbd_dev->user_callback_set_config[i] = callback;


### PR DESCRIPTION
just a small fix protects register one callback multiple times, that will loose callbacl slots and may prevent executing configuration multiple times at activation