### PR TITLE
STM32F0: Enable prefetch buffer in rcc_clock_setup_*()

### DIFF
--- a/lib/stm32/f0/rcc.c
+++ b/lib/stm32/f0/rcc.c
@@ -543,6 +543,7 @@ void rcc_clock_setup_in_hse_8mhz_out_48mhz(void)
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
 
+	flash_prefetch_buffer_enable();
 	flash_set_ws(FLASH_ACR_LATENCY_024_048MHZ);
 
 	/* PLL: 8MHz * 6 = 48MHz */
@@ -570,6 +571,7 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
 
+	flash_prefetch_buffer_enable();
 	flash_set_ws(FLASH_ACR_LATENCY_024_048MHZ);
 
 	/* 8MHz * 12 / 2 = 48MHz */
@@ -595,6 +597,7 @@ void rcc_clock_setup_in_hsi48_out_48mhz(void)
 	rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
 	rcc_set_ppre(RCC_CFGR_PPRE_NODIV);
 
+	flash_prefetch_buffer_enable();
 	flash_set_ws(FLASH_ACR_LATENCY_024_048MHZ);
 
 	rcc_set_sysclk_source(RCC_HSI48);

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -744,7 +744,7 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 	rcc_set_ppre2(RCC_CFGR_PPRE2_HCLK_NODIV); /* Set. 24MHz Max. 24MHz */
 
 	/*
-	 * Sysclk is (will be) running with 24MHz -> 2 waitstates.
+	 * Sysclk is (will be) running with 24MHz -> 0 waitstates.
 	 * 0WS from 0-24MHz
 	 * 1WS from 24-48MHz
 	 * 2WS from 48-72MHz


### PR DESCRIPTION
This modification enables the prefetch buffer which makes code execution from the Flash memory faster.

Reasons for the modification:
- The `rcc_clock_setup_*()` functions should provide the maximum possible speed as described in 0259102560ad7d0be17d0b8c7a8ffecb04ab0650
- The code is now more consistent with other families as STM32L0/L1 functions `rcc_clock_setup_*()` also enable the prefetch buffer

I wanted to enable the prefetch buffer for STM32F1 parts as well, but it is already enabled after reset according to the reference manual (STM32F0 parts have the prefetch buffer disabled by default).