### PR TITLE
stm32: can: Fixed incorrect CAN_FMR_CAN2SB_SHIFT value

### DIFF
--- a/include/libopencm3/stm32/can.h
+++ b/include/libopencm3/stm32/can.h
@@ -588,8 +588,8 @@ LGPL License Terms @ref lgpl_license
  * CAN2SB[5:0]: CAN2 start bank
  * (only on connectivity line devices otherwise reserved)
  */
-#define CAN_FMR_CAN2SB_MASK		(0x3F << 8)
-#define CAN_FMR_CAN2SB_SHIFT		15
+#define CAN_FMR_CAN2SB_SHIFT		8
+#define CAN_FMR_CAN2SB_MASK		(0x3F << CAN_FMR_CAN2SB_SHIFT)
 
 /* 7:1 Reserved, forced to reset value */
 


### PR DESCRIPTION
According to several reference manuals for MCUs of the STM32F4 series, the CAN_FMR_CAN2SB_SHIFT value should be 8, not 15.