### PR TITLE
!usb: fix loosing XFRC flag after slow IN endpoint callback

### DIFF
--- a/lib/usb/usb_fx07_common.c
+++ b/lib/usb/usb_fx07_common.c
@@ -310,14 +310,13 @@ void stm32fx07_poll(usbd_device *usbd_dev)
 	 */
 	for (i = 0; i < 4; i++) { /* Iterate over endpoints. */
 		if (REBASE(OTG_DIEPINT(i)) & OTG_DIEPINTX_XFRC) {
+			REBASE(OTG_DIEPINT(i)) = OTG_DIEPINTX_XFRC;
 			/* Transfer complete. */
 			if (usbd_dev->user_callback_ctr[i]
 						       [USB_TRANSACTION_IN]) {
 				usbd_dev->user_callback_ctr[i]
 					[USB_TRANSACTION_IN](usbd_dev, i);
 			}
-
-			REBASE(OTG_DIEPINT(i)) = OTG_DIEPINTX_XFRC;
 		}
 	}
 


### PR DESCRIPTION
*Descibe: if IN callback is slow enough, that usb core completes send transfer before callback
        return, OTG_DIEPINTX_XFRC will dorp by poller, therefore completion of sended frame
        cant be noifyed. that s why need to clear OTG_DIEPINTX_XFRC before callback