### PR TITLE
STM32F3: add function to setup 72mhz clock from 8mhz bypass source

### DIFF
--- a/include/libopencm3/stm32/f3/rcc.h
+++ b/include/libopencm3/stm32/f3/rcc.h
@@ -608,6 +608,7 @@ void rcc_set_pll_multiplier(uint32_t pll);
 uint32_t rcc_get_system_clock_source(void);
 void rcc_backupdomain_reset(void);
 void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock);
+void rcc_clock_setup_hse_8mhz_bypass_72mhz(void);
 void rcc_set_i2c_clock_hsi(uint32_t i2c);
 void rcc_set_i2c_clock_sysclk(uint32_t i2c);
 uint32_t rcc_get_i2c_clocks(void);


### PR DESCRIPTION
This patch adds an utility function for the STM32F3 line to set up a 72MHz system clock from a 8MHz HSE bypass source. This is useful for quickly getting the STM32F3-Discovery board set to it's maximum clock speed and having the USB peripheral run at 48MHz.