### PR TITLE
stm32: usb: Fix handling of CTR_RX

### DIFF
--- a/lib/stm32/common/st_usbfs_core.c
+++ b/lib/stm32/common/st_usbfs_core.c
@@ -205,7 +205,6 @@ uint16_t st_usbfs_ep_read_packet(usbd_device *dev, uint8_t addr,
 
 	len = MIN(USB_GET_EP_RX_COUNT(addr) & 0x3ff, len);
 	st_usbfs_copy_from_pm(buf, USB_GET_EP_RX_BUFF(addr), len);
-	USB_CLR_EP_RX_CTR(addr);
 
 	if (!st_usbfs_force_nak[addr]) {
 		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
@@ -236,6 +235,7 @@ void st_usbfs_poll(usbd_device *dev)
 			} else {
 				type = USB_TRANSACTION_OUT;
 			}
+			USB_CLR_EP_RX_CTR(ep);
 		} else {
 			type = USB_TRANSACTION_IN;
 			USB_CLR_EP_TX_CTR(ep);
@@ -243,8 +243,6 @@ void st_usbfs_poll(usbd_device *dev)
 
 		if (dev->user_callback_ctr[ep][type]) {
 			dev->user_callback_ctr[ep][type] (dev, ep);
-		} else {
-			USB_CLR_EP_RX_CTR(ep);
 		}
 	}
 

--- a/lib/stm32/common/st_usbfs_core.c
+++ b/lib/stm32/common/st_usbfs_core.c
@@ -235,7 +235,6 @@ void st_usbfs_poll(usbd_device *dev)
 			} else {
 				type = USB_TRANSACTION_OUT;
 			}
-			USB_CLR_EP_RX_CTR(ep);
 		} else {
 			type = USB_TRANSACTION_IN;
 			USB_CLR_EP_TX_CTR(ep);
@@ -243,6 +242,10 @@ void st_usbfs_poll(usbd_device *dev)
 
 		if (dev->user_callback_ctr[ep][type]) {
 			dev->user_callback_ctr[ep][type] (dev, ep);
+		}
+
+		if (istr & USB_ISTR_DIR) {
+			USB_CLR_EP_RX_CTR(ep);
 		}
 	}
 


### PR DESCRIPTION
The way the st_usbfs code handles the CTR_RX flag is bad and can result in both interrupt storms and lost data.

The current code clears CTR_RX either when ep_read() is called or when poll() is called and there is no callback configured to handle the event.

In the first case, the responsibility for the event being cleared is delegated away from the poll() function to the callback function, expecting it to call ep_read(). In a corner case where the callback doesn't read (e.g. in the control request handler code when it's in an unexpected state) the event won't be cleared before poll() returns, potentially resulting in a stuck endpoint or an interrupt storm if poll() is called from the USB ISR.

In the second case, CTR_RX flag is being cleared if there is no callback function configured. This however happens regardless of event type, so a TX event without a configured callback will clear any pending RX event on the same endpoint, resulting in lost data. The documentation for the DIR bit in USB_ISTR states that if both TX and RX events are pending, RX will be reported first, so the window for this race condition is pretty slim.

This patch fixes both issues by always clearing CTR_RX once we've determined that we're processing an RX event. CTR_RX is not used for anything other than for poll() to determine that there's an RX event to process, so this should not break any functionality for existing code.

I don't have a test case to demonstrate the problem and the fix, but the patch is simple and should be quick to review manually. The logic error in the original code is evident by just reading it, and existing test cases should be able to verify that this fix doesn't break usb functionality.

This problem is possibly the root cause of #447 and related issues.