### PR TITLE
Fix c99 errors in i2c common code

### DIFF
--- a/lib/stm32/common/i2c_common_v1.c
+++ b/lib/stm32/common/i2c_common_v1.c
@@ -465,6 +465,8 @@ void i2c_clear_dma_last_transfer(uint32_t i2c)
 
 static void i2c_write7_v1(uint32_t i2c, int addr, uint8_t *data, size_t n)
 {
+	size_t i;
+
 	while ((I2C_SR2(i2c) & I2C_SR2_BUSY)) {
 	}
 
@@ -482,7 +484,7 @@ static void i2c_write7_v1(uint32_t i2c, int addr, uint8_t *data, size_t n)
 	/* Clearing ADDR condition sequence. */
 	(void)I2C_SR2(i2c);
 
-	for (size_t i = 0; i < n; i++) {
+	for (i = 0; i < n; i++) {
 		i2c_send_data(i2c, data[i]);
 		while (!(I2C_SR1(i2c) & (I2C_SR1_BTF)));
 	}
@@ -490,6 +492,8 @@ static void i2c_write7_v1(uint32_t i2c, int addr, uint8_t *data, size_t n)
 
 static void i2c_read7_v1(uint32_t i2c, int addr, uint8_t *res, size_t n)
 {
+	size_t i;
+
 	i2c_send_start(i2c);
 	i2c_enable_ack(i2c);
 
@@ -504,7 +508,7 @@ static void i2c_read7_v1(uint32_t i2c, int addr, uint8_t *res, size_t n)
 	/* Clearing ADDR condition sequence. */
 	(void)I2C_SR2(i2c);
 
-	for (size_t i = 0; i < n; ++i) {
+	for (i = 0; i < n; ++i) {
 		if (i == n - 1) {
 			i2c_disable_ack(i2c);
 		}

--- a/lib/stm32/common/i2c_common_v2.c
+++ b/lib/stm32/common/i2c_common_v2.c
@@ -419,6 +419,8 @@ void i2c_transfer7(uint32_t i2c, uint8_t addr, uint8_t *w, size_t wn, uint8_t *r
 	}
 
 	if (rn) {
+		size_t i;
+
 		/* Setting transfer properties */
 		i2c_set_7bit_address(i2c, addr);
 		i2c_set_read_transfer_dir(i2c);
@@ -428,7 +430,7 @@ void i2c_transfer7(uint32_t i2c, uint8_t addr, uint8_t *w, size_t wn, uint8_t *r
 		/* important to do it afterwards to do a proper repeated start! */
 		i2c_enable_autoend(i2c);
 
-		for (size_t i = 0; i < rn; i++) {
+		for (i = 0; i < rn; i++) {
 			while (i2c_received_data(i2c) == 0);
 			r[i] = i2c_get_data(i2c);
 		}


### PR DESCRIPTION
Fixes a compile problem with GCC 4.9.3 introduced by -std=c99 in #773 

With this change everything builds cleanly for me.