### PR TITLE
usb_standard: Care for terminating 0 in string handling.

### DIFF
--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -196,7 +196,7 @@ static int usb_standard_get_descriptor(usbd_device *usbd_dev,
 			/* This string is returned as UTF16, hence the
 			 * multiplication
 			 */
-			sd->bLength = strlen(usbd_dev->strings[array_idx]) * 2 +
+			sd->bLength = (1 + strlen(usbd_dev->strings[array_idx])) * 2 +
 				      sizeof(sd->bLength) +
 				      sizeof(sd->bDescriptorType);
 


### PR DESCRIPTION
When space for the UTF strings is allocated, the terminating 0 must be considered. Otherwise a string with length 64 will lead to errors when the hosts requests the string.