### PR TITLE
added functions for setting rtc-relevant registers in the rcc domain,…

### DIFF
--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -959,6 +959,11 @@ void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq, uint32_t pllr);
 uint32_t rcc_system_clock_source(void);
 void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
+void rcc_backupdomain_reset(void);
+void rcc_set_rtc_source(uint32_t rtc_sel);
+void rcc_set_lsemode(uint32_t mode);
+void rcc_rtc_clk_enable(void);
+void rcc_rtc_clk_disable(void);
 
 END_DECLS
 

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -760,4 +760,42 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	rcc_osc_off(RCC_HSI);
 }
 
+void rcc_backupdomain_reset(void)
+{
+    /* Set the backup domain software reset. */
+    RCC_BDCR |= RCC_BDCR_BDRST;
+
+    /* Clear the backup domain software reset. */
+    RCC_BDCR &= ~RCC_BDCR_BDRST;
+}
+
+void rcc_set_rtc_source(uint32_t rtc_sel)
+{
+    uint32_t reg32;
+
+    reg32 = RCC_BDCR;
+    reg32 &= ~(RCC_BDCR_RTCSEL_MASK << RCC_BDCR_RTCSEL_SHIFT);
+    reg32 |= (rtc_sel & RCC_BDCR_RTCSEL_MASK) << RCC_BDCR_RTCSEL_SHIFT;
+    RCC_BDCR = reg32;
+}
+
+void rcc_rtc_clk_enable(void)
+{
+    RCC_BDCR |= RCC_BDCR_RTCEN;
+}
+
+void rcc_rtc_clk_disable(void)
+{
+    RCC_BDCR &= ~(RCC_BDCR_RTCEN);
+}
+
+void rcc_set_lsemode(uint32_t mode)
+{
+    uint32_t reg32;
+
+    reg32 = RCC_BDCR;
+    reg32 &= ~(RCC_BDCR_LSEMOD);
+    RCC_BDCR = (reg32 | mode);
+}
+
 /**@}*/


### PR DESCRIPTION
… mainly clock sources and backup domain resetting

Looks to be relevant to L1, F0,2,3,4 based on [http://www.st.com/resource/en/application_note/dm00025071.pdf](url) Currently the only files modified are for F4, but that could be expanded.