### PR TITLE
Mention GNU awk requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ _TIP_: Include this repository as a GIT submodule in your project. To make sure
 Prerequisites
 -------------
 
-Building requires python. (Some code is generated)
+Building requires python and GNU awk (`gawk`, e.g. `mawk` won't do), which
+help generate some code.
 
 **For Ubuntu/Fedora:**
 


### PR DESCRIPTION
Mention GNU awk (gawk) as being required, as the build would fail
with e.g. mawk.

E.g. libopencm3-examples fails with mawk like this:

      GENLNK  samd10d14
    arm-none-eabi-gcc -E -mcpu=cortex-m0plus -mthumb -msoft-float -DSAMD  -P -E /home/nick/projects/github.com/libopencm3/libopencm3-examples/libopencm3/ld/linker.ld.S > generated.samd10d14.ld
    arm-none-eabi-gcc --static -nostartfiles -Tgenerated.samd10d14.ld -mcpu=cortex-m0plus -mthumb -msoft-float -Wl,-Map=miniblink.map -Wl,--gc-sections -L/home/nick/projects/github.com/libopencm3/libopencm3-examples/libopencm3/lib miniblink.o -lopencm3_samd -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group -o miniblink.elf
    /usr/lib/gcc/arm-none-eabi/5.4.1/../../../arm-none-eabi/bin/ld:generated.samd10d14.ld:16: warning: memory region `rom' not declared
    /usr/lib/gcc/arm-none-eabi/5.4.1/../../../arm-none-eabi/bin/ld: invalid origin for memory region ram