### PR TITLE
Updated makefile to be able to build for specific target families only.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,14 @@ space:=
 space+=
 SRCLIBDIR:= $(subst $(space),\$(space),$(realpath lib))
 
-TARGETS := stm32/f0 stm32/f1 stm32/f2 stm32/f3 stm32/f4 stm32/f7
-TARGETS += stm32/l0 stm32/l1 stm32/l4
-TARGETS += lpc13xx lpc17xx lpc43xx/m4 lpc43xx/m0
-TARGETS += lm3s lm4f
-TARGETS += efm32/tg efm32/g efm32/lg efm32/gg
-TARGETS += sam/3a sam/3n sam/3s sam/3u sam/3x
-TARGETS += sam/d
-TARGETS += vf6xx
+TARGETS ?=	stm32/f0 stm32/f1 stm32/f2 stm32/f3 stm32/f4 stm32/f7 \
+		stm32/l0 stm32/l1 stm32/l4 \
+		lpc13xx lpc17xx lpc43xx/m4 lpc43xx/m0 \
+		lm3s lm4f \
+		efm32/tg efm32/g efm32/lg efm32/gg \
+		sam/3a sam/3n sam/3s sam/3u sam/3x \
+		sam/d \
+		vf6xx
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)
@@ -43,7 +43,7 @@ Q := @
 MAKEFLAGS += --no-print-directory
 endif
 
-IRQ_DEFN_FILES	:= $(shell find . -name 'irq.json')
+IRQ_DEFN_FILES  := $(foreach TARGET,$(TARGETS),$(wildcard include/libopencm3/$(TARGET)/irq.json))
 STYLECHECKFILES := $(shell find . -name '*.[ch]')
 
 all: build


### PR DESCRIPTION
Hi .. 

I'm tough it would be nice to be able to build libopencm3 only for a specific target family if desired. I like that as it saves time and avoids unneeded output in the build console. 

All what has to be done to allow this is to set TARGETS only if absent to the default as it has been done so far. When a user sets TARGETS (e.g. make TARGETS=stm32/f1) only this part of the library will be build. Furthermore I have changed the way the irq.json files are collected to get only the needed ones.

Br. J.