### PR TITLE
Allows registration of non-continous description string

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -141,6 +141,9 @@ extern int usbd_register_set_config_callback(usbd_device *usbd_dev,
 extern void usbd_register_set_altsetting_callback(usbd_device *usbd_dev,
 					usbd_set_altsetting_callback callback);
 
+/** Registers a non-contiguous string descriptor */
+extern void usbd_register_extra_string(usbd_device *usbd_dev, int index, const char* string);
+
 /* Functions to be provided by the hardware abstraction layer */
 extern void usbd_poll(usbd_device *usbd_dev);
 

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -56,6 +56,8 @@ usbd_device *usbd_init(const usbd_driver *driver,
 	usbd_dev->num_strings = num_strings;
 	usbd_dev->ctrl_buf = control_buffer;
 	usbd_dev->ctrl_buf_len = control_buffer_size;
+	usbd_dev->extra_string_idx = -1;
+	usbd_dev->extra_string = NULL;
 
 	usbd_dev->user_callback_ctr[0][USB_TRANSACTION_SETUP] =
 	    _usbd_control_setup;
@@ -92,6 +94,19 @@ void usbd_register_resume_callback(usbd_device *usbd_dev,
 void usbd_register_sof_callback(usbd_device *usbd_dev, void (*callback)(void))
 {
 	usbd_dev->user_callback_sof = callback;
+}
+
+void usbd_register_extra_string(usbd_device *usbd_dev, int index, const char* string)
+{
+	if (string != NULL && index > 0)
+	{
+		usbd_dev->extra_string_idx = index;
+		usbd_dev->extra_string = string;
+	}
+	else
+	{
+		usbd_dev->extra_string_idx = -1;
+	}
 }
 
 void _usbd_reset(usbd_device *usbd_dev)

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -93,6 +93,9 @@ struct _usbd_device {
 	const struct _usbd_driver *driver;
 
 	/* private driver data */
+	/* Extra, non-contiguous user string descriptor index and value */
+	int extra_string_idx;
+	const char* extra_string;
 
 	uint16_t fifo_mem_top;
 	uint16_t fifo_mem_top_ep0;

--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -174,6 +174,20 @@ static int usb_standard_get_descriptor(usbd_device *usbd_dev,
 				      sizeof(sd->wData[0]);
 
 			*len = MIN(*len, sd->bLength);
+		} else if (descr_idx == usbd_dev->extra_string_idx) {
+			/* This string is returned as UTF16, hence the
+			 * multiplication
+			 */
+			sd->bLength = strlen(usbd_dev->extra_string) * 2 +
+				      sizeof(sd->bLength) +
+				      sizeof(sd->bDescriptorType);
+
+			*len = MIN(*len, sd->bLength);
+
+			for (i = 0; i < (*len / 2) - 1; i++) {
+				sd->wData[i] =
+					usbd_dev->extra_string[i];
+			}
 		} else {
 			array_idx = descr_idx - 1;
 
@@ -213,6 +227,7 @@ static int usb_standard_get_descriptor(usbd_device *usbd_dev,
 
 		return USBD_REQ_HANDLED;
 	}
+
 	return USBD_REQ_NOTSUPP;
 }
 


### PR DESCRIPTION
It can help register a special string index (0xee) for Windows's WCID for USBd stack which enables automatic WinUSB driver installation, just like HID or MSC class device.