### PR TITLE
Added hsi clock setup for STM32F4.

### DIFF
--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -741,6 +741,8 @@ extern const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END];
 
+extern const struct rcc_clock_scale *rcc_hsi;
+
 enum rcc_osc {
 	RCC_PLL,
 	RCC_PLLSAI,
@@ -1042,6 +1044,7 @@ void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq, uint32_t pllr);
 uint32_t rcc_system_clock_source(void);
 void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
+void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock);
 
 END_DECLS
 


### PR DESCRIPTION
I needed this for a NUCLEO F401RE board, but it should be working with all F4 MCUs (as long as you select frequencies within the spec).