### PR TITLE
Add exti to makefile STM32L0

### DIFF
--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -42,6 +42,7 @@ OBJS		+= timer_common_all.o
 OBJS            += gpio_common_all.o gpio_common_f0234.o rcc_common_all.o
 OBJS		+= adc_common_v2.o
 OBJS		+= crs_common_all.o
+OBJS		+= exti_common_all.o
 
 OBJS            += usb.o usb_control.o usb_standard.o
 OBJS            += st_usbfs_core.o st_usbfs_v2.o


### PR DESCRIPTION
EXTI support is missing for the STM32L0. It only needed to be added to the makefile.

Tested with a Lora radio application that used three GPIO lines to send different interrupts from the radio module to the L052. Tested with a Jeenode Zero Rev1.