### PR TITLE
Added can.o in Stm32F0 Makefile

### DIFF
--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -213,7 +213,7 @@ Control</b>
 #define RCC_APB1RSTR_DACRST			(1 << 29)
 #define RCC_APB1RSTR_PWRRST			(1 << 28)
 #define RCC_APB1RSTR_CRSRST			(1 << 27)
-#define RCC_APB1RSTR_CANRST			(1 << 25)
+#define RCC_APB1RSTR_CAN1RST			(1 << 25)	/* ../can.c:79:39 needs RCC_APB1RSTR_CAN1RST to be defined  */
 #define RCC_APB1RSTR_USBRST			(1 << 23)
 #define RCC_APB1RSTR_I2C2RST			(1 << 22)
 #define RCC_APB1RSTR_I2C1RST			(1 << 21)

--- a/lib/stm32/can.c
+++ b/lib/stm32/can.c
@@ -37,7 +37,9 @@ LGPL License Terms @ref lgpl_license
 
 #include <libopencm3/stm32/can.h>
 
-#if defined(STM32F1)
+#if defined(STM32F0)
+#	include <libopencm3/stm32/f0/rcc.h>
+#elif defined(STM32F1)
 #	include <libopencm3/stm32/f1/rcc.h>
 #elif defined(STM32F2)
 #	include <libopencm3/stm32/f2/rcc.h>

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -35,7 +35,7 @@ TGT_CFLAGS      += $(DEBUG_FLAGS)
 
 ARFLAGS		= rcs
 
-OBJS		= flash.o rcc.o usart.o dma.o rtc.o comparator.o crc.o \
+OBJS		= flash.o  rcc.o can.o usart.o dma.o rtc.o comparator.o crc.o \
                   dac.o iwdg.o pwr.o gpio.o timer.o adc.o desig.o
 
 OBJS            += gpio_common_all.o gpio_common_f0234.o crc_common_all.o \
@@ -54,4 +54,3 @@ OBJS		+= st_usbfs_core.o st_usbfs_v2.o
 VPATH += ../../usb:../:../../cm3:../common
 
 include ../../Makefile.include
-


### PR DESCRIPTION
Enabled CAN for STM32F0 devices.