### PR TITLE
CAN: change Filter Match Index size

### DIFF
--- a/include/libopencm3/stm32/can.h
+++ b/include/libopencm3/stm32/can.h
@@ -669,7 +669,7 @@ void can_disable_irq(uint32_t canport, uint32_t irq);
 int can_transmit(uint32_t canport, uint32_t id, bool ext, bool rtr,
 		 uint8_t length, uint8_t *data);
 void can_receive(uint32_t canport, uint8_t fifo, bool release, uint32_t *id,
-		 bool *ext, bool *rtr, uint32_t *fmi, uint8_t *length,
+		 bool *ext, bool *rtr, uint8_t *fmi, uint8_t *length,
 		 uint8_t *data);
 
 void can_fifo_release(uint32_t canport, uint8_t fifo);

--- a/lib/stm32/can.c
+++ b/lib/stm32/can.c
@@ -479,7 +479,7 @@ void can_fifo_release(uint32_t canport, uint8_t fifo)
 @param[out] id Unsigned int32 pointer. Message ID.
 @param[out] ext bool pointer. The message ID is extended?
 @param[out] rtr bool pointer. Request of transmission?
-@param[out] fmi Unsigned int32 pointer. ID of the matched filter.
+@param[out] fmi Unsigned int8 pointer. ID of the matched filter.
 @param[out] length Unsigned int8 pointer. Length of message payload.
 @param[out] data Unsigned int8[]. Message payload data.
  */

--- a/lib/stm32/can.c
+++ b/lib/stm32/can.c
@@ -484,7 +484,7 @@ void can_fifo_release(uint32_t canport, uint8_t fifo)
 @param[out] data Unsigned int8[]. Message payload data.
  */
 void can_receive(uint32_t canport, uint8_t fifo, bool release, uint32_t *id,
-		 bool *ext, bool *rtr, uint32_t *fmi, uint8_t *length,
+		 bool *ext, bool *rtr, uint8_t *fmi, uint8_t *length,
 		 uint8_t *data)
 {
 	uint32_t fifo_id = 0;


### PR DESCRIPTION
Caught this by mistake, datasheet shows the FMI can only ever be 8 bit wide, so i set my variable to 8 bits, and gave that as an argument to the can_receive() function, not worrying about it.
The next variable in memory just happened to be my systick counter, which got reset to 0 every time i received a CAN message. Took me a while to figure out what was going on, but this fixes it, and brings it closer to what's in the datasheet.