### PR TITLE
stm32f4: adc: Add VBat sensor enable/disable

### DIFF
--- a/include/libopencm3/stm32/f4/adc.h
+++ b/include/libopencm3/stm32/f4/adc.h
@@ -579,9 +579,10 @@ void adc_eoc_after_each(uint32_t adc);
 void adc_eoc_after_group(uint32_t adc);
 void adc_set_dma_continue(uint32_t adc);
 void adc_set_dma_terminate(uint32_t adc);
-
 void adc_enable_temperature_sensor(void);
 void adc_disable_temperature_sensor(void);
+void adc_enable_vbat_sensor(void);
+void adc_disable_vbat_sensor(void);
 
 END_DECLS
 

--- a/lib/stm32/f4/adc.c
+++ b/lib/stm32/f4/adc.c
@@ -432,6 +432,30 @@ void adc_disable_temperature_sensor()
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief ADC Enable The VBat Sensor
+
+This enables the battery voltage measurements on ADC1 channel 18. On STM32F42x
+and STM32F43x, this must be disabled when the temperature sensor is enabled. If
+both are enabled, only the VBat conversion is performed.
+*/
+
+void adc_enable_vbat_sensor(void)
+{
+	ADC_CCR |= ADC_CCR_VBATE;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief ADC Disable The VBat Sensor
+
+Disabling this will reduce power consumption from the battery voltage
+measurement.
+*/
+
+void adc_disable_vbat_sensor(void)
+{
+	ADC_CCR &= ~ADC_CCR_VBATE;
+}
+
+/*---------------------------------------------------------------------------*/
 
 /**@}*/
-


### PR DESCRIPTION
Fairly straightforward addition of enable/disable functions for VBat sensor.