### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+script: make
+
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:team-gcc-arm-embedded/ppa'
+    packages:
+    - gcc-arm-embedded


### PR DESCRIPTION
Adding .travis.yml lets Travis CI, once enabled for this repo, automatically build/validate each pull request, ensuring they don't break the build for any targets.

This removes the main argument against #774.