### PR TITLE
F7 clocks

### DIFF
--- a/include/libopencm3/stm32/f7/flash.h
+++ b/include/libopencm3/stm32/f7/flash.h
@@ -1,18 +1,22 @@
-/** @defgroup flash_defines FLASH Defines
- *
- * @ingroup STM32F7xx_defines
- *
- * @brief Defined Constants and Types for the STM32F7xx FLASH Memory
- *
- * @version 1.0.0
- *
- * @date 14 January 2014
- *
- * LGPL License Terms @ref lgpl_license
- */
+#ifndef LIBOPENCM3_FLASH_H
+#define LIBOPENCM3_FLASH_H
 
+/** @addtogroup flash_defines
+ *
+ * @author @htmlonly &copy; @endhtmlonly 2017
+ * Matthew Lai <m@matthewlai.ca>
+ * @author @htmlonly &copy; @endhtmlonly 2010
+ * Thomas Otto <tommi@viadmin.org>
+ * @author @htmlonly &copy; @endhtmlonly 2010
+ * Mark Butler <mbutler@physics.otago.ac.nz>
+ *
+ */
 /*
  * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2017 Matthew Lai <m@matthewlai.ca>
+ * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2010 Mark Butler <mbutler@physics.otago.ac.nz>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -28,10 +32,174 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBOPENCM3_FLASH_H
-#define LIBOPENCM3_FLASH_H
+/*
+ * For details see:
+ * PM0081 Programming manual: STM32F40xxx and STM32F41xxx Flash programming
+ * September 2011, Doc ID 018520 Rev 1
+ * https://github.com/libopencm3/libopencm3-archive/blob/master/st_micro/DM00023388.pdf
+ */
 
-#include <libopencm3/stm32/common/flash_common_f24.h>
+/*
+ * Differences between F7 and F4:
+ * 1. 	icache and dcache are now combined into a unified ART cache. The CPU has
+ * 	its own d/i-caches, but those are unrelated to this. They are on the
+ *	AXIM bus.
+ * 2. 	There's an OPTCR1 is now used for boot addresses. Write protect bits
+ * 	are in OPTCR. Why does F4 have 2 copies of nWRP?
+ * 3. 	Latency field in FLASH_ACR is now 4 bits. Some CPU frequencies supported
+ * 	by F7 require more than 7 wait states.
+ * 4. 	FLASH_SR_PGSERR (programming sequence error) is now FLASH_SR_ERSERR (
+ *	erase sequence error).
+ * 5. 	FLASH_SR_BSY field is now read-only. Seems to also be read-only in F4?
+ *	Why did we have a clear busy flag function?
+ * 6. 	There are now two watchdogs - IWDG (independent watchdog) and WWDG (
+ * 	window watchdog).
+ */
+
+/**@{*/
+/* --- FLASH registers ----------------------------------------------------- */
+
+#define FLASH_ACR			MMIO32(FLASH_MEM_INTERFACE_BASE + 0x00)
+#define FLASH_KEYR			MMIO32(FLASH_MEM_INTERFACE_BASE + 0x04)
+#define FLASH_OPTKEYR			MMIO32(FLASH_MEM_INTERFACE_BASE + 0x08)
+#define FLASH_SR			MMIO32(FLASH_MEM_INTERFACE_BASE + 0x0C)
+#define FLASH_CR			MMIO32(FLASH_MEM_INTERFACE_BASE + 0x10)
+#define FLASH_OPTCR			MMIO32(FLASH_MEM_INTERFACE_BASE + 0x14)
+#define FLASH_OPTCR1			MMIO32(FLASH_MEM_INTERFACE_BASE + 0x18)
+
+/* --- FLASH Keys -----------------------------------------------------------*/
+
+#define FLASH_KEYR_KEY1			((uint32_t)0x45670123)
+#define FLASH_KEYR_KEY2			((uint32_t)0xcdef89ab)
+#define FLASH_OPTKEYR_KEY1		((uint32_t)0x08192a3b)
+#define FLASH_OPTKEYR_KEY2		((uint32_t)0x4c5d6e7f)
+
+/* --- FLASH registers ----------------------------------------------------- */
+
+/* --- FLASH_ACR values ---------------------------------------------------- */
+
+#define FLASH_ACR_ARTRST		(1 << 11)
+#define FLASH_ACR_ARTEN			(1 << 9)
+#define FLASH_ACR_PRFTEN		(1 << 8)
+
+#define FLASH_ACR_LATENCY_MASK		0x0f
+#define FLASH_ACR_LATENCY_0WS		0x00
+#define FLASH_ACR_LATENCY_1WS		0x01
+#define FLASH_ACR_LATENCY_2WS		0x02
+#define FLASH_ACR_LATENCY_3WS		0x03
+#define FLASH_ACR_LATENCY_4WS		0x04
+#define FLASH_ACR_LATENCY_5WS		0x05
+#define FLASH_ACR_LATENCY_6WS		0x06
+#define FLASH_ACR_LATENCY_7WS		0x07
+#define FLASH_ACR_LATENCY_8WS		0x08
+#define FLASH_ACR_LATENCY_9WS		0x09
+#define FLASH_ACR_LATENCY_10WS		0x0a
+#define FLASH_ACR_LATENCY_11WS		0x0b
+#define FLASH_ACR_LATENCY_12WS		0x0c
+#define FLASH_ACR_LATENCY_13WS		0x0d
+#define FLASH_ACR_LATENCY_14WS		0x0e
+#define FLASH_ACR_LATENCY_15WS		0x0f
+
+/* --- FLASH_SR values ----------------------------------------------------- */
+
+#define FLASH_SR_BSY			(1 << 16)
+#define FLASH_SR_ERSERR			(1 << 7)
+#define FLASH_SR_PGPERR			(1 << 6)
+#define FLASH_SR_PGAERR			(1 << 5)
+#define FLASH_SR_WRPERR			(1 << 4)
+#define FLASH_SR_OPERR			(1 << 1)
+#define FLASH_SR_EOP			(1 << 0)
+
+/* --- FLASH_CR values ----------------------------------------------------- */
+
+#define FLASH_CR_LOCK			(1 << 31)
+#define FLASH_CR_ERRIE			(1 << 25)
+#define FLASH_CR_EOPIE			(1 << 24)
+#define FLASH_CR_STRT			(1 << 16)
+
+#define FLASH_CR_PROGRAM_MASK		0x3
+#define FLASH_CR_PROGRAM_SHIFT		8
+/** @defgroup flash_cr_program_width Flash programming width
+@ingroup flash_group
+@{*/
+#define FLASH_CR_PROGRAM_X8		0
+#define FLASH_CR_PROGRAM_X16		1
+#define FLASH_CR_PROGRAM_X32		2
+#define FLASH_CR_PROGRAM_X64		3
+/**@}*/
+
+#define FLASH_CR_SNB_SHIFT		3
+#define FLASH_CR_SNB_MASK		0x1f
+
+#define FLASH_CR_MER			(1 << 2)
+#define FLASH_CR_SER			(1 << 1)
+#define FLASH_CR_PG			(1 << 0)
+
+/* --- FLASH_OPTCR values -------------------------------------------------- */
+
+#define FLASH_OPTCR_IWDG_STOP		(1 << 31)
+#define FLASH_OPTCR_IWDG_STDBY		(1 << 30)
+
+#define FLASH_OPTCR_NWRP_SHIFT		16
+#define FLASH_OPTCR_NWRP_MASK		0xff
+
+#define FLASH_OPTCR_RDP_SHIFT		8
+#define FLASH_OPTCR_RDP_MASK		0xff
+
+#define FLASH_OPTCR_NRST_STDBY		(1 << 7)
+#define FLASH_OPTCR_NRST_STOP		(1 << 6)
+#define FLASH_OPTCR_IWDG_SW		(1 << 5)
+#define FLASH_OPTCR_WWDG_SW		(1 << 4)
+
+#define FLASH_OPTCR_BOR_LEV_MASK	3
+#define FLASH_OPTCR_BOR_LEV_SHIFT	2
+#define FLASH_OPTCR_BOR_LEV_3		0x00
+#define FLASH_OPTCR_BOR_LEV_2		0x01
+#define FLASH_OPTCR_BOR_LEV_1		0x02
+#define FLASH_OPTCR_BOR_OFF		0x03
+
+#define FLASH_OPTCR_OPTSTRT		(1 << 1)
+#define FLASH_OPTCR_OPTLOCK		(1 << 0)
+
+/* --- FLASH_OPTCR1 values ------------------------------------------------- */
+#define FLASH_OPTCR1_BOOT_ADD1_MASK	0xffff
+#define FLASH_OPTCR1_BOOT_ADD1_SHIFT	16
+#define FLASH_OPTCR1_BOOT_ADD0_MASK	0xffff
+#define FLASH_OPTCR1_BOOT_ADD0_SHIFT	0
+
+/* --- Function prototypes ------------------------------------------------- */
+
+BEGIN_DECLS
+
+void flash_set_ws(uint32_t ws);
+void flash_unlock(void);
+void flash_lock(void);
+void flash_clear_pgperr_flag(void);
+void flash_clear_eop_flag(void);
+void flash_wait_for_last_operation(void);
+
+void flash_unlock_option_bytes(void);
+void flash_lock_option_bytes(void);
+void flash_clear_erserr_flag(void);
+void flash_clear_wrperr_flag(void);
+void flash_clear_pgaerr_flag(void);
+void flash_art_enable(void);
+void flash_art_disable(void);
+void flash_prefetch_enable(void);
+void flash_prefetch_disable(void);
+void flash_art_reset(void);
+void flash_clear_status_flags(void);
+void flash_erase_all_sectors(uint32_t program_size);
+void flash_erase_sector(uint8_t sector, uint32_t program_size);
+void flash_program_double_word(uint32_t address, uint64_t data);
+void flash_program_word(uint32_t address, uint32_t data);
+void flash_program_half_word(uint32_t address, uint16_t data);
+void flash_program_byte(uint32_t address, uint8_t data);
+void flash_program(uint32_t address, uint8_t *data, uint32_t len);
+void flash_program_option_bytes(uint32_t data);
+
+END_DECLS
+/**@}*/
 
 #endif
 

--- a/include/libopencm3/stm32/f7/pwr.h
+++ b/include/libopencm3/stm32/f7/pwr.h
@@ -1,0 +1,282 @@
+/** @defgroup pwr_defines PWR Defines
+
+@brief <b>Defined Constants and Types for the STM32F7xx Power Control</b>
+
+@ingroup STM32F7xx_defines
+
+@version 1.0.0
+
+@author @htmlonly &copy; @endhtmlonly 2017 Matthew Lai <m@matthewlai.ca>
+
+@date 12 March 2017
+
+LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2017 Matthew Lai <m@matthewlai.ca>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_PWR_H
+#define LIBOPENCM3_PWR_H
+
+/**@{*/
+
+/* --- PWR registers ------------------------------------------------------- */
+
+/* Power control register (PWR_CR1) */
+#define PWR_CR1				MMIO32(POWER_CONTROL_BASE + 0x00)
+
+/* Power control/status register (PWR_CSR1) */
+#define PWR_CSR1			MMIO32(POWER_CONTROL_BASE + 0x04)
+
+/* Power control register 2 (PWR_CR2) */
+#define PWR_CR2				MMIO32(POWER_CONTROL_BASE + 0x08)
+
+/* Power control/status register 2 (PWR_CSR2) */
+#define PWR_CSR2			MMIO32(POWER_CONTROL_BASE + 0x0c)
+
+/* --- PWR_CR1 values ------------------------------------------------------- */
+
+/* Bits [31:20]: Reserved, must be kept at reset value. */
+
+/* UDEN[19:18]: Under-drive enable in stop mode */
+#define PWR_CR1_UDEN_LSB		18
+/** @defgroup pwr_uden Under-drive enable in stop mode
+@ingroup STM32F_pwr_defines
+
+@{*/
+#define PWR_CR1_UDEN_DISABLED		(0x0 << PWR_CR1_UDEN_LSB)
+#define PWR_CR1_UDEN_ENABLED		(0x3 << PWR_CR1_UDEN_LSB)
+/**@}*/
+#define PWR_CR1_UDEN_MASK		(0x3 << PWR_CR1_UDEN_LSB)
+
+/* ODSWEN: Over-drive switching enabled */
+#define PWR_CR1_ODSWEN			(1 << 17)
+
+/* ODEN: Over-drive enable */
+#define PWR_CR1_ODEN			(1 << 16)
+
+/* VOS[15:14]: Regulator voltage scaling output selection */
+#define PWR_CR1_VOS_LSB			14
+/** @defgroup pwr_vos Regulator voltage scaling output selection
+@ingroup STM32F_pwr_defines
+
+@{*/
+#define PWR_CR1_VOS_SCALE_3		(0x1 << PWR_CR1_VOS_LSB)
+#define PWR_CR1_VOS_SCALE_2		(0x2 << PWR_CR1_VOS_LSB)
+#define PWR_CR1_VOS_SCALE_1		(0x3 << PWR_CR1_VOS_LSB)
+/**@}*/
+#define PWR_CR1_VOS_MASK		(0x3 << PWR_CR1_VOS_LSB)
+
+/* ADCDC1: Masks extra flash accesses by prefetch (see AN4073) */
+#define PWR_CR1_ADCDC1			(1 << 13)
+
+/* Bit 12: Reserved, must be kept at reset value. */
+
+/* MRUDS: Main regulator in deepsleep under-drive mode */
+#define PWR_CR1_MRUDS			(1 << 11)
+
+/* LPUDS: Low-power regulator in deepsleep under-drive mode */
+#define PWR_CR1_LPUDS			(1 << 10)
+
+/* FPDS: Flash power-down in Stop mode */
+#define PWR_CR1_FPDS			(1 << 9)
+
+/* DBP: Disable backup domain write protection */
+#define PWR_CR1_DBP			(1 << 8)
+
+/* PLS[7:5]: PVD level selection */
+#define PWR_CR1_PLS_LSB			5
+/** @defgroup pwr_pls PVD level selection
+@ingroup STM32F_pwr_defines
+
+@{*/
+#define PWR_CR1_PLS_2V0			(0x0 << PWR_CR_PLS_LSB)
+#define PWR_CR1_PLS_2V1			(0x1 << PWR_CR_PLS_LSB)
+#define PWR_CR1_PLS_2V3			(0x2 << PWR_CR_PLS_LSB)
+#define PWR_CR1_PLS_2V5			(0x3 << PWR_CR_PLS_LSB)
+#define PWR_CR1_PLS_2V6			(0x4 << PWR_CR_PLS_LSB)
+#define PWR_CR1_PLS_2V7			(0x5 << PWR_CR_PLS_LSB)
+#define PWR_CR1_PLS_2V8			(0x6 << PWR_CR_PLS_LSB)
+#define PWR_CR1_PLS_2V9			(0x7 << PWR_CR_PLS_LSB)
+/**@}*/
+#define PWR_CR1_PLS_MASK		(0x7 << PWR_CR_PLS_LSB)
+
+/* PVDE: Power voltage detector enable */
+#define PWR_CR1_PVDE			(1 << 4)
+
+/* CSBF: Clear standby flag */
+#define PWR_CR1_CSBF			(1 << 3)
+
+/* Bit 2: Reserved, must be kept at reset value. */
+
+/* PDDS: Power down deepsleep */
+#define PWR_CR1_PDDS			(1 << 1)
+
+/* LPDS: Low-power deepsleep */
+#define PWR_CR1_LPDS			(1 << 0)
+
+/* --- PWR_CSR1 values ------------------------------------------------------ */
+
+/* Bits [31:20]: Reserved, must be kept at reset value. */
+
+/* UDRDY[19:18]: Under-drive ready flag */
+#define PWR_CSR1_UDRDY_LSB		18
+/** @defgroup pwr_udrdy Under-drive ready flag
+@ingroup STM32F_pwr_defines
+
+@{*/
+#define PWR_CSR1_UDRDY_DISABLED		(0x0 << PWR_CSR1_UDRDY_LSB)
+#define PWR_CSR1_UDRDY_ACTIVATED	(0x3 << PWR_CSR1_UDRDY_LSB)
+/**@}*/
+#define PWR_CSR1_UDRDY_MASK		(0x3 << PWR_CSR1_UDRDY_LSB)
+
+/* ODSWRDY: Over-drive mode switching ready */
+#define PWR_CSR1_ODSWRDY		(1 << 17)
+
+/* ODRDY: Over-drive mode ready */
+#define PWR_CSR1_ODRDY			(1 << 16)
+
+/* Bit 15: Reserved, must be kept at reset value. */
+
+/* VOSRDY: Regulator voltage scaling output selection ready bit */
+#define PWR_CSR1_VOSRDY			(1 << 14)
+
+/* Bits [13:10]: Reserved, must be kept at reset value. */
+
+/* BRE: Backup regulator enable */
+#define PWR_CSR1_BRE			(1 << 9)
+
+/* EIWUP: Enable internal wakeup */
+#define PWR_CSR1_EIWUP			(1 << 8)
+
+/* Bits [7:4]: Reserved, must be kept at reset value. */
+
+/* BRR: Backup regulator ready */
+#define PWR_CSR1_BRR			(1 << 3)
+
+/* PVDO: PVD output */
+#define PWR_CSR1_PVDO			(1 << 2)
+
+/* SBF: Standby flag */
+#define PWR_CSR1_SBF			(1 << 1)
+
+/* WUIF: Wakeup internal flag */
+#define PWR_CSR1_WUIF			(1 << 0)
+
+/* --- PWR_CR2 values ------------------------------------------------------ */
+
+/* Bits [31:14]: Reserved, must be kept at reset value. */
+
+/* WUPP6: Wakeup pin polarity bit for PI11 */
+#define PWR_CR2_WUPP6			(1 << 13)
+
+/* WUPP5: Wakeup pin polarity bit for PI8 */
+#define PWR_CR2_WUPP5			(1 << 12)
+
+/* WUPP4: Wakeup pin polarity bit for PC13 */
+#define PWR_CR2_WUPP4			(1 << 11)
+
+/* WUPP3: Wakeup pin polarity bit for PC1 */
+#define PWR_CR2_WUPP3			(1 << 10)
+
+/* WUPP2: Wakeup pin polarity bit for PA2 */
+#define PWR_CR2_WUPP2			(1 << 9)
+
+/* WUPP1: Wakeup pin polarity bit for PA0 */
+#define PWR_CR2_WUPP1			(1 << 8)
+
+/* Bits [7:6]: Reserved, must be kept at reset value. */
+
+/* CWUPF6: Clear Wakeup Pin flag for PI11 */
+#define PWR_CR2_CWUPF6			(1 << 5)
+
+/* CWUPF5: Clear Wakeup Pin flag for PI8 */
+#define PWR_CR2_CWUPF5			(1 << 4)
+
+/* CWUPF4: Clear Wakeup Pin flag for PC13 */
+#define PWR_CR2_CWUPF4			(1 << 3)
+
+/* CWUPF3: Clear Wakeup Pin flag for PC1 */
+#define PWR_CR2_CWUPF3			(1 << 2)
+
+/* CWUPF2: Clear Wakeup Pin flag for PA2 */
+#define PWR_CR2_CWUPF2			(1 << 1)
+
+/* CWUPF1: Clear Wakeup Pin flag for PA0 */
+#define PWR_CR2_CWUPF1			(1 << 0)
+
+/* --- PWR_CSR2 values ------------------------------------------------------ */
+
+/* Bits [31:14]: Reserved, must be kept at reset value. */
+
+/* EWUP6: Enable Wakeup pin for PI11 */
+#define PWR_CSR2_EWUP6			(1 << 13)
+
+/* EWUP5: Enable Wakeup pin for PI8 */
+#define PWR_CSR2_EWUP5			(1 << 12)
+
+/* EWUP4: Enable Wakeup pin for PC13 */
+#define PWR_CSR2_EWUP4			(1 << 11)
+
+/* EWUP3: Enable Wakeup pin for PC1 */
+#define PWR_CSR2_EWUP3			(1 << 10)
+
+/* EWUP2: Enable Wakeup pin for PA2 */
+#define PWR_CSR2_EWUP2			(1 << 19)
+
+/* EWUP1: Enable Wakeup pin for PA0 */
+#define PWR_CSR2_EWUP1			(1 << 18)
+
+/* Bits [7:6]: Reserved, must be kept at reset value. */
+
+/* WUPF6: Wakeup Pin flag for PI11 */
+#define PWR_CSR2_WUPF6			(1 << 5)
+
+/* WUPF5: Wakeup Pin flag for PI8 */
+#define PWR_CSR2_WUPF5			(1 << 4)
+
+/* WUPF4: Wakeup Pin flag for PC13 */
+#define PWR_CSR2_WUPF4			(1 << 3)
+
+/* WUPF3: Wakeup Pin flag for PC1 */
+#define PWR_CSR2_WUPF3			(1 << 2)
+
+/* WUPF2: Wakeup Pin flag for PA2 */
+#define PWR_CSR2_WUPF2			(1 << 1)
+
+/* WUPF1: Wakeup Pin flag for PA0 */
+#define PWR_CSR2_WUPF1			(1 << 0)
+
+/* --- Function prototypes ------------------------------------------------- */
+
+enum pwr_vos_scale {
+	PWR_SCALE1, /** <= 180MHz w/o overdrive, <= 216MHz w/ overdrive */
+	PWR_SCALE2, /** <= 168MHz w/o overdrive, <= 180MHz w/ overdrive */
+	PWR_SCALE3, /** <= 144MHz */
+};
+
+BEGIN_DECLS
+
+void pwr_set_vos_scale(enum pwr_vos_scale scale);
+void pwr_enable_overdrive(void);
+void pwr_disable_overdrive(void);
+
+END_DECLS
+
+#endif

--- a/include/libopencm3/stm32/f7/rcc.h
+++ b/include/libopencm3/stm32/f7/rcc.h
@@ -615,7 +615,7 @@ struct rcc_clock_scale {
 	uint16_t plln;
 	uint8_t pllp;
 	uint8_t pllq;
-	uint32_t flash_config;
+	uint32_t flash_waitstates;
 	uint8_t hpre;
 	uint8_t ppre1;
 	uint8_t ppre2;

--- a/include/libopencm3/stm32/f7/rcc.h
+++ b/include/libopencm3/stm32/f7/rcc.h
@@ -36,6 +36,8 @@
 #ifndef LIBOPENCM3_RCC_H
 #define LIBOPENCM3_RCC_H
 
+#include <libopencm3/stm32/f7/pwr.h>
+
 /* --- RCC registers ------------------------------------------------------- */
 
 #define RCC_CR					MMIO32(RCC_BASE + 0x00)
@@ -617,7 +619,8 @@ struct rcc_clock_scale {
 	uint8_t hpre;
 	uint8_t ppre1;
 	uint8_t ppre2;
-	uint8_t power_save;
+	enum pwr_vos_scale vos_scale;
+	uint8_t overdrive;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
 };

--- a/include/libopencm3/stm32/f7/rcc.h
+++ b/include/libopencm3/stm32/f7/rcc.h
@@ -607,11 +607,16 @@ extern uint32_t rcc_apb2_frequency;
 
 enum rcc_clock_3v3 {
 	RCC_CLOCK_3V3_216MHZ,
+	RCC_CLOCK_3V3_168MHZ,
+	RCC_CLOCK_3V3_120MHZ,
+	RCC_CLOCK_3V3_72MHZ,
+	RCC_CLOCK_3V3_48MHZ,
+	RCC_CLOCK_3V3_24MHZ,
 	RCC_CLOCK_3V3_END
 };
 
 struct rcc_clock_scale {
-	uint8_t pllm;
+	// PLLM not specified here because it depends on input clock freq.
 	uint16_t plln;
 	uint8_t pllp;
 	uint8_t pllq;
@@ -621,11 +626,12 @@ struct rcc_clock_scale {
 	uint8_t ppre2;
 	enum pwr_vos_scale vos_scale;
 	uint8_t overdrive;
+	uint32_t ahb_frequency;
 	uint32_t apb1_frequency;
 	uint32_t apb2_frequency;
 };
 
-extern const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_3v3[RCC_CLOCK_3V3_END];
 
 enum rcc_osc {
 	RCC_PLL,
@@ -934,7 +940,8 @@ void rcc_set_main_pll_hsi(uint32_t pllm, uint32_t plln, uint32_t pllp,
 void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq);
 uint32_t rcc_system_clock_source(void);
-void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
+void rcc_clock_setup_hse(const struct rcc_clock_scale *clock, uint32_t hse_mhz);
+void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock);
 END_DECLS
 
 #endif

--- a/include/libopencm3/stm32/pwr.h
+++ b/include/libopencm3/stm32/pwr.h
@@ -30,6 +30,8 @@
 #       include <libopencm3/stm32/f3/pwr.h>
 #elif defined(STM32F4)
 #       include <libopencm3/stm32/f4/pwr.h>
+#elif defined(STM32F7)
+#       include <libopencm3/stm32/f7/pwr.h>
 #elif defined(STM32L1)
 #       include <libopencm3/stm32/l1/pwr.h>
 #elif defined(STM32L0)

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -40,9 +40,9 @@ TGT_CFLAGS	= -Os -g \
 
 ARFLAGS		= rcs
 
-OBJS		= pwr.o rcc.o gpio.o gpio_common_all.o gpio_common_f0234.o
+OBJS		= flash.o pwr.o rcc.o gpio.o gpio_common_all.o gpio_common_f0234.o
 
-OBJS		+= rcc_common_all.o flash_common_f234.o flash_common_f24.o
+OBJS		+= rcc_common_all.o
 
 OBJS		+= rng_common_v1.o
 

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -40,7 +40,7 @@ TGT_CFLAGS	= -Os -g \
 
 ARFLAGS		= rcs
 
-OBJS		= rcc.o gpio.o gpio_common_all.o gpio_common_f0234.o
+OBJS		= pwr.o rcc.o gpio.o gpio_common_all.o gpio_common_f0234.o
 
 OBJS		+= rcc_common_all.o flash_common_f234.o flash_common_f24.o
 

--- a/lib/stm32/f7/flash.c
+++ b/lib/stm32/f7/flash.c
@@ -1,0 +1,478 @@
+/** @addtogroup flash_file
+ *
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2017 Matthew Lai @m@matthewlai.ca>
+ * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2010 Mark Butler <mbutler@physics.otago.ac.nz>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+#include <libopencm3/stm32/flash.h>
+
+/*---------------------------------------------------------------------------*/
+/** @brief Set the Program Parallelism Size
+
+Set the programming word width. Note carefully the power supply voltage
+restrictions under which the different word sizes may be used. See the
+programming manual for more information.
+@param[in] psize The programming word width one of: @ref flash_cr_program_width
+*/
+
+static inline void flash_set_program_size(uint32_t psize)
+{
+	FLASH_CR &= ~(FLASH_CR_PROGRAM_MASK << FLASH_CR_PROGRAM_SHIFT);
+	FLASH_CR |= psize << FLASH_CR_PROGRAM_SHIFT;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Issue Pipeline Stall
+
+Issue a pipeline stall to make sure all write operations completed.
+
+RM0385: After performing a data write operation and before polling the BSY bit
+to be cleared, the software can issue a DSB instruction to guarantee the 
+completion of a previous data write operation.
+
+*/
+
+static inline void flash_pipeline_stall(void)
+{
+	asm volatile("dsb":::"memory");
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Set the Number of Wait States
+
+Used to match the system clock to the FLASH memory access time. See the
+programming manual for more information on clock speed ranges. The latency must
+be changed to the appropriate value <b>before</b> any increase in clock
+speed, or <b>after</b> any decrease in clock speed.
+
+@param[in] ws values from @ref flash_latency.
+*/
+void flash_set_ws(uint32_t ws)
+{
+	uint32_t reg32;
+
+	reg32 = FLASH_ACR;
+	reg32 &= ~(FLASH_ACR_LATENCY_MASK);
+	reg32 |= ws;
+	FLASH_ACR = reg32;
+
+	/* Wait until the new wait states take effect.
+	 * RM0385: Check that the new number of wait states is taken into
+	 * account to access the Flash memory by reading the FLASH_ACR register.
+	 */
+	while ((FLASH_ACR & FLASH_ACR_LATENCY_MASK) != ws);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Unlock the Flash Program and Erase Controller
+
+This enables write access to the Flash memory. It is locked by default on
+reset.
+*/
+
+void flash_unlock(void)
+{
+	/* Clear the unlock sequence state. */
+	FLASH_CR |= FLASH_CR_LOCK;
+
+	/* Authorize the FPEC access. */
+	FLASH_KEYR = FLASH_KEYR_KEY1;
+	FLASH_KEYR = FLASH_KEYR_KEY2;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Lock the Flash Program and Erase Controller
+
+Used to prevent spurious writes to FLASH.
+*/
+
+void flash_lock(void)
+{
+	FLASH_CR |= FLASH_CR_LOCK;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear the Programming Error Status Flag
+
+*/
+
+void flash_clear_pgperr_flag(void)
+{
+	FLASH_SR |= FLASH_SR_PGPERR;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear the End of Operation Status Flag
+
+*/
+
+void flash_clear_eop_flag(void)
+{
+	FLASH_SR |= FLASH_SR_EOP;
+}
+
+
+/*---------------------------------------------------------------------------*/
+/** @brief Wait until Last Operation has Ended
+
+This loops indefinitely until an operation (write or erase) has completed by
+testing the busy flag.
+*/
+
+void flash_wait_for_last_operation(void)
+{
+	flash_pipeline_stall();
+	while ((FLASH_SR & FLASH_SR_BSY) == FLASH_SR_BSY);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Unlock the Option Byte Access
+
+This enables write access to the option bytes. It is locked by default on
+reset.
+*/
+
+void flash_unlock_option_bytes(void)
+{
+	/* Clear the unlock state. */
+	FLASH_OPTCR |= FLASH_OPTCR_OPTLOCK;
+
+	/* Unlock option bytes. */
+	FLASH_OPTKEYR = FLASH_OPTKEYR_KEY1;
+	FLASH_OPTKEYR = FLASH_OPTKEYR_KEY2;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Lock the Option Byte Access
+
+This disables write access to the option bytes. It is locked by default on
+reset.
+*/
+
+void flash_lock_option_bytes(void)
+{
+	FLASH_OPTCR |= FLASH_OPTCR_OPTLOCK;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear the Erase Sequence Error Flag
+
+This flag is set when an erase operation is performed with control register has
+not been correctly set.
+*/
+
+void flash_clear_erserr_flag(void)
+{
+	FLASH_SR |= FLASH_SR_ERSERR;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear the Programming Alignment Error Flag
+
+*/
+
+void flash_clear_pgaerr_flag(void)
+{
+	FLASH_SR |= FLASH_SR_PGAERR;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear the Write Protect Error Flag
+
+*/
+
+void flash_clear_wrperr_flag(void)
+{
+	FLASH_SR |= FLASH_SR_WRPERR;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Enable the ART Cache
+
+*/
+
+void flash_art_enable(void)
+{
+	FLASH_ACR |= FLASH_ACR_ARTEN;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Enable the FLASH Prefetch Buffer
+
+This buffer is used for instruction fetches and is enabled by default after
+reset.
+
+Note carefully the clock restrictions under which the prefetch buffer may be
+enabled or disabled. Changes are normally made while the clock is running in
+the power-on low frequency mode before being set to a higher speed mode.
+See the reference manual for details.
+*/
+
+void flash_prefetch_enable(void)
+{
+	FLASH_ACR |= FLASH_ACR_PRFTEN;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Disable the FLASH Prefetch Buffer
+
+Note carefully the clock restrictions under which the prefetch buffer may be
+set to disabled. See the reference manual for details.
+*/
+
+void flash_prefetch_disable(void)
+{
+	FLASH_ACR &= ~FLASH_ACR_PRFTEN;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Reset the ART Cache
+
+The ART cache must be disabled for this to have effect.
+*/
+
+void flash_art_reset(void)
+{
+	FLASH_ACR |= FLASH_ACR_ARTRST;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear All Status Flags
+
+Program error, end of operation, write protect error.
+*/
+
+void flash_clear_status_flags(void)
+{
+	flash_clear_erserr_flag();
+	flash_clear_pgaerr_flag();
+	flash_clear_wrperr_flag();
+	flash_clear_pgperr_flag();
+	flash_clear_eop_flag();
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Erase All FLASH
+
+This performs all operations necessary to erase all sectors in the FLASH
+memory.
+
+@param program_size: 0 (8-bit), 1 (16-bit), 2 (32-bit), 3 (64-bit)
+*/
+
+void flash_erase_all_sectors(uint32_t program_size)
+{
+	flash_wait_for_last_operation();
+	flash_set_program_size(program_size);
+
+	FLASH_CR |= FLASH_CR_MER;		/* Enable mass erase. */
+	FLASH_CR |= FLASH_CR_STRT;		/* Trigger the erase. */
+
+	flash_wait_for_last_operation();
+	FLASH_CR &= ~FLASH_CR_MER;		/* Disable mass erase. */
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Erase a Sector of FLASH
+
+This performs all operations necessary to erase a sector in FLASH memory.
+The page should be checked to ensure that it was properly erased. A sector must
+first be fully erased before attempting to program it.
+
+See the reference manual or the FLASH programming manual for details.
+
+@param[in] sector (0 - 11 for some parts, 0-23 on others)
+@param program_size: 0 (8-bit), 1 (16-bit), 2 (32-bit), 3 (64-bit)
+*/
+
+void flash_erase_sector(uint8_t sector, uint32_t program_size)
+{
+	flash_wait_for_last_operation();
+	flash_set_program_size(program_size);
+
+	FLASH_CR &= ~(FLASH_CR_SNB_MASK << FLASH_CR_SNB_SHIFT);
+	FLASH_CR |= (sector & FLASH_CR_SNB_MASK) << FLASH_CR_SNB_SHIFT;
+	FLASH_CR |= FLASH_CR_SER;
+	FLASH_CR |= FLASH_CR_STRT;
+
+	flash_wait_for_last_operation();
+	FLASH_CR &= ~FLASH_CR_SER;
+	FLASH_CR &= ~(FLASH_CR_SNB_MASK << FLASH_CR_SNB_SHIFT);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program a 64 bit Word to FLASH
+
+This performs all operations necessary to program a 64 bit word to FLASH memory.
+The program error flag should be checked separately for the event that memory
+was not properly erased.
+
+@param[in] address Starting address in Flash.
+@param[in] data Double word to write
+*/
+
+void flash_program_double_word(uint32_t address, uint64_t data)
+{
+	/* Ensure that all flash operations are complete. */
+	flash_wait_for_last_operation();
+	flash_set_program_size(FLASH_CR_PROGRAM_X64);
+
+	/* Enable writes to flash. */
+	FLASH_CR |= FLASH_CR_PG;
+
+	/* Program the double_word. */
+	MMIO64(address) = data;
+
+	/* Wait for the write to complete. */
+	flash_wait_for_last_operation();
+
+	/* Disable writes to flash. */
+	FLASH_CR &= ~FLASH_CR_PG;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program a 32 bit Word to FLASH
+
+This performs all operations necessary to program a 32 bit word to FLASH memory.
+The program error flag should be checked separately for the event that memory
+was not properly erased.
+
+@param[in] address Starting address in Flash.
+@param[in] data word to write
+*/
+
+void flash_program_word(uint32_t address, uint32_t data)
+{
+	/* Ensure that all flash operations are complete. */
+	flash_wait_for_last_operation();
+	flash_set_program_size(FLASH_CR_PROGRAM_X32);
+
+	/* Enable writes to flash. */
+	FLASH_CR |= FLASH_CR_PG;
+
+	/* Program the word. */
+	MMIO32(address) = data;
+
+	/* Wait for the write to complete. */
+	flash_wait_for_last_operation();
+
+	/* Disable writes to flash. */
+	FLASH_CR &= ~FLASH_CR_PG;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program a Half Word to FLASH
+
+This performs all operations necessary to program a 16 bit word to FLASH memory.
+The program error flag should be checked separately for the event that memory
+was not properly erased.
+
+@param[in] address Starting address in Flash.
+@param[in] data half word to write
+*/
+
+void flash_program_half_word(uint32_t address, uint16_t data)
+{
+	flash_wait_for_last_operation();
+	flash_set_program_size(FLASH_CR_PROGRAM_X16);
+
+	FLASH_CR |= FLASH_CR_PG;
+
+	MMIO16(address) = data;
+
+	flash_wait_for_last_operation();
+
+	FLASH_CR &= ~FLASH_CR_PG;		/* Disable the PG bit. */
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program an 8 bit Byte to FLASH
+
+This performs all operations necessary to program an 8 bit byte to FLASH memory.
+The program error flag should be checked separately for the event that memory
+was not properly erased.
+
+@param[in] address Starting address in Flash.
+@param[in] data byte to write
+*/
+
+void flash_program_byte(uint32_t address, uint8_t data)
+{
+	flash_wait_for_last_operation();
+	flash_set_program_size(FLASH_CR_PROGRAM_X8);
+
+	FLASH_CR |= FLASH_CR_PG;
+
+	MMIO8(address) = data;
+
+	flash_wait_for_last_operation();
+
+	FLASH_CR &= ~FLASH_CR_PG;		/* Disable the PG bit. */
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program a Data Block to FLASH
+
+This programs an arbitrary length data block to FLASH memory.
+The program error flag should be checked separately for the event that memory
+was not properly erased.
+
+@param[in] address Starting address in Flash.
+@param[in] data Pointer to start of data block.
+@param[in] len Length of data block.
+*/
+
+void flash_program(uint32_t address, uint8_t *data, uint32_t len)
+{
+	/* TODO: Use dword and word size program operations where possible for
+	 * turbo speed.
+	 */
+	uint32_t i;
+	for (i = 0; i < len; i++) {
+		flash_program_byte(address+i, data[i]);
+	}
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program the Option Bytes
+
+This performs all operations necessary to program the option bytes.
+The option bytes do not need to be erased first.
+
+@param[in] data value to be programmed.
+*/
+
+void flash_program_option_bytes(uint32_t data)
+{
+	flash_wait_for_last_operation();
+
+	if (FLASH_OPTCR & FLASH_OPTCR_OPTLOCK) {
+		flash_unlock_option_bytes();
+	}
+
+	FLASH_OPTCR = data & ~0x3;
+	FLASH_OPTCR |= FLASH_OPTCR_OPTSTRT;  /* Enable option byte prog. */
+	flash_wait_for_last_operation();
+}
+/**@}*/

--- a/lib/stm32/f7/pwr.c
+++ b/lib/stm32/f7/pwr.c
@@ -1,0 +1,66 @@
+/** @defgroup pwr_file PWR
+ *
+ * @ingroup STM32F7xx
+ *
+ * @brief <b>libopencm3 STM32F7xx Power Control</b>
+ *
+ * @version 1.0.0
+ *
+ * @author @htmlonly &copy; @endhtmlonly 2011 Stephen Caudle <scaudle@doceme.com>
+ * @author @htmlonly &copy; @endhtmlonly 2017 Matthew Lai <m@matthewlai.ca>
+ *
+ * @date 12 March 2017
+ *
+ * This library supports the power control system for the
+ * STM32F7 series of ARM Cortex Microcontrollers by ST Microelectronics.
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (C) 2017 Matthew Lai <m@matthewlai.ca>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/pwr.h>
+
+void pwr_set_vos_scale(enum pwr_vos_scale scale)
+{
+	PWR_CR1 &= ~PWR_CR1_VOS_MASK;
+
+	if (scale == PWR_SCALE1) {
+		PWR_CR1 |= PWR_CR1_VOS_SCALE_1;
+	} else if (scale == PWR_SCALE2) {
+		PWR_CR1 |= PWR_CR1_VOS_SCALE_2;
+	} else if (scale == PWR_SCALE3) {
+		PWR_CR1 |= PWR_CR1_VOS_SCALE_3;
+	}
+}
+
+void pwr_enable_overdrive(void)
+{
+	PWR_CR1 |= PWR_CR1_ODEN;
+	while (!(PWR_CSR1 & PWR_CSR1_ODRDY));
+	PWR_CR1 |= PWR_CR1_ODSWEN;
+	while (!(PWR_CSR1 & PWR_CSR1_ODSWRDY));
+}
+
+void pwr_disable_overdrive(void)
+{
+	PWR_CR1 &= ~(PWR_CR1_ODEN | PWR_CR1_ODSWEN);
+	while (!(PWR_CSR1 & PWR_CSR1_ODSWRDY));
+}

--- a/lib/stm32/f7/rcc.c
+++ b/lib/stm32/f7/rcc.c
@@ -7,9 +7,10 @@ uint32_t rcc_ahb_frequency = 16000000;
 uint32_t rcc_apb1_frequency = 16000000;
 uint32_t rcc_apb2_frequency = 16000000;
 
-const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
+// All PLL configurations without PLLM. PLLM should be set to the input clock
+// frequency in MHz.
+const struct rcc_clock_scale rcc_3v3[RCC_CLOCK_3V3_END] = {
 	{ /* 216MHz */
-		.pllm = 25,
 		.plln = 432,
 		.pllp = 2,
 		.pllq = 9,
@@ -19,9 +20,80 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.vos_scale = PWR_SCALE1,
 		.overdrive = 1,
 		.flash_waitstates = FLASH_ACR_LATENCY_7WS,
-		.apb1_frequency = 108000000,
-		.apb2_frequency = 216000000,
+		.ahb_frequency = 216000000,
+		.apb1_frequency = 54000000,
+		.apb2_frequency = 108000000,
 	},
+	{ /* 168MHz */
+		.plln = 336,
+		.pllp = 2,
+		.pllq = 7,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.vos_scale = PWR_SCALE2,
+		.overdrive = 1,
+		.flash_waitstates = FLASH_ACR_LATENCY_5WS,
+		.ahb_frequency = 168000000,
+		.apb1_frequency = 42000000,
+		.apb2_frequency = 84000000,
+	},
+	{ /* 120MHz */
+		.plln = 240,
+		.pllp = 2,
+		.pllq = 5,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.vos_scale = PWR_SCALE3,
+		.overdrive = 0,
+		.flash_waitstates = FLASH_ACR_LATENCY_3WS,
+		.ahb_frequency = 120000000,
+		.apb1_frequency = 30000000,
+		.apb2_frequency = 60000000,
+	},
+	{ /* 72MHz */
+		.plln = 144,
+		.pllp = 2,
+		.pllq = 3,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.vos_scale = PWR_SCALE3,
+		.overdrive = 0,
+		.flash_waitstates = FLASH_ACR_LATENCY_2WS,
+		.ahb_frequency = 72000000,
+		.apb1_frequency = 18000000,
+		.apb2_frequency = 36000000,
+	},
+	{ /* 48MHz */
+		.plln = 192,
+		.pllp = 4,
+		.pllq = 4,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_2,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.vos_scale = PWR_SCALE3,
+		.overdrive = 0,
+		.flash_waitstates = FLASH_ACR_LATENCY_1WS,
+		.ahb_frequency = 48000000,
+		.apb1_frequency = 24000000,
+		.apb2_frequency = 24000000,
+	},
+	{ /* 24MHz */
+		.plln = 192,
+		.pllp = 8,
+		.pllq = 4,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_NONE,
+		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+		.vos_scale = PWR_SCALE3,
+		.overdrive = 0,
+		.flash_waitstates = FLASH_ACR_LATENCY_0WS,
+		.ahb_frequency = 24000000,
+		.apb1_frequency = 24000000,
+		.apb2_frequency = 24000000,
+	}
 };
 
 void rcc_osc_ready_int_clear(enum rcc_osc osc)
@@ -326,9 +398,10 @@ uint32_t rcc_system_clock_source(void)
 	return (RCC_CFGR >> RCC_CFGR_SWS_SHIFT) & RCC_CFGR_SWS_MASK;
 }
 
-
-void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
+void rcc_clock_setup_hse(const struct rcc_clock_scale *clock, uint32_t hse_mhz)
 {
+	uint8_t pllm = hse_mhz;
+
 	/* Enable internal high-speed oscillator. */
 	rcc_osc_on(RCC_HSI);
 	rcc_wait_for_osc_ready(RCC_HSI);
@@ -336,7 +409,7 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	/* Select HSI as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
 
-	/* Enable external high-speed oscillator 8MHz. */
+	/* Enable external high-speed oscillator. */
 	rcc_osc_on(RCC_HSE);
 	rcc_wait_for_osc_ready(RCC_HSE);
 
@@ -355,8 +428,8 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	rcc_set_ppre1(clock->ppre1);
 	rcc_set_ppre2(clock->ppre2);
 
-	rcc_set_main_pll_hse(clock->pllm, clock->plln,
-			clock->pllp, clock->pllq);
+	rcc_set_main_pll_hse(pllm, clock->plln,
+			     clock->pllp, clock->pllq);
 
 	/* Enable PLL oscillator and wait for it to stabilize. */
 	rcc_osc_on(RCC_PLL);
@@ -373,10 +446,61 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	/* Wait for PLL clock to be selected. */
 	rcc_wait_for_sysclk_status(RCC_PLL);
 
-	/* Set the peripheral clock frequencies used. */
+	/* Set the clock frequencies used. */
+	rcc_ahb_frequency = clock->ahb_frequency;
 	rcc_apb1_frequency = clock->apb1_frequency;
 	rcc_apb2_frequency = clock->apb2_frequency;
 
 	/* Disable internal high-speed oscillator. */
 	rcc_osc_off(RCC_HSI);
+}
+
+void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock)
+{
+	uint8_t pllm = 16;
+
+	/* Enable internal high-speed oscillator. */
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
+
+	rcc_periph_clock_enable(RCC_PWR);
+	pwr_set_vos_scale(clock->vos_scale);
+
+	if (clock->overdrive) {
+		pwr_enable_overdrive();
+	}
+
+	/*
+	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Do this before touching the PLL (TODO: why?).
+	 */
+	rcc_set_hpre(clock->hpre);
+	rcc_set_ppre1(clock->ppre1);
+	rcc_set_ppre2(clock->ppre2);
+
+	rcc_set_main_pll_hsi(pllm, clock->plln,
+			     clock->pllp, clock->pllq);
+
+	/* Enable PLL oscillator and wait for it to stabilize. */
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
+
+	/* Configure flash settings. */
+	flash_set_ws(clock->flash_waitstates);
+	flash_art_enable();
+	flash_prefetch_enable();
+
+	/* Select PLL as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_PLL);
+
+	/* Wait for PLL clock to be selected. */
+	rcc_wait_for_sysclk_status(RCC_PLL);
+
+	/* Set the clock frequencies used. */
+	rcc_ahb_frequency = clock->ahb_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
 }

--- a/lib/stm32/f7/rcc.c
+++ b/lib/stm32/f7/rcc.c
@@ -13,13 +13,12 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 		.plln = 432,
 		.pllp = 2,
 		.pllq = 9,
-		.flash_config = FLASH_ACR_ICEN | FLASH_ACR_DCEN |
-				FLASH_ACR_LATENCY_7WS,
 		.hpre = RCC_CFGR_HPRE_DIV_NONE,
 		.ppre1 = RCC_CFGR_PPRE_DIV_4,
 		.ppre2 = RCC_CFGR_PPRE_DIV_2,
 		.vos_scale = PWR_SCALE1,
 		.overdrive = 1,
+		.flash_waitstates = FLASH_ACR_LATENCY_7WS,
 		.apb1_frequency = 108000000,
 		.apb2_frequency = 216000000,
 	},
@@ -364,7 +363,9 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Configure flash settings. */
-	flash_set_ws(clock->flash_config);
+	flash_set_ws(clock->flash_waitstates);
+	flash_art_enable();
+	flash_prefetch_enable();
 
 	/* Select PLL as SYSCLK source. */
 	rcc_set_sysclk_source(RCC_CFGR_SW_PLL);


### PR DESCRIPTION
This is on top of #766 (pwr support) and #775 (flash support).

I added configurations for a few more clock speeds, and took PLLM out of the struct to be set at application time. This way we don't need a copy of the array for each HSE clock frequency we want (the ST boards use several different ones already) and one more for HSI.

All settings tested to at least boot up and blink an LED at the right frequency.