### PR TITLE
stm32:i2c-v2: Clarify digital filter setting

### DIFF
--- a/include/libopencm3/stm32/common/i2c_common_v2.h
+++ b/include/libopencm3/stm32/common/i2c_common_v2.h
@@ -137,24 +137,9 @@ specific memorymap.h header before including this header file.*/
 /* ANFOFF: Analog noise filter OFF */
 #define I2C_CR1_ANFOFF			(1 << 12)
 
-/* DNF[3:0]: Digital noise filter */
-#define I2C_CR1_DNF_DISABLED		(0x0 << 8)
-#define I2C_CR1_DNF_UP_1_TI2CCLK	(0x1 << 8)
-#define I2C_CR1_DNF_UP_2_TI2CCLK	(0x2 << 8)
-#define I2C_CR1_DNF_UP_3_TI2CCLK	(0x3 << 8)
-#define I2C_CR1_DNF_UP_4_TI2CCLK	(0x4 << 8)
-#define I2C_CR1_DNF_UP_5_TI2CCLK	(0x5 << 8)
-#define I2C_CR1_DNF_UP_6_TI2CCLK	(0x6 << 8)
-#define I2C_CR1_DNF_UP_7_TI2CCLK	(0x7 << 8)
-#define I2C_CR1_DNF_UP_8_TI2CCLK	(0x8 << 8)
-#define I2C_CR1_DNF_UP_9_TI2CCLK	(0x9 << 8)
-#define I2C_CR1_DNF_UP_10_TI2CCLK	(0xA << 8)
-#define I2C_CR1_DNF_UP_11_TI2CCLK	(0xB << 8)
-#define I2C_CR1_DNF_UP_12_TI2CCLK	(0xC << 8)
-#define I2C_CR1_DNF_UP_13_TI2CCLK	(0xD << 8)
-#define I2C_CR1_DNF_UP_14_TI2CCLK	(0xE << 8)
-#define I2C_CR1_DNF_UP_15_TI2CCLK	(0xF << 8)
-#define I2C_CR1_DNF_MASK                (0xF << 8)
+/** DNF[3:0]: Digital noise filter. */
+#define I2C_CR1_DNF_MASK		0xF
+#define I2C_CR1_DNF_SHIFT		8
 
 /* ERRIE: Error interrupts enable */
 #define I2C_CR1_ERRIE			(1 << 7)

--- a/lib/stm32/common/i2c_common_v2.c
+++ b/lib/stm32/common/i2c_common_v2.c
@@ -188,9 +188,18 @@ void i2c_disable_analog_filter(uint32_t i2c)
 	I2C_CR1(i2c) |= I2C_CR1_ANFOFF;
 }
 
+/**
+ * Set the I2C digital filter.
+ * These bits are used to configure the digital noise filter on SDA and
+ * SCL input. The digital filter will filter spikes with a length of up
+ * to dnf_setting * I2CCLK clocks
+ * @param i2c peripheral of interest
+ * @param dnf_setting 0 to disable, else 1..15 i2c clocks
+ */
 void i2c_set_digital_filter(uint32_t i2c, uint8_t dnf_setting)
 {
-	I2C_CR1(i2c) = (I2C_CR1(i2c) & ~I2C_CR1_DNF_MASK) | dnf_setting;
+	I2C_CR1(i2c) = (I2C_CR1(i2c) & ~(I2C_CR1_DNF_MASK << I2C_CR1_DNF_SHIFT)) |
+		(dnf_setting << I2C_CR1_DNF_SHIFT);
 }
 
 /* t_presc= (presc+1)*t_i2cclk */


### PR DESCRIPTION
Drop redundant field definitions, fix truncation of argument bug and add
documentation.

Fixes: https://github.com/libopencm3/libopencm3/issues/831