### PR TITLE
stm32f4: flash: Refactor FLASH_ACR code

### DIFF
--- a/include/libopencm3/stm32/common/flash_common_f234.h
+++ b/include/libopencm3/stm32/common/flash_common_f234.h
@@ -50,6 +50,8 @@
 
 /* --- FLASH_ACR values ---------------------------------------------------- */
 
+#define FLASH_ACR_LATENCY_MASK	0x07
+
 #define FLASH_ACR_LATENCY_0WS		0x00
 #define FLASH_ACR_LATENCY_1WS		0x01
 #define FLASH_ACR_LATENCY_2WS		0x02

--- a/include/libopencm3/stm32/common/flash_common_f24.h
+++ b/include/libopencm3/stm32/common/flash_common_f24.h
@@ -51,8 +51,8 @@
 
 #define FLASH_ACR_DCRST			(1 << 12)
 #define FLASH_ACR_ICRST			(1 << 11)
-#define FLASH_ACR_DCE			(1 << 10)
-#define FLASH_ACR_ICE			(1 << 9)
+#define FLASH_ACR_DCEN			(1 << 10)
+#define FLASH_ACR_ICEN			(1 << 9)
 #define FLASH_ACR_PRFTEN		(1 << 8)
 
 /* --- FLASH_SR values ----------------------------------------------------- */
@@ -147,4 +147,3 @@ END_DECLS
 #warning "only via flash.h"
 #endif
 /** @endcond */
-

--- a/lib/stm32/common/flash_common_f234.c
+++ b/lib/stm32/common/flash_common_f234.c
@@ -41,7 +41,7 @@ void flash_set_ws(uint32_t ws)
 	uint32_t reg32;
 
 	reg32 = FLASH_ACR;
-	reg32 &= ~((1 << 0) | (1 << 1) | (1 << 2));
+	reg32 &= ~(FLASH_ACR_LATENCY_MASK);
 	reg32 |= ws;
 	FLASH_ACR = reg32;
 }

--- a/lib/stm32/common/flash_common_f234.c
+++ b/lib/stm32/common/flash_common_f234.c
@@ -117,4 +117,3 @@ void flash_wait_for_last_operation(void)
 	while ((FLASH_SR & FLASH_SR_BSY) == FLASH_SR_BSY);
 }
 /**@}*/
-

--- a/lib/stm32/common/flash_common_f24.c
+++ b/lib/stm32/common/flash_common_f24.c
@@ -48,7 +48,7 @@ static inline void flash_set_program_size(uint32_t psize)
 
 void flash_dcache_enable(void)
 {
-	FLASH_ACR |= FLASH_ACR_DCE;
+	FLASH_ACR |= FLASH_ACR_DCEN;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -58,7 +58,7 @@ void flash_dcache_enable(void)
 
 void flash_dcache_disable(void)
 {
-	FLASH_ACR &= ~FLASH_ACR_DCE;
+	FLASH_ACR &= ~FLASH_ACR_DCEN;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -68,7 +68,7 @@ void flash_dcache_disable(void)
 
 void flash_icache_enable(void)
 {
-	FLASH_ACR |= FLASH_ACR_ICE;
+	FLASH_ACR |= FLASH_ACR_ICEN;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -78,7 +78,7 @@ void flash_icache_enable(void)
 
 void flash_icache_disable(void)
 {
-	FLASH_ACR &= ~FLASH_ACR_ICE;
+	FLASH_ACR &= ~FLASH_ACR_ICEN;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -412,4 +412,3 @@ void flash_program_option_bytes(uint32_t data)
 	flash_wait_for_last_operation();
 }
 /**@}*/
-

--- a/lib/stm32/f2/rcc.c
+++ b/lib/stm32/f2/rcc.c
@@ -57,8 +57,7 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
 	},

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -60,8 +60,7 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 48000000,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
@@ -75,8 +74,7 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_2,
 		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_2WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_2WS,
 		.ahb_frequency  = 84000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
@@ -91,8 +89,7 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 120000000,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
@@ -106,8 +103,7 @@ const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_5WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_5WS,
 		.ahb_frequency  = 168000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
@@ -125,8 +121,7 @@ const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 48000000,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
@@ -140,8 +135,7 @@ const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_2,
 		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_2WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_2WS,
 		.ahb_frequency  = 84000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
@@ -156,8 +150,7 @@ const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 120000000,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
@@ -171,8 +164,7 @@ const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_5WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_5WS,
 		.ahb_frequency  = 168000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
@@ -190,8 +182,7 @@ const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 48000000,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
@@ -205,8 +196,7 @@ const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_2,
 		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_2WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_2WS,
 		.ahb_frequency  = 84000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
@@ -221,8 +211,7 @@ const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 120000000,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
@@ -236,8 +225,7 @@ const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_5WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_5WS,
 		.ahb_frequency  = 168000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
@@ -255,8 +243,7 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 48000000,
 		.apb1_frequency = 12000000,
 		.apb2_frequency = 24000000,
@@ -270,8 +257,7 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_2,
 		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_2WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_2WS,
 		.ahb_frequency  = 84000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,
@@ -286,8 +272,7 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.power_save = 1,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_3WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_3WS,
 		.ahb_frequency  = 120000000,
 		.apb1_frequency = 30000000,
 		.apb2_frequency = 60000000,
@@ -301,8 +286,7 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
-		.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE |
-				FLASH_ACR_LATENCY_5WS,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_5WS,
 		.ahb_frequency  = 168000000,
 		.apb1_frequency = 42000000,
 		.apb2_frequency = 84000000,


### PR DESCRIPTION
Instead of enabling data and instruction caches through flash_set_ws(), use their dedicated functions. This seemed hacky to be using flash_set_ws() to set bits other than the wait state bits. I changed it to instead use the flash_dcache_enable() and flash_icache_enable() functions, which should be more robust.