### PR TITLE
stm32: Fix address offset for ADC_CDR register

### DIFF
--- a/include/libopencm3/stm32/common/adc_common_v2_multi.h
+++ b/include/libopencm3/stm32/common/adc_common_v2_multi.h
@@ -83,7 +83,7 @@ specific memorymap.h header before including this header file.*/
 
 /* ADC common (shared) registers */
 #define ADC_CSR(adc)		MMIO32((adc) + 0x300 + 0x0)
-#define ADC_CDR(adc)		MMIO32((adc) + 0x300 + 0xa)
+#define ADC_CDR(adc)		MMIO32((adc) + 0x300 + 0xc)
 
 /* --- Register values ------------------------------------------------------*/
 /* ADC_ISR Values -----------------------------------------------------------*/


### PR DESCRIPTION
See #846 
Tested and working in my project that uses this register.