### PR TITLE
timers: define ADVANCED_TIMERS in a "portable" manner

### DIFF
--- a/lib/stm32/common/timer_common_all.c
+++ b/lib/stm32/common/timer_common_all.c
@@ -114,7 +114,11 @@ knob.
 #include <libopencm3/stm32/timer.h>
 #include <libopencm3/stm32/rcc.h>
 
-#define ADVANCED_TIMERS (defined(TIM1_BASE) || defined(TIM8_BASE))
+#if (defined(TIM1_BASE) || defined(TIM8_BASE))
+#define ADVANCED_TIMERS 1
+#else
+#define ADVANCED_TIMERS 0
+#endif
 
 #if defined(TIM8)
 #define TIMER_IS_ADVANCED(periph) (((periph) == TIM1) || ((periph) == TIM8))


### PR DESCRIPTION
UNTESTED!

gcc7.2 complained about the old syntax.  So, be more verbose.

Fixes: https://github.com/libopencm3/libopencm3/issues/826