### PR TITLE
Remove unused Python imports

### DIFF
--- a/scripts/data/lpc43xx/csv2yaml.py
+++ b/scripts/data/lpc43xx/csv2yaml.py
@@ -4,7 +4,6 @@ import sys
 import yaml
 import csv
 from collections import OrderedDict
-import yaml_odict
  
 def convert_file(fname):
     reader = csv.reader(open(fname, 'r'))

--- a/scripts/data/lpc43xx/gen.py
+++ b/scripts/data/lpc43xx/gen.py
@@ -2,10 +2,6 @@
 
 import sys
 import yaml
-import yaml_odict
-from collections import OrderedDict
-
-from pprint import pprint
 
 registers = yaml.load(open(sys.argv[1], 'r'))
 

--- a/tests/gadget-zero/test_gadget0.py
+++ b/tests/gadget-zero/test_gadget0.py
@@ -2,7 +2,6 @@ import array
 import datetime
 import usb.core
 import usb.util as uu
-import logging
 import sys
 
 import unittest


### PR DESCRIPTION
Remove modules that are imported but never used in the code.