### PR TITLE
Adding basic UART support to stm32l4.

### DIFF
--- a/include/libopencm3/stm32/l4/usart.h
+++ b/include/libopencm3/stm32/l4/usart.h
@@ -28,13 +28,17 @@ LGPL License Terms @ref lgpl_license
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**@{*/
+
 #ifndef LIBOPENCM3_USART_H
 #define LIBOPENCM3_USART_H
 
 #include <libopencm3/stm32/common/usart_common_all.h>
 
 /* --- USART registers ----------------------------------------------------- */
+/** @defgroup usart_reg_base USART register base addresses
 
+@{*/
 /* Control register 1 (USARTx_CR1) */
 #define USART_CR1(usart_base)		MMIO32((usart_base) + 0x00)
 #define USART1_CR1			USART_CR1(USART1_BASE)
@@ -51,7 +55,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_CR2			USART_CR2(USART3_BASE)
 #define UART4_CR2			USART_CR2(UART4_BASE)
 #define UART5_CR2			USART_CR2(UART5_BASE)
-#define LPUART1_CR2			USART_CR1(LPUART1_BASE)
+#define LPUART1_CR2			USART_CR2(LPUART1_BASE)
 
 /* Control register 3 (USARTx_CR3) */
 #define USART_CR3(usart_base)		MMIO32((usart_base) + 0x08)
@@ -60,7 +64,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_CR3			USART_CR3(USART3_BASE)
 #define UART4_CR3			USART_CR3(UART4_BASE)
 #define UART5_CR3			USART_CR3(UART5_BASE)
-#define LPUART1_CR3			USART_CR1(LPUART1_BASE)
+#define LPUART1_CR3			USART_CR3(LPUART1_BASE)
 
 /* Baud rate register (USARTx_BRR) */
 #define USART_BRR(usart_base)		MMIO32((usart_base) + 0x0C)
@@ -69,7 +73,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_BRR			USART_BRR(USART3_BASE)
 #define UART4_BRR			USART_BRR(UART4_BASE)
 #define UART5_BRR			USART_BRR(UART5_BASE)
-#define LPUART1_BRR			USART_CR1(LPUART1_BASE)
+#define LPUART1_BRR			USART_BRR(LPUART1_BASE)
 
 /* Guard time and prescaler register (USARTx_GTPR) */
 #define USART_GTPR(usart_base)		MMIO32((usart_base) + 0x10)
@@ -78,7 +82,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_GTPR			USART_GTPR(USART3_BASE)
 #define UART4_GTPR			USART_GTPR(UART4_BASE)
 #define UART5_GTPR			USART_GTPR(UART5_BASE)
-#define LPUART1_GTPR			USART_CR1(LPUART1_BASE)
+#define LPUART1_GTPR			USART_GTPR(LPUART1_BASE)
 
 /* Receiver timeout register (USARTx_RTOR) */
 #define USART_RTOR(usart_base)		MMIO32((usart_base) + 0x14)
@@ -87,7 +91,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_RTOR			USART_RTOR(USART3_BASE)
 #define UART4_RTOR			USART_RTOR(UART4_BASE)
 #define UART5_RTOR			USART_RTOR(UART5_BASE)
-#define LPUART1_RTOR			USART_CR1(LPUART1_BASE)
+#define LPUART1_RTOR			USART_RTOR(LPUART1_BASE)
 
 /* Request register (USARTx_RQR) */
 #define USART_RQR(usart_base)		MMIO32((usart_base) + 0x18)
@@ -96,7 +100,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_RQR			USART_RQR(USART3_BASE)
 #define UART4_RQR			USART_RQR(UART4_BASE)
 #define UART5_RQR			USART_RQR(UART5_BASE)
-#define LPUART1_RQR			USART_CR1(LPUART1_BASE)
+#define LPUART1_RQR			USART_RQR(LPUART1_BASE)
 
 /* Interrupt and status register (USARTx_ISR) */
 #define USART_ISR(usart_base)		MMIO32((usart_base) + 0x1C)
@@ -105,7 +109,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_ISR			USART_ISR(USART3_BASE)
 #define UART4_ISR			USART_ISR(UART4_BASE)
 #define UART5_ISR			USART_ISR(UART5_BASE)
-#define LPUART1_ISR			USART_CR1(LPUART1_BASE)
+#define LPUART1_ISR			USART_ISR(LPUART1_BASE)
 
 /* Interrupt flag clear register (USARTx_ICR) */
 #define USART_ICR(usart_base)		MMIO32((usart_base) + 0x20)
@@ -114,7 +118,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_ICR			USART_ICR(USART3_BASE)
 #define UART4_ICR			USART_ICR(UART4_BASE)
 #define UART5_ICR			USART_ICR(UART5_BASE)
-#define LPUART1_ICR			USART_CR1(LPUART1_BASE)
+#define LPUART1_ICR			USART_ICR(LPUART1_BASE)
 
 /* Receive data register (USARTx_RDR) */
 #define USART_RDR(usart_base)		MMIO32((usart_base) + 0x24)
@@ -123,7 +127,7 @@ LGPL License Terms @ref lgpl_license
 #define USART3_RDR			USART_RDR(USART3_BASE)
 #define UART4_RDR			USART_RDR(UART4_BASE)
 #define UART5_RDR			USART_RDR(UART5_BASE)
-#define LPUART1_RDR			USART_CR1(LPUART1_BASE)
+#define LPUART1_RDR			USART_RDR(LPUART1_BASE)
 
 /* Transmit data register (USARTx_TDR) */
 #define USART_TDR(usart_base)		MMIO32((usart_base) + 0x28)
@@ -132,386 +136,411 @@ LGPL License Terms @ref lgpl_license
 #define USART3_TDR			USART_TDR(USART3_BASE)
 #define UART4_TDR			USART_TDR(UART4_BASE)
 #define UART5_TDR			USART_TDR(UART5_BASE)
-#define LPUART1_TDR			USART_CR1(LPUART1_BASE)
+#define LPUART1_TDR			USART_TDR(LPUART1_BASE)
 
+/**@}*/
 
 /* --- USART_CR1 values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_cr1_values USART_CR1 values
 
-/* M1: Word length */
+@{*/
+
+/** M1: Word length */
 #define USART_CR1_M1			(1 << 28)
 
-/* EOBIE: End of Block interrupt enable */
+/** EOBIE: End of Block interrupt enable */
 #define USART_CR1_EOBIE			(1 << 27)
 
-/* RTOIE: Receiver timeout interrupt enable */
+/** RTOIE: Receiver timeout interrupt enable */
 #define USART_CR1_RTOIE			(1 << 26)
 
-/* DEAT[4:0]: Driver Enable assertion time */
+/** DEAT[4:0]: Driver Enable assertion time */
 #define USART_CR1_DEAT_MASK		(0x1F << 21)
 
-/* DEDT[4:0]: Driver Enable de-assertion time */
+/** DEDT[4:0]: Driver Enable de-assertion time */
 #define USART_CR1_DEDT_MASK		(0x1F << 16)
 
-/* OVER8: Oversampling mode */
+/** OVER8: Oversampling mode */
 #define USART_CR1_OVER8			(1 << 15)
 
-/* CMIE: Character match interrupt enable */
+/** CMIE: Character match interrupt enable */
 #define USART_CR1_CMIE			(1 << 14)
 
-/* MME: Mute mode enable */
+/** MME: Mute mode enable */
 #define USART_CR1_MME			(1 << 13)
 
-/* M0: Word length */
+/** M0: Word length */
 #define USART_CR1_M			(1 << 12)
 
-/* WAKE: Receiver wakeup method */
+/** WAKE: Receiver wakeup method */
 #define USART_CR1_WAKE			(1 << 11)
 
-/* PCE: Parity control enable */
+/** PCE: Parity control enable */
 #define USART_CR1_PCE			(1 << 10)
 
-/* PS: Parity selection */
+/** PS: Parity selection */
 #define USART_CR1_PS			(1 << 9)
 
-/* PEIE: PE interrupt enable */
+/** PEIE: PE interrupt enable */
 #define USART_CR1_PEIE			(1 << 8)
 
-/* TXEIE: interrupt enable */
+/** TXEIE: interrupt enable */
 #define USART_CR1_TXEIE			(1 << 7)
 
-/* TCIE: Transmission complete interrupt enable */
+/** TCIE: Transmission complete interrupt enable */
 #define USART_CR1_TCIE			(1 << 6)
 
-/* RXNEIE: RXNE interrupt enable */
+/** RXNEIE: RXNE interrupt enable */
 #define USART_CR1_RXNEIE		(1 << 5)
 
-/* IDLEIE: IDLE interrupt enable */
+/** IDLEIE: IDLE interrupt enable */
 #define USART_CR1_IDLEIE		(1 << 4)
 
-/* TE: Transmitter enable */
+/** TE: Transmitter enable */
 #define USART_CR1_TE			(1 << 3)
 
-/* RE: Receiver enable */
+/** RE: Receiver enable */
 #define USART_CR1_RE			(1 << 2)
 
-/* UESM: USART enable in Stop mode */
+/** UESM: USART enable in Stop mode */
 #define USART_CR1_UESM			(1 << 1)
 
-/* UE: USART enable */
+/** UE: USART enable */
 #define USART_CR1_UE			(1 << 0)
 
+/**@}*/
 
 /* --- USART_CR2 values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_cr2_values USART_CR2 values
+@{*/
 
-/* ADD[7:4]: Address of the USART node */
+/** ADD[7:4]: Address of the USART node */
 #define USART_CR2_ADD_HIGH_MASK		(0xF << 28)
 
-/* ADD[3:0]: Address of the USART node */
+/** ADD[3:0]: Address of the USART node */
 #define USART_CR2_ADD_LOW_MASK		(0xF << 24)
 
-/* RTOEN: Receiver timeout enable */
+/** RTOEN: Receiver timeout enable */
 #define USART_CR2_RTOEN			(1 << 23)
 
-/* ABRMOD[1:0]: Auto baud rate mode */
+/** ABRMOD[1:0]: Auto baud rate mode */
 #define USART_CR2_ABRMOD_MASK		(0x3 << 21)
 
-/* ABREN: Auto baud rate enable */
+/** ABREN: Auto baud rate enable */
 #define USART_CR2_ABREN			(1 << 20)
 
-/* MSBFIRST: Most significant bit first */
+/** MSBFIRST: Most significant bit first */
 #define USART_CR2_MSBFIRST		(1 << 19)
 
-/* DATAINV: Binary data inversion */
+/** DATAINV: Binary data inversion */
 #define USART_CR2_DATAINV		(1 << 18)
 
-/* TXINV: TX pin active level inversion */
+/** TXINV: TX pin active level inversion */
 #define USART_CR2_TXINV			(1 << 17)
 
-/* RXINV: RX pin active level inversion */
+/** RXINV: RX pin active level inversion */
 #define USART_CR2_RXINV			(1 << 16)
 
-/* SWAP: Swap TX/RX pins */
+/** SWAP: Swap TX/RX pins */
 #define USART_CR2_SWAP			(1 << 15)
 
-/* LINEN: LIN mode enable */
+/** LINEN: LIN mode enable */
 #define USART_CR2_LINEN			(1 << 14)
 
-/* STOP[1:0]: STOP bits */
+/** STOP[1:0]: STOP bits */
 #define USART_CR2_STOPBITS_1		(0x00 << 12)     /* 1 stop bit */
 #define USART_CR2_STOPBITS_0_5		(0x01 << 12)     /* 0.5 stop bits */
 #define USART_CR2_STOPBITS_2		(0x02 << 12)     /* 2 stop bits */
 #define USART_CR2_STOPBITS_1_5		(0x03 << 12)     /* 1.5 stop bits */
 #define USART_CR2_STOPBITS_MASK		(0x3 << 12)
 
-/* CLKEN: Clock enable */
+/** CLKEN: Clock enable */
 #define USART_CR2_CLKEN			(1 << 11)
 
-/* CPOL: Clock polarity */
+/** CPOL: Clock polarity */
 #define USART_CR2_CPOL			(1 << 10)
 
-/* CPHA: Clock phase */
+/** CPHA: Clock phase */
 #define USART_CR2_CPHA			(1 << 9)
 
-/* LBCL: Last bit clock pulse */
+/** LBCL: Last bit clock pulse */
 #define USART_CR2_LBCL			(1 << 8)
 
-/* LBDIE: LIN break detection interrupt enable */
+/** LBDIE: LIN break detection interrupt enable */
 #define USART_CR2_LBDIE			(1 << 6)
 
-/* LBDL: LIN break detection length */
+/** LBDL: LIN break detection length */
 #define USART_CR2_LBDL			(1 << 5)
 
-/* ADDM7: 7-bit Address Detection/4-bit Address Detection */
+/** ADDM7: 7-bit Address Detection/4-bit Address Detection */
 #define USART_CR2_ADDM7			(1 << 4)
 
+/**@}*/
 
 /* --- USART_CR3 values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_cr3_values USART_CR3 values
+@{*/
 
-/* TCBGTIE: Transmission complete before guard time interrupt enable */
+/** TCBGTIE: Transmission complete before guard time interrupt enable */
 #define USART_CR3_TCBGTIE		(1 << 24)
 
-/* UCESM: USART Clock Enable in Stop mode. */
+/** UCESM: USART Clock Enable in Stop mode. */
 #define USART_CR3_UCESM			(1 << 23)
 
-/* WUFIE: Wakeup from Stop mode interrupt enable */
+/** WUFIE: Wakeup from Stop mode interrupt enable */
 #define USART_CR3_WUFIE			(1 << 22)
 
-/* WUS[1:0]: Wakeup from Stop mode interrupt flag selection */
+/** WUS[1:0]: Wakeup from Stop mode interrupt flag selection */
 #define USART_CR3_WUS_MASK		(0x3 << 20)
 
-/* SCARCNT[2:0]: Smartcard auto-retry count */
+/** SCARCNT[2:0]: Smartcard auto-retry count */
 #define USART_CR3_SCARCNT_MASK		(0x7 << 17)
 
-/* DEP: Driver enable polarity selection */
+/** DEP: Driver enable polarity selection */
 #define USART_CR3_DEP			(1 << 15)
 
-/* DEM: Driver enable mode */
+/** DEM: Driver enable mode */
 #define USART_CR3_DEM			(1 << 14)
 
-/* DDRE: DMA Disable on Reception Error */
+/** DDRE: DMA Disable on Reception Error */
 #define USART_CR3_DDRE			(1 << 13)
 
-/* OVRDIS: Overrun Disable */
+/** OVRDIS: Overrun Disable */
 #define USART_CR3_OVRDIS		(1 << 12)
 
-/* ONEBIT: One sample bit method enable */
+/** ONEBIT: One sample bit method enable */
 #define USART_CR3_ONEBIT		(1 << 11)
 
-/* CTSIE: CTS interrupt enable */
+/** CTSIE: CTS interrupt enable */
 #define USART_CR3_CTSIE			(1 << 10)
 
-/* CTSE: CTS enable */
+/** CTSE: CTS enable */
 #define USART_CR3_CTSE			(1 << 9)
 
-/* RTSE: RTS enable */
+/** RTSE: RTS enable */
 #define USART_CR3_RTSE			(1 << 8)
 
-/* DMAT: DMA enable transmitter */
+/** DMAT: DMA enable transmitter */
 #define USART_CR3_DMAT			(1 << 7)
 
-/* DMAR: DMA enable receiver */
+/** DMAR: DMA enable receiver */
 #define USART_CR3_DMAR			(1 << 6)
 
-/* SCEN: Smartcard mode enable */
+/** SCEN: Smartcard mode enable */
 #define USART_CR3_SCEN			(1 << 5)
 
-/* NACK: Smartcard NACK enable */
+/** NACK: Smartcard NACK enable */
 #define USART_CR3_NACK			(1 << 4)
 
-/* HDSEL: Half-duplex selection */
+/** HDSEL: Half-duplex selection */
 #define USART_CR3_HDSEL			(1 << 3)
 
-/* IRLP: IrDA low-power */
+/** IRLP: IrDA low-power */
 #define USART_CR3_IRLP			(1 << 2)
 
-/* IREN: IrDA mode enable */
+/** IREN: IrDA mode enable */
 #define USART_CR3_IREN			(1 << 1)
 
-/* EIE: Error interrupt enable */
+/** EIE: Error interrupt enable */
 #define USART_CR3_EIE			(1 << 0)
 
+/**@}*/
 
 /* --- USART_BRR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_brr_values USART_BRR values
+@{*/
 
-/* BRR[15:4]: */
+/** BRR[15:4]: */
 #define USART_BRR_BRR_HIGH_MASK		(0xFFF << 4)
 
-/* BRR[3:0]: */
+/** BRR[3:0]: */
 #define USART_BRR_BRR_LOW_MASK		(0xF << 0)
 
+/**@}*/
 
 /* --- USART_GTPR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_gtpr_values USART_GTPR values
+@{*/
 
-/* GT[7:0]: Guard time value */
+/** GT[7:0]: Guard time value */
 #define USART_GTPR_GT_MASK		(0xFF << 8)
 
-/* PSC[7:0]: Prescaler value */
+/** PSC[7:0]: Prescaler value */
 #define USART_GTPR_PSC_MASK		(0xFF << 0)
 
+/**@}*/
 
 /* --- USART_RTOR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_rtor_values USART_RTOR values
+@{*/
 
-/* BLEN[7:0]: Block Length */
+/** BLEN[7:0]: Block Length */
 #define USART_RTOR_BLEN_MASK		(0xFF << 24)
 
-/* RTO[23:0]: Receiver timeout value */
+/** RTO[23:0]: Receiver timeout value */
 #define USART_RTOR_RTO_MASK		(0xFFFFFF << 0)
 
+/**@}*/
 
 /* --- USART_RQR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_rqr_values USART_RQR values
+@{*/
 
-/* TXFRQ: Transmit data flush request */
+/** TXFRQ: Transmit data flush request */
 #define USART_RQR_TXFRQ			(1 << 4)
 
-/* RXFRQ: Receive data flush request */
+/** RXFRQ: Receive data flush request */
 #define USART_RQR_RXFRQ			(1 << 3)
 
-/* MMRQ: Mute mode request */
+/** MMRQ: Mute mode request */
 #define USART_RQR_MMRQ			(1 << 2)
 
-/* SBKRQ: Send break request */
+/** SBKRQ: Send break request */
 #define USART_RQR_SBKRQ			(1 << 1)
 
-/* ABRRQ: Auto baud rate request */
+/** ABRRQ: Auto baud rate request */
 #define USART_RQR_ABRRQ			(1 << 0)
 
+/**@}*/
 
 /* --- USART_ISR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_isr_values USART_ISR values
+@{*/
 
-/* TCBGT: Transmission complete before guard time completion. */
+/** TCBGT: Transmission complete before guard time completion. */
 #define USART_ISR_TCBGT			(1 << 25)
 
-/* REACK: Receive enable acknowledge flag */
+/** REACK: Receive enable acknowledge flag */
 #define USART_ISR_REACK			(1 << 22)
 
-/* TEACK: Transmit enable acknowledge flag */
+/** TEACK: Transmit enable acknowledge flag */
 #define USART_ISR_TEACK			(1 << 21)
 
-/* WUF: Wakeup from Stop mode flag */
+/** WUF: Wakeup from Stop mode flag */
 #define USART_ISR_WUF			(1 << 20)
 
-/* RWU: Receiver wakeup from Mute mode */
+/** RWU: Receiver wakeup from Mute mode */
 #define USART_ISR_RWU			(1 << 19)
 
-/* SBKF: Send break flag */
+/** SBKF: Send break flag */
 #define USART_ISR_SBKF			(1 << 18)
 
-/* CMF: Character match flag */
+/** CMF: Character match flag */
 #define USART_ISR_CMF			(1 << 17)
 
-/* BUSY: Busy flag */
+/** BUSY: Busy flag */
 #define USART_ISR_BUSY			(1 << 16)
 
-/* ABRF: Auto baud rate flag */
+/** ABRF: Auto baud rate flag */
 #define USART_ISR_ABRF			(1 << 15)
 
-/* ABRE: Auto baud rate error */
+/** ABRE: Auto baud rate error */
 #define USART_ISR_ABRE			(1 << 14)
 
-/* EOBF: End of block flag */
+/** EOBF: End of block flag */
 #define USART_ISR_EOBF			(1 << 12)
 
-/* RTOF: Receiver timeout */
+/** RTOF: Receiver timeout */
 #define USART_ISR_RTOF			(1 << 11)
 
-/* CTS: CTS flag */
+/** CTS: CTS flag */
 #define USART_ISR_CTS			(1 << 10)
 
-/* CTSIF: CTS interrupt flag */
+/** CTSIF: CTS interrupt flag */
 #define USART_ISR_CTSIF			(1 << 9)
 
-/* LBDF: LIN break detection flag */
+/** LBDF: LIN break detection flag */
 #define USART_ISR_LBDF			(1 << 8)
 
-/* TXE: Transmit data register empty */
+/** TXE: Transmit data register empty */
 #define USART_ISR_TXE			(1 << 7)
 
-/* TC: Transmission complete */
+/** TC: Transmission complete */
 #define USART_ISR_TC			(1 << 6)
 
-/* RXNE: Read data register not empty */
+/** RXNE: Read data register not empty */
 #define USART_ISR_RXNE			(1 << 5)
 
-/* IDLE: Idle line detected */
+/** IDLE: Idle line detected */
 #define USART_ISR_IDLE			(1 << 4)
 
-/* ORE: Overrun error */
+/** ORE: Overrun error */
 #define USART_ISR_ORE			(1 << 3)
 
-/* NF: START bit Noise detection flag */
+/** NF: START bit Noise detection flag */
 #define USART_ISR_NF			(1 << 2)
 
-/* FE: Framing error */
+/** FE: Framing error */
 #define USART_ISR_FE			(1 << 1)
 
-/* PE: Parity error */
+/** PE: Parity error */
 #define USART_ISR_PE			(1 << 0)
 
+/**@}*/
 
 /* --- USART_ICR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_icr_values USART_ICR values
+@{*/
 
-/* WUCF: Wakeup from Stop mode clear flag */
+/** WUCF: Wakeup from Stop mode clear flag */
 #define USART_ICR_WUCF			(1 << 20)
 
-/* CMCF: Character match clear flag */
+/** CMCF: Character match clear flag */
 #define USART_ICR_CMCF			(1 << 17)
 
-/* EOBCF: End of block clear flag */
+/** EOBCF: End of block clear flag */
 #define USART_ICR_EOBCF			(1 << 12)
 
-/* RTOCF: Receiver timeout clear flag */
+/** RTOCF: Receiver timeout clear flag */
 #define USART_ICR_RTOCF			(1 << 11)
 
-/* CTSCF: CTS clear flag */
+/** CTSCF: CTS clear flag */
 #define USART_ICR_CTSCF			(1 << 9)
 
-/* LBDCF: LIN break detection clear flag */
+/** LBDCF: LIN break detection clear flag */
 #define USART_ICR_LBDCF			(1 << 8)
 
-/* TCBGTCF: Transmission completed before guard time clear flag */
+/** TCBGTCF: Transmission completed before guard time clear flag */
 #define USART_ICR_TCBGTCF		(1 << 7)
 
-/* TCCF: Transmission complete clear flag */
+/** TCCF: Transmission complete clear flag */
 #define USART_ICR_TCCF			(1 << 6)
 
-/* IDLECF: Idle line detected clear flag */
+/** IDLECF: Idle line detected clear flag */
 #define USART_ICR_IDLECF		(1 << 4)
 
-/* ORECF: Overrun error clear flag */
+/** ORECF: Overrun error clear flag */
 #define USART_ICR_ORECF			(1 << 3)
 
-/* NCF: Noise detected clear flag */
+/** NCF: Noise detected clear flag */
 #define USART_ICR_NCF			(1 << 2)
 
-/* FECF: Framing error clear flag */
+/** FECF: Framing error clear flag */
 #define USART_ICR_FECF			(1 << 1)
 
-/* PECF: Parity error clear flag */
+/** PECF: Parity error clear flag */
 #define USART_ICR_PECF			(1 << 0)
 
+/**@}*/
 
 /* --- USART_RDR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+/** @defgroup usart_rdr_values USART_RDR values
+@{*/
 
-/* RDR[8:0]: Receive data value */
+/** RDR[8:0]: Receive data value */
 #define USART_RDR_RDR_MASK		(0x1FF << 0)
 
+/**@}*/
 
 /* --- USART_TDR values ----------------------------------------------------- */
-/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
 
-/* TDR[8:0]: Transmit data value */
+/** @defgroup usart_tdr_values USART_TDR values
+@{*/
+
+/** TDR[8:0]: Transmit data value */
 #define USART_TDR_TDR_MASK		(0x1FF << 0)
 
+/**@}*/
 
 #endif
 /** @endcond */

--- a/include/libopencm3/stm32/l4/usart.h
+++ b/include/libopencm3/stm32/l4/usart.h
@@ -1,0 +1,519 @@
+/** @defgroup usart_defines USART Defines
+
+@brief <b>Defined Constants and Types for the STM32L4xx USART</b>
+
+@ingroup STM32L4xx_defines
+
+@version 1.0.0
+
+@date 22 June 2017
+
+LGPL License Terms @ref lgpl_license
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_USART_H
+#define LIBOPENCM3_USART_H
+
+#include <libopencm3/stm32/common/usart_common_all.h>
+
+/* --- USART registers ----------------------------------------------------- */
+
+/* Control register 1 (USARTx_CR1) */
+#define USART_CR1(usart_base)		MMIO32((usart_base) + 0x00)
+#define USART1_CR1			USART_CR1(USART1_BASE)
+#define USART2_CR1			USART_CR1(USART2_BASE)
+#define USART3_CR1			USART_CR1(USART3_BASE)
+#define UART4_CR1			USART_CR1(UART4_BASE)
+#define UART5_CR1			USART_CR1(UART5_BASE)
+#define LPUART1_CR1			USART_CR1(LPUART1_BASE)
+
+/* Control register 2 (USARTx_CR2) */
+#define USART_CR2(usart_base)		MMIO32((usart_base) + 0x04)
+#define USART1_CR2			USART_CR2(USART1_BASE)
+#define USART2_CR2			USART_CR2(USART2_BASE)
+#define USART3_CR2			USART_CR2(USART3_BASE)
+#define UART4_CR2			USART_CR2(UART4_BASE)
+#define UART5_CR2			USART_CR2(UART5_BASE)
+#define LPUART1_CR2			USART_CR1(LPUART1_BASE)
+
+/* Control register 3 (USARTx_CR3) */
+#define USART_CR3(usart_base)		MMIO32((usart_base) + 0x08)
+#define USART1_CR3			USART_CR3(USART1_BASE)
+#define USART2_CR3			USART_CR3(USART2_BASE)
+#define USART3_CR3			USART_CR3(USART3_BASE)
+#define UART4_CR3			USART_CR3(UART4_BASE)
+#define UART5_CR3			USART_CR3(UART5_BASE)
+#define LPUART1_CR3			USART_CR1(LPUART1_BASE)
+
+/* Baud rate register (USARTx_BRR) */
+#define USART_BRR(usart_base)		MMIO32((usart_base) + 0x0C)
+#define USART1_BRR			USART_BRR(USART1_BASE)
+#define USART2_BRR			USART_BRR(USART2_BASE)
+#define USART3_BRR			USART_BRR(USART3_BASE)
+#define UART4_BRR			USART_BRR(UART4_BASE)
+#define UART5_BRR			USART_BRR(UART5_BASE)
+#define LPUART1_BRR			USART_CR1(LPUART1_BASE)
+
+/* Guard time and prescaler register (USARTx_GTPR) */
+#define USART_GTPR(usart_base)		MMIO32((usart_base) + 0x10)
+#define USART1_GTPR			USART_GTPR(USART1_BASE)
+#define USART2_GTPR			USART_GTPR(USART2_BASE)
+#define USART3_GTPR			USART_GTPR(USART3_BASE)
+#define UART4_GTPR			USART_GTPR(UART4_BASE)
+#define UART5_GTPR			USART_GTPR(UART5_BASE)
+#define LPUART1_GTPR			USART_CR1(LPUART1_BASE)
+
+/* Receiver timeout register (USARTx_RTOR) */
+#define USART_RTOR(usart_base)		MMIO32((usart_base) + 0x14)
+#define USART1_RTOR			USART_RTOR(USART1_BASE)
+#define USART2_RTOR			USART_RTOR(USART2_BASE)
+#define USART3_RTOR			USART_RTOR(USART3_BASE)
+#define UART4_RTOR			USART_RTOR(UART4_BASE)
+#define UART5_RTOR			USART_RTOR(UART5_BASE)
+#define LPUART1_RTOR			USART_CR1(LPUART1_BASE)
+
+/* Request register (USARTx_RQR) */
+#define USART_RQR(usart_base)		MMIO32((usart_base) + 0x18)
+#define USART1_RQR			USART_RQR(USART1_BASE)
+#define USART2_RQR			USART_RQR(USART2_BASE)
+#define USART3_RQR			USART_RQR(USART3_BASE)
+#define UART4_RQR			USART_RQR(UART4_BASE)
+#define UART5_RQR			USART_RQR(UART5_BASE)
+#define LPUART1_RQR			USART_CR1(LPUART1_BASE)
+
+/* Interrupt and status register (USARTx_ISR) */
+#define USART_ISR(usart_base)		MMIO32((usart_base) + 0x1C)
+#define USART1_ISR			USART_ISR(USART1_BASE)
+#define USART2_ISR			USART_ISR(USART2_BASE)
+#define USART3_ISR			USART_ISR(USART3_BASE)
+#define UART4_ISR			USART_ISR(UART4_BASE)
+#define UART5_ISR			USART_ISR(UART5_BASE)
+#define LPUART1_ISR			USART_CR1(LPUART1_BASE)
+
+/* Interrupt flag clear register (USARTx_ICR) */
+#define USART_ICR(usart_base)		MMIO32((usart_base) + 0x20)
+#define USART1_ICR			USART_ICR(USART1_BASE)
+#define USART2_ICR			USART_ICR(USART2_BASE)
+#define USART3_ICR			USART_ICR(USART3_BASE)
+#define UART4_ICR			USART_ICR(UART4_BASE)
+#define UART5_ICR			USART_ICR(UART5_BASE)
+#define LPUART1_ICR			USART_CR1(LPUART1_BASE)
+
+/* Receive data register (USARTx_RDR) */
+#define USART_RDR(usart_base)		MMIO32((usart_base) + 0x24)
+#define USART1_RDR			USART_RDR(USART1_BASE)
+#define USART2_RDR			USART_RDR(USART2_BASE)
+#define USART3_RDR			USART_RDR(USART3_BASE)
+#define UART4_RDR			USART_RDR(UART4_BASE)
+#define UART5_RDR			USART_RDR(UART5_BASE)
+#define LPUART1_RDR			USART_CR1(LPUART1_BASE)
+
+/* Transmit data register (USARTx_TDR) */
+#define USART_TDR(usart_base)		MMIO32((usart_base) + 0x28)
+#define USART1_TDR			USART_TDR(USART1_BASE)
+#define USART2_TDR			USART_TDR(USART2_BASE)
+#define USART3_TDR			USART_TDR(USART3_BASE)
+#define UART4_TDR			USART_TDR(UART4_BASE)
+#define UART5_TDR			USART_TDR(UART5_BASE)
+#define LPUART1_TDR			USART_CR1(LPUART1_BASE)
+
+
+/* --- USART_CR1 values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* M1: Word length */
+#define USART_CR1_M1			(1 << 28)
+
+/* EOBIE: End of Block interrupt enable */
+#define USART_CR1_EOBIE			(1 << 27)
+
+/* RTOIE: Receiver timeout interrupt enable */
+#define USART_CR1_RTOIE			(1 << 26)
+
+/* DEAT[4:0]: Driver Enable assertion time */
+#define USART_CR1_DEAT_MASK		(0x1F << 21)
+
+/* DEDT[4:0]: Driver Enable de-assertion time */
+#define USART_CR1_DEDT_MASK		(0x1F << 16)
+
+/* OVER8: Oversampling mode */
+#define USART_CR1_OVER8			(1 << 15)
+
+/* CMIE: Character match interrupt enable */
+#define USART_CR1_CMIE			(1 << 14)
+
+/* MME: Mute mode enable */
+#define USART_CR1_MME			(1 << 13)
+
+/* M0: Word length */
+#define USART_CR1_M			(1 << 12)
+
+/* WAKE: Receiver wakeup method */
+#define USART_CR1_WAKE			(1 << 11)
+
+/* PCE: Parity control enable */
+#define USART_CR1_PCE			(1 << 10)
+
+/* PS: Parity selection */
+#define USART_CR1_PS			(1 << 9)
+
+/* PEIE: PE interrupt enable */
+#define USART_CR1_PEIE			(1 << 8)
+
+/* TXEIE: interrupt enable */
+#define USART_CR1_TXEIE			(1 << 7)
+
+/* TCIE: Transmission complete interrupt enable */
+#define USART_CR1_TCIE			(1 << 6)
+
+/* RXNEIE: RXNE interrupt enable */
+#define USART_CR1_RXNEIE		(1 << 5)
+
+/* IDLEIE: IDLE interrupt enable */
+#define USART_CR1_IDLEIE		(1 << 4)
+
+/* TE: Transmitter enable */
+#define USART_CR1_TE			(1 << 3)
+
+/* RE: Receiver enable */
+#define USART_CR1_RE			(1 << 2)
+
+/* UESM: USART enable in Stop mode */
+#define USART_CR1_UESM			(1 << 1)
+
+/* UE: USART enable */
+#define USART_CR1_UE			(1 << 0)
+
+
+/* --- USART_CR2 values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* ADD[7:4]: Address of the USART node */
+#define USART_CR2_ADD_HIGH_MASK		(0xF << 28)
+
+/* ADD[3:0]: Address of the USART node */
+#define USART_CR2_ADD_LOW_MASK		(0xF << 24)
+
+/* RTOEN: Receiver timeout enable */
+#define USART_CR2_RTOEN			(1 << 23)
+
+/* ABRMOD[1:0]: Auto baud rate mode */
+#define USART_CR2_ABRMOD_MASK		(0x3 << 21)
+
+/* ABREN: Auto baud rate enable */
+#define USART_CR2_ABREN			(1 << 20)
+
+/* MSBFIRST: Most significant bit first */
+#define USART_CR2_MSBFIRST		(1 << 19)
+
+/* DATAINV: Binary data inversion */
+#define USART_CR2_DATAINV		(1 << 18)
+
+/* TXINV: TX pin active level inversion */
+#define USART_CR2_TXINV			(1 << 17)
+
+/* RXINV: RX pin active level inversion */
+#define USART_CR2_RXINV			(1 << 16)
+
+/* SWAP: Swap TX/RX pins */
+#define USART_CR2_SWAP			(1 << 15)
+
+/* LINEN: LIN mode enable */
+#define USART_CR2_LINEN			(1 << 14)
+
+/* STOP[1:0]: STOP bits */
+#define USART_CR2_STOPBITS_1		(0x00 << 12)     /* 1 stop bit */
+#define USART_CR2_STOPBITS_0_5		(0x01 << 12)     /* 0.5 stop bits */
+#define USART_CR2_STOPBITS_2		(0x02 << 12)     /* 2 stop bits */
+#define USART_CR2_STOPBITS_1_5		(0x03 << 12)     /* 1.5 stop bits */
+#define USART_CR2_STOPBITS_MASK		(0x3 << 12)
+
+/* CLKEN: Clock enable */
+#define USART_CR2_CLKEN			(1 << 11)
+
+/* CPOL: Clock polarity */
+#define USART_CR2_CPOL			(1 << 10)
+
+/* CPHA: Clock phase */
+#define USART_CR2_CPHA			(1 << 9)
+
+/* LBCL: Last bit clock pulse */
+#define USART_CR2_LBCL			(1 << 8)
+
+/* LBDIE: LIN break detection interrupt enable */
+#define USART_CR2_LBDIE			(1 << 6)
+
+/* LBDL: LIN break detection length */
+#define USART_CR2_LBDL			(1 << 5)
+
+/* ADDM7: 7-bit Address Detection/4-bit Address Detection */
+#define USART_CR2_ADDM7			(1 << 4)
+
+
+/* --- USART_CR3 values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* TCBGTIE: Transmission complete before guard time interrupt enable */
+#define USART_CR3_TCBGTIE		(1 << 24)
+
+/* UCESM: USART Clock Enable in Stop mode. */
+#define USART_CR3_UCESM			(1 << 23)
+
+/* WUFIE: Wakeup from Stop mode interrupt enable */
+#define USART_CR3_WUFIE			(1 << 22)
+
+/* WUS[1:0]: Wakeup from Stop mode interrupt flag selection */
+#define USART_CR3_WUS_MASK		(0x3 << 20)
+
+/* SCARCNT[2:0]: Smartcard auto-retry count */
+#define USART_CR3_SCARCNT_MASK		(0x7 << 17)
+
+/* DEP: Driver enable polarity selection */
+#define USART_CR3_DEP			(1 << 15)
+
+/* DEM: Driver enable mode */
+#define USART_CR3_DEM			(1 << 14)
+
+/* DDRE: DMA Disable on Reception Error */
+#define USART_CR3_DDRE			(1 << 13)
+
+/* OVRDIS: Overrun Disable */
+#define USART_CR3_OVRDIS		(1 << 12)
+
+/* ONEBIT: One sample bit method enable */
+#define USART_CR3_ONEBIT		(1 << 11)
+
+/* CTSIE: CTS interrupt enable */
+#define USART_CR3_CTSIE			(1 << 10)
+
+/* CTSE: CTS enable */
+#define USART_CR3_CTSE			(1 << 9)
+
+/* RTSE: RTS enable */
+#define USART_CR3_RTSE			(1 << 8)
+
+/* DMAT: DMA enable transmitter */
+#define USART_CR3_DMAT			(1 << 7)
+
+/* DMAR: DMA enable receiver */
+#define USART_CR3_DMAR			(1 << 6)
+
+/* SCEN: Smartcard mode enable */
+#define USART_CR3_SCEN			(1 << 5)
+
+/* NACK: Smartcard NACK enable */
+#define USART_CR3_NACK			(1 << 4)
+
+/* HDSEL: Half-duplex selection */
+#define USART_CR3_HDSEL			(1 << 3)
+
+/* IRLP: IrDA low-power */
+#define USART_CR3_IRLP			(1 << 2)
+
+/* IREN: IrDA mode enable */
+#define USART_CR3_IREN			(1 << 1)
+
+/* EIE: Error interrupt enable */
+#define USART_CR3_EIE			(1 << 0)
+
+
+/* --- USART_BRR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* BRR[15:4]: */
+#define USART_BRR_BRR_HIGH_MASK		(0xFFF << 4)
+
+/* BRR[3:0]: */
+#define USART_BRR_BRR_LOW_MASK		(0xF << 0)
+
+
+/* --- USART_GTPR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* GT[7:0]: Guard time value */
+#define USART_GTPR_GT_MASK		(0xFF << 8)
+
+/* PSC[7:0]: Prescaler value */
+#define USART_GTPR_PSC_MASK		(0xFF << 0)
+
+
+/* --- USART_RTOR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* BLEN[7:0]: Block Length */
+#define USART_RTOR_BLEN_MASK		(0xFF << 24)
+
+/* RTO[23:0]: Receiver timeout value */
+#define USART_RTOR_RTO_MASK		(0xFFFFFF << 0)
+
+
+/* --- USART_RQR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* TXFRQ: Transmit data flush request */
+#define USART_RQR_TXFRQ			(1 << 4)
+
+/* RXFRQ: Receive data flush request */
+#define USART_RQR_RXFRQ			(1 << 3)
+
+/* MMRQ: Mute mode request */
+#define USART_RQR_MMRQ			(1 << 2)
+
+/* SBKRQ: Send break request */
+#define USART_RQR_SBKRQ			(1 << 1)
+
+/* ABRRQ: Auto baud rate request */
+#define USART_RQR_ABRRQ			(1 << 0)
+
+
+/* --- USART_ISR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* TCBGT: Transmission complete before guard time completion. */
+#define USART_ISR_TCBGT			(1 << 25)
+
+/* REACK: Receive enable acknowledge flag */
+#define USART_ISR_REACK			(1 << 22)
+
+/* TEACK: Transmit enable acknowledge flag */
+#define USART_ISR_TEACK			(1 << 21)
+
+/* WUF: Wakeup from Stop mode flag */
+#define USART_ISR_WUF			(1 << 20)
+
+/* RWU: Receiver wakeup from Mute mode */
+#define USART_ISR_RWU			(1 << 19)
+
+/* SBKF: Send break flag */
+#define USART_ISR_SBKF			(1 << 18)
+
+/* CMF: Character match flag */
+#define USART_ISR_CMF			(1 << 17)
+
+/* BUSY: Busy flag */
+#define USART_ISR_BUSY			(1 << 16)
+
+/* ABRF: Auto baud rate flag */
+#define USART_ISR_ABRF			(1 << 15)
+
+/* ABRE: Auto baud rate error */
+#define USART_ISR_ABRE			(1 << 14)
+
+/* EOBF: End of block flag */
+#define USART_ISR_EOBF			(1 << 12)
+
+/* RTOF: Receiver timeout */
+#define USART_ISR_RTOF			(1 << 11)
+
+/* CTS: CTS flag */
+#define USART_ISR_CTS			(1 << 10)
+
+/* CTSIF: CTS interrupt flag */
+#define USART_ISR_CTSIF			(1 << 9)
+
+/* LBDF: LIN break detection flag */
+#define USART_ISR_LBDF			(1 << 8)
+
+/* TXE: Transmit data register empty */
+#define USART_ISR_TXE			(1 << 7)
+
+/* TC: Transmission complete */
+#define USART_ISR_TC			(1 << 6)
+
+/* RXNE: Read data register not empty */
+#define USART_ISR_RXNE			(1 << 5)
+
+/* IDLE: Idle line detected */
+#define USART_ISR_IDLE			(1 << 4)
+
+/* ORE: Overrun error */
+#define USART_ISR_ORE			(1 << 3)
+
+/* NF: START bit Noise detection flag */
+#define USART_ISR_NF			(1 << 2)
+
+/* FE: Framing error */
+#define USART_ISR_FE			(1 << 1)
+
+/* PE: Parity error */
+#define USART_ISR_PE			(1 << 0)
+
+
+/* --- USART_ICR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* WUCF: Wakeup from Stop mode clear flag */
+#define USART_ICR_WUCF			(1 << 20)
+
+/* CMCF: Character match clear flag */
+#define USART_ICR_CMCF			(1 << 17)
+
+/* EOBCF: End of block clear flag */
+#define USART_ICR_EOBCF			(1 << 12)
+
+/* RTOCF: Receiver timeout clear flag */
+#define USART_ICR_RTOCF			(1 << 11)
+
+/* CTSCF: CTS clear flag */
+#define USART_ICR_CTSCF			(1 << 9)
+
+/* LBDCF: LIN break detection clear flag */
+#define USART_ICR_LBDCF			(1 << 8)
+
+/* TCBGTCF: Transmission completed before guard time clear flag */
+#define USART_ICR_TCBGTCF		(1 << 7)
+
+/* TCCF: Transmission complete clear flag */
+#define USART_ICR_TCCF			(1 << 6)
+
+/* IDLECF: Idle line detected clear flag */
+#define USART_ICR_IDLECF		(1 << 4)
+
+/* ORECF: Overrun error clear flag */
+#define USART_ICR_ORECF			(1 << 3)
+
+/* NCF: Noise detected clear flag */
+#define USART_ICR_NCF			(1 << 2)
+
+/* FECF: Framing error clear flag */
+#define USART_ICR_FECF			(1 << 1)
+
+/* PECF: Parity error clear flag */
+#define USART_ICR_PECF			(1 << 0)
+
+
+/* --- USART_RDR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* RDR[8:0]: Receive data value */
+#define USART_RDR_RDR_MASK		(0x1FF << 0)
+
+
+/* --- USART_TDR values ----------------------------------------------------- */
+/* --- (dsparse v1.1 at Thu Jun 22 12:28:02 2017) --- */
+
+/* TDR[8:0]: Transmit data value */
+#define USART_TDR_TDR_MASK		(0x1FF << 0)
+
+
+#endif
+/** @endcond */
+/**@}*/
+

--- a/include/libopencm3/stm32/usart.h
+++ b/include/libopencm3/stm32/usart.h
@@ -32,6 +32,8 @@
 #       include <libopencm3/stm32/f4/usart.h>
 #elif defined(STM32L1)
 #       include <libopencm3/stm32/l1/usart.h>
+#elif defined(STM32L4)
+#       include <libopencm3/stm32/l4/usart.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/lib/stm32/l4/Makefile
+++ b/lib/stm32/l4/Makefile
@@ -37,7 +37,7 @@ TGT_CFLAGS      += $(DEBUG_FLAGS)
 ARFLAGS		= rcs
 
 # Specific objs
-OBJS		= adc.o flash.o pwr.o rcc.o
+OBJS		= adc.o flash.o pwr.o rcc.o usart.o
 
 # common/shared objs
 OBJS            += rcc_common_all.o
@@ -46,6 +46,7 @@ OBJS            += adc_common_v2.o adc_common_v2_multi.o
 OBJS            += rng_common_v1.o
 OBJS            += timer_common_all.o
 OBJS            += i2c_common_v2.o
+OBJS            += usart_common_all.o
 
 VPATH += ../../usb:../:../../cm3:../common
 VPATH += ../../ethernet

--- a/lib/stm32/l4/usart.c
+++ b/lib/stm32/l4/usart.c
@@ -1,0 +1,115 @@
+/** @defgroup usart_file USART
+
+@ingroup STM32L4xx
+
+@brief <b>libopencm3 STM32L4xx USART</b>
+
+@version 1.0.0
+
+@date 22 June 2017
+
+LGPL License Terms @ref lgpl_license
+*/
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/stm32/rcc.h>
+
+/*---------------------------------------------------------------------------*/
+/** @brief USART Send a Data Word.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@param[in] data unsigned 16 bit.
+*/
+
+void usart_send(uint32_t usart, uint16_t data)
+{
+	/* Send data. */
+	USART_TDR(usart) = (data & USART_TDR_TDR_MASK);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief USART Read a Received Data Word.
+
+If parity is enabled the MSB (bit 7 or 8 depending on the word length) is the
+parity bit.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@returns unsigned 16 bit data word.
+*/
+
+uint16_t usart_recv(uint32_t usart)
+{
+	/* Receive data. */
+	return USART_RDR(usart) & USART_RDR_RDR_MASK;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief USART Wait for Transmit Data Buffer Empty
+
+Blocks until the transmit data buffer becomes empty and is ready to accept the
+next data word.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+*/
+
+void usart_wait_send_ready(uint32_t usart)
+{
+	/* Wait until the data has been transferred into the shift register. */
+	while ((USART_ISR(usart) & USART_ISR_TXE) == 0);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief USART Wait for Received Data Available
+
+Blocks until the receive data buffer holds a valid received data word.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+*/
+
+void usart_wait_recv_ready(uint32_t usart)
+{
+	/* Wait until the data is ready to be received. */
+	while ((USART_ISR(usart) & USART_ISR_RXNE) == 0);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief USART Read a Status Flag.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@param[in] flag Unsigned int32. Status register flag  @ref usart_sr_flags.
+@returns boolean: flag set.
+*/
+
+bool usart_get_flag(uint32_t usart, uint32_t flag)
+{
+	return ((USART_ISR(usart) & flag) != 0);
+}
+
+
+/**@}*/


### PR DESCRIPTION
Adds USART support to the STM32L4.  I followed the existing examples as closely as is practical and verified that the docs seem to generate properly and include the new stuff.

Also of note is that if others are making driver files for the STM32 platform, I put together a python script that can be used to parse the reference manual and spit out code for the driver.  It can be found here: https://github.com/therealchalz/datasheetparser