### PR TITLE
make: avoid shell find for windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,12 @@ Q := @
 MAKEFLAGS += --no-print-directory
 endif
 
-IRQ_DEFN_FILES	:= $(shell find . -name 'irq.json')
-STYLECHECKFILES := $(shell find . -name '*.[ch]')
+# Avoid the use of shell find, for windows compatibility
+IRQ_DEFN_FILES	:= $(wildcard include/libopencm3/*/irq.json)
+IRQ_DEFN_FILES	+= $(wildcard include/libopencm3/*/*/irq.json)
+STYLECHECKFILES := $(wildcard include/*/*.h include/*/*/*.h include/*/*/*/*.h)
+STYLECHECKFILES += $(wildcard lib/*/*.h lib/*/*/*.h lib/*/*/*/*.h)
+STYLECHECKFILES += $(wildcard lib/*/*.c lib/*/*/*.c lib/*/*/*/*.c)
 
 all: build
 


### PR DESCRIPTION
Instead of expecting a posix-ish "find" in the shell, simply leverage
our knowledge of our source structure to make a single list using make's
builtin wildcard() functionality.

Fixes https://github.com/libopencm3/libopencm3/issues/828