### PR TITLE
stm32f1: adc: Add functions to get and clear flags

### DIFF
--- a/include/libopencm3/stm32/common/adc_common_v1.h
+++ b/include/libopencm3/stm32/common/adc_common_v1.h
@@ -185,12 +185,27 @@ specific memorymap.h header before including this header file.*/
 
 
 /* --- ADC_SR values ------------------------------------------------------- */
+/****************************************************************************/
+/** @defgroup adc_sr_values ADC Status Register Flags
+@ingroup STM32xx_adc_defines
 
+@{*/
+
+/* STRT:*//** Regular channel Start flag */
 #define ADC_SR_STRT                     (1 << 4)
+
+/* JSTRT:*//** Injected channel Start flag */
 #define ADC_SR_JSTRT                    (1 << 3)
+
+/* JEOC:*//** Injected channel end of conversion */
 #define ADC_SR_JEOC                     (1 << 2)
+
+/* EOC:*//** End of conversion */
 #define ADC_SR_EOC                      (1 << 1)
+
+/* AWD:*//** Analog watchdog flag */
 #define ADC_SR_AWD                      (1 << 0)
+/**@}*/
 
 /* --- ADC_CR1 values ------------------------------------------------------ */
 

--- a/include/libopencm3/stm32/common/adc_common_v1.h
+++ b/include/libopencm3/stm32/common/adc_common_v1.h
@@ -411,6 +411,8 @@ void adc_start_conversion_regular(uint32_t adc);
 void adc_start_conversion_injected(uint32_t adc);
 void adc_enable_dma(uint32_t adc);
 void adc_disable_dma(uint32_t adc);
+bool adc_get_flag(uint32_t adc, uint32_t flag);
+void adc_clear_flag(uint32_t adc, uint32_t flag);
 
 /* common methods that have slight differences */
 void adc_set_sample_time(uint32_t adc, uint8_t channel, uint8_t time);

--- a/include/libopencm3/stm32/f1/adc.h
+++ b/include/libopencm3/stm32/f1/adc.h
@@ -417,9 +417,10 @@ void adc_calibration(uint32_t adc)
 void adc_calibrate_async(uint32_t adc);
 bool adc_is_calibrating(uint32_t adc);
 void adc_calibrate(uint32_t adc);
+bool adc_get_flag(uint32_t adc, uint32_t flag);
+void adc_clear_flag(uint32_t adc, uint32_t flag);
 
 END_DECLS
 
 #endif
 /**@}*/
-

--- a/include/libopencm3/stm32/f1/adc.h
+++ b/include/libopencm3/stm32/f1/adc.h
@@ -417,8 +417,6 @@ void adc_calibration(uint32_t adc)
 void adc_calibrate_async(uint32_t adc);
 bool adc_is_calibrating(uint32_t adc);
 void adc_calibrate(uint32_t adc);
-bool adc_get_flag(uint32_t adc, uint32_t flag);
-void adc_clear_flag(uint32_t adc, uint32_t flag);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f4/adc.h
+++ b/include/libopencm3/stm32/f4/adc.h
@@ -96,7 +96,13 @@ LGPL License Terms @ref lgpl_license
 
 /* --- ADC_SR values ------------------------------------------------------- */
 
+/** @defgroup adc_sr_values ADC Status Register Flags
+ * @ingroup adc_defines
+ *@{*/
+
+/* OVR:*//** Overrun */
 #define ADC_SR_OVR			(1 << 5)
+/**@}*/
 
 /* --- ADC_CR1 values specific to STM32F2,4--------------------------------- */
 

--- a/include/libopencm3/stm32/l1/adc.h
+++ b/include/libopencm3/stm32/l1/adc.h
@@ -101,10 +101,24 @@ LGPL License Terms @ref lgpl_license
 /**@}*/
 
 /* --- ADC_SR values ------------------------------------------------------- */
+/****************************************************************************/
+/** @defgroup adc_sr_values ADC Status Register Flags
+ * @ingroup adc_defines
+ *
+ *@{*/
+
+/* JCNR:*//** Injected channel not ready */
 #define ADC_SR_JCNR			(1 << 9)
+
+/* RCNR:*//** Regular channel not ready */
 #define ADC_SR_RCNR			(1 << 8)
+
+/* ADONS:*//** ADC ON status */
 #define ADC_SR_ADONS			(1 << 6)
+
+/* OVR:*//** Overrun */
 #define ADC_SR_OVR			(1 << 5)
+/**@}*/
 
 /* --- ADC_CR1 values ------------------------------------------------------- */
 #define ADC_CR1_OVRIE			(1 << 28)

--- a/lib/stm32/common/adc_common_v1.c
+++ b/lib/stm32/common/adc_common_v1.c
@@ -747,6 +747,36 @@ void adc_disable_dma(uint32_t adc)
 	ADC_CR2(adc) &= ~ADC_CR2_DMA;
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief Read a Status Flag.
 
+@param[in] adc Unsigned int32. ADC register address base @ref adc_reg_base
+@param[in] flag Unsigned int32. Status register flag  @ref adc_sr_values.
+@returns boolean: flag set.
+*/
+
+bool adc_get_flag(uint32_t adc, uint32_t flag)
+{
+	if ((ADC_SR(adc) & flag) != 0) {
+		return true;
+	}
+
+	return false;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear a Status Flag.
+
+@param[in] adc Unsigned int32. ADC register address base @ref adc_reg_base
+@param[in] flag Unsigned int32. Status register flag  @ref adc_sr_values.
+*/
+
+void adc_clear_flag(uint32_t adc, uint32_t flag)
+{
+	/* All defined bits are rc_w0 */
+	ADC_SR(adc) = ~flag;
+}
+
+/*---------------------------------------------------------------------------*/
 
 /**@}*/

--- a/lib/stm32/f1/adc.c
+++ b/lib/stm32/f1/adc.c
@@ -454,36 +454,4 @@ void adc_set_sample_time_on_all_channels(uint32_t adc, uint8_t time)
 	ADC_SMPR1(adc) = reg32;
 }
 
-/*---------------------------------------------------------------------------*/
-/** @brief Read a Status Flag.
-
-@param[in] adc Unsigned int32. ADC register address base @ref adc_reg_base
-@param[in] flag Unsigned int32. Status register flag  @ref adc_sr_values.
-@returns boolean: flag set.
-*/
-
-bool adc_get_flag(uint32_t adc, uint32_t flag)
-{
-	if ((ADC_SR(adc) & flag) != 0) {
-		return true;
-	}
-
-	return false;
-}
-
-/*---------------------------------------------------------------------------*/
-/** @brief Clear a Status Flag.
-
-@param[in] adc Unsigned int32. ADC register address base @ref adc_reg_base
-@param[in] flag Unsigned int32. Status register flag  @ref adc_sr_values.
-*/
-
-void adc_clear_flag(uint32_t adc, uint32_t flag)
-{
-	/* All defined bits are rc_w0 */
-	ADC_SR(adc) = ~flag;
-}
-
-/*---------------------------------------------------------------------------*/
-
 /**@}*/

--- a/lib/stm32/f1/adc.c
+++ b/lib/stm32/f1/adc.c
@@ -454,8 +454,36 @@ void adc_set_sample_time_on_all_channels(uint32_t adc, uint8_t time)
 	ADC_SMPR1(adc) = reg32;
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief Read a Status Flag.
+
+@param[in] adc Unsigned int32. ADC register address base @ref adc_reg_base
+@param[in] flag Unsigned int32. Status register flag  @ref adc_sr_values.
+@returns boolean: flag set.
+*/
+
+bool adc_get_flag(uint32_t adc, uint32_t flag)
+{
+	if ((ADC_SR(adc) & flag) != 0) {
+		return true;
+	}
+
+	return false;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clear a Status Flag.
+
+@param[in] adc Unsigned int32. ADC register address base @ref adc_reg_base
+@param[in] flag Unsigned int32. Status register flag  @ref adc_sr_values.
+*/
+
+void adc_clear_flag(uint32_t adc, uint32_t flag)
+{
+	/* All defined bits are rc_w0 */
+	ADC_SR(adc) = ~flag;
+}
 
 /*---------------------------------------------------------------------------*/
 
 /**@}*/
-


### PR DESCRIPTION
- Include new functions to get and clear flags from ADC status register (ADC_SR) on STM32F1 ADCs.
These are based on the timer functions:  timer_clear_flag and timer_get_flag for similar purposes. (Check stm32/common/timer_common_all.h and /stm32/common/timer_common_all.c)
- Add some descriptions and "@refgroup" on adc_common_v1.h file to get linked documentation.