### PR TITLE
usb: Ensure control events are handled in order

### DIFF
--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -211,6 +211,8 @@ static void usb_control_setup_write(usbd_device *usbd_dev,
 	} else {
 		usbd_dev->control_state.state = LAST_DATA_OUT;
 	}
+
+	usbd_ep_nak_set(usbd_dev, 0, 0);
 }
 
 /* Do not appear to belong to the API, so are omitted from docs */
@@ -222,6 +224,8 @@ void _usbd_control_setup(usbd_device *usbd_dev, uint8_t ea)
 	(void)ea;
 
 	usbd_dev->control_state.complete = NULL;
+
+	usbd_ep_nak_set(usbd_dev, 0, 1);
 
 	if (usbd_ep_read_packet(usbd_dev, 0, req, 8) != 8) {
 		stall_transaction(usbd_dev);
@@ -294,6 +298,7 @@ void _usbd_control_in(usbd_device *usbd_dev, uint8_t ea)
 		break;
 	case LAST_DATA_IN:
 		usbd_dev->control_state.state = STATUS_OUT;
+		usbd_ep_nak_set(usbd_dev, 0, 0);
 		break;
 	case STATUS_IN:
 		if (usbd_dev->control_state.complete) {


### PR DESCRIPTION
Use EP0 OUT flow control to NAK OUT packets when we're not yet expecting any. This prevents the status OUT event from arriving while the control state machine is still expecting the data IN completion event.

This fixes #779, and testing with the test case from #777 shows correct behavior regardless of whether #777 is also applied or not.

I haven't tested on any other devices than F0 yet. Since this change is in the common USB stack, it ought to be tested on other devices too, to ensure there's no regressions with other drivers.