### PR TITLE
adc: fix adc_start_conversion_regular()

### DIFF
--- a/lib/stm32/common/adc_common_v2.c
+++ b/lib/stm32/common/adc_common_v2.c
@@ -384,9 +384,6 @@ void adc_start_conversion_regular(uint32_t adc)
 {
 	/* Start conversion on regular channels. */
 	ADC_CR(adc) |= ADC_CR_ADSTART;
-
-	/* Wait until the ADC starts the conversion. */
-	while (ADC_CR(adc) & ADC_CR_ADSTART);
 }
 
 /**@}*/


### PR DESCRIPTION
the CR_ADSTART bit only gets cleared by hardware when the conversion of
all channels have completed (see RM0360 page 210), not when the
conversion has started as the code comment suggest, and this while loop
causes a hang if adc wait mode is used, as well as disallows any
possibility of reading all but the last channel when sequenced
conversion is used 
#557 