### PR TITLE
stm32: usart: drop usart_get_interrupt_source()

### DIFF
--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -127,7 +127,6 @@ void usart_disable_tx_interrupt(uint32_t usart);
 void usart_enable_error_interrupt(uint32_t usart);
 void usart_disable_error_interrupt(uint32_t usart);
 bool usart_get_flag(uint32_t usart, uint32_t flag);
-bool usart_get_interrupt_source(uint32_t usart, uint32_t flag);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f0/usart.h
+++ b/include/libopencm3/stm32/f0/usart.h
@@ -326,7 +326,6 @@ void usart_disable_tx_interrupt(uint32_t usart);
 void usart_enable_error_interrupt(uint32_t usart);
 void usart_disable_error_interrupt(uint32_t usart);
 bool usart_get_flag(uint32_t usart, uint32_t flag);
-bool usart_get_interrupt_source(uint32_t usart, uint32_t flag);
 
 END_DECLS
 

--- a/lib/stm32/common/usart_common_f124.c
+++ b/lib/stm32/common/usart_common_f124.c
@@ -109,35 +109,5 @@ bool usart_get_flag(uint32_t usart, uint32_t flag)
 	return ((USART_SR(usart) & flag) != 0);
 }
 
-/*---------------------------------------------------------------------------*/
-/** @brief USART Return Interrupt Source.
-
-Returns true if the specified interrupt flag (IDLE, RXNE, TC, TXE or OE) was
-set and the interrupt was enabled. If the specified flag is not an interrupt
-flag, the function returns false.
-
-@todo  These are the most important interrupts likely to be used. Others
-relating to LIN break, and error conditions in multibuffer communication, need
-to be added for completeness.
-
-@param[in] usart unsigned 32 bit. USART block register address base @ref
-usart_reg_base
-@param[in] flag Unsigned int32. Status register flag  @ref usart_sr_flags.
-@returns boolean: flag and interrupt enable both set.
-*/
-
-bool usart_get_interrupt_source(uint32_t usart, uint32_t flag)
-{
-	uint32_t flag_set = (USART_SR(usart) & flag);
-	/* IDLE, RXNE, TC, TXE interrupts */
-	if ((flag >= USART_SR_IDLE) && (flag <= USART_SR_TXE)) {
-		return ((flag_set & USART_CR1(usart)) != 0);
-	/* Overrun error */
-	} else if (flag == USART_SR_ORE) {
-		return flag_set && (USART_CR3(usart) & USART_CR3_CTSIE);
-	}
-
-	return false;
-}
 
 /**@}*/

--- a/lib/stm32/f0/usart.c
+++ b/lib/stm32/f0/usart.c
@@ -398,32 +398,5 @@ bool usart_get_flag(uint32_t usart, uint32_t flag)
 	return ((USART_ISR(usart) & flag) != 0);
 }
 
-/*---------------------------------------------------------------------------*/
-/** @brief USART Return Interrupt Source.
- *
- * Returns true if the specified interrupt flag (IDLE, RXNE, TC, TXE or OE) was
- * set and the interrupt was enabled. If the specified flag is not an interrupt
- * flag, the function returns false.
- *
- * @param[in] usart unsigned 32 bit. USART block register address base @ref
- * usart_reg_base
- * @param[in] flag Unsigned int32. Status register flag  @ref usart_sr_flags.
- * @returns boolean: flag and interrupt enable both set.
- */
-
-bool usart_get_interrupt_source(uint32_t usart, uint32_t flag)
-{
-	uint32_t flag_set = (USART_ISR(usart) & flag);
-	/* IDLE, RXNE, TC, TXE interrupts */
-	if ((flag >= USART_ISR_IDLE) && (flag <= USART_ISR_TXE)) {
-		return ((flag_set & USART_CR1(usart)) != 0);
-	/* Overrun error */
-	} else if (flag == USART_ISR_ORE) {
-		return flag_set && (USART_CR3(usart) & USART_CR3_CTSIE);
-	}
-
-	return false;
-}
-
 /**@}*/
 

--- a/lib/stm32/f3/usart.c
+++ b/lib/stm32/f3/usart.c
@@ -106,35 +106,5 @@ bool usart_get_flag(uint32_t usart, uint32_t flag)
 	return ((USART_ISR(usart) & flag) != 0);
 }
 
-/*---------------------------------------------------------------------------*/
-/** @brief USART Return Interrupt Source.
- *
- * Returns true if the specified interrupt flag (IDLE, RXNE, TC, TXE or OE) was
- * set and the interrupt was enabled. If the specified flag is not an interrupt
- * flag, the function returns false.
- *
- * @todo  These are the most important interrupts likely to be used. Others
- * relating to LIN break, and error conditions in multibuffer communication,
- * need to be added for completeness.
- *
- * @param[in] usart unsigned 32 bit. USART block register address base @ref
- * usart_reg_base
- * @param[in] flag Unsigned int32. Status register flag  @ref usart_sr_flags.
- * @returns boolean: flag and interrupt enable both set.
- */
-
-bool usart_get_interrupt_source(uint32_t usart, uint32_t flag)
-{
-	uint32_t flag_set = (USART_ISR(usart) & flag);
-	/* IDLE, RXNE, TC, TXE interrupts */
-	if ((flag >= USART_ISR_IDLE) && (flag <= USART_ISR_TXE)) {
-		return ((flag_set & USART_CR1(usart)) != 0);
-	/* Overrun error */
-	} else if (flag == USART_ISR_ORE) {
-		return flag_set && (USART_CR3(usart) & USART_CR3_CTSIE);
-	}
-
-	return false;
-}
 
 /**@}*/


### PR DESCRIPTION
It was never complete, even for F1 family code, and went on to be even
less complete for f0 and f3.  The usefulness of a library function to
check for both the irq being enabled _and_ the status flag is highly
questionable, and caused known user confusion.

The existing, much simpler, and fully functional usart_get_flag() is
a good replacement in almost all sane use cases.

Fixes https://github.com/libopencm3/libopencm3/issues/734