### PR TITLE
DRAFT: vector: make common linker definitions available to users

### DIFF
--- a/include/libopencm3/cm3/vector.h
+++ b/include/libopencm3/cm3/vector.h
@@ -61,4 +61,8 @@ typedef struct {
 	vector_table_entry_t irq[NVIC_IRQ_COUNT];
 } vector_table_t;
 
+/* Common symbols exported by the linker script(s): */
+extern unsigned _data_loadaddr, _data, _edata, _ebss, _stack;
+extern unsigned vector_table;
+
 #endif

--- a/lib/cm3/vector.c
+++ b/lib/cm3/vector.c
@@ -26,8 +26,7 @@
 /* load the weak symbols for IRQ_HANDLERS */
 #include "../dispatch/vector_nvic.c"
 
-/* Symbols exported by the linker script(s): */
-extern unsigned _data_loadaddr, _data, _edata, _ebss, _stack;
+/* Less common symbols exported by the linker script(s): */
 typedef void (*funcp_t) (void);
 extern funcp_t __preinit_array_start, __preinit_array_end;
 extern funcp_t __init_array_start, __init_array_end;


### PR DESCRIPTION
_data_loadaddr, _data, _edata, _ebss, _stack and vector_table all now
available in vector.h.

Suggested on IRC.  Feedback on the types and the general idea very welcome.