### PR TITLE
STM32F3 Power module fixes

### DIFF
--- a/lib/stm32/common/pwr_common_v1.c
+++ b/lib/stm32/common/pwr_common_v1.c
@@ -172,7 +172,7 @@ threshold.
 
 bool pwr_voltage_high(void)
 {
-	return PWR_CSR & PWR_CSR_PVDO;
+	return !(PWR_CSR & PWR_CSR_PVDO);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/f3/Makefile
+++ b/lib/stm32/f3/Makefile
@@ -37,11 +37,11 @@ TGT_CFLAGS	+= $(STANDARD_FLAGS)
 
 ARFLAGS		= rcs
 
-OBJS		= rcc.o adc.o can.o usart.o dma.o flash.o desig.o
+OBJS		= rcc.o adc.o can.o pwr.o usart.o dma.o flash.o desig.o
 
 OBJS            += gpio_common_all.o gpio_common_f0234.o \
 		   dac_common_all.o crc_common_all.o \
-		   iwdg_common_all.o spi_common_all.o dma_common_l1f013.o\
+		   iwdg_common_all.o pwr_common_v1.o spi_common_all.o dma_common_l1f013.o\
 		   timer_common_all.o timer_common_f0234.o flash_common_f234.o \
 		   flash.o exti_common_all.o rcc_common_all.o spi_common_f03.o
 OBJS		+= adc_common_v2.o adc_common_v2_multi.o


### PR DESCRIPTION
1) Fixes Makefile to include pwr.o and power_common_v1.o object files for STM32F3
2) Fixes flipped logic for PVDO bit for pwr module 

http://www.st.com/content/ccc/resource/technical/document/reference_manual/4a/19/6e/18/9d/92/43/32/DM00043574.pdf/files/DM00043574.pdf/jcr:content/translations/en.DM00043574.pdf

Bit 2 PVDO: PVD output
This bit is set and cleared by hardware. It is valid only if PVD is enabled by the
PVDE bit.
0: VDD/VDDA is higher than the PVD threshold selected with the PLS[2:0] bits.
1: VDD/VDDA is **lower** than the PVD threshold selected with the PLS[2:0] bits.