### PR TITLE
stm32: make reset_handler reusable in app

### DIFF
--- a/include/libopencm3/cm3/nvic.h
+++ b/include/libopencm3/cm3/nvic.h
@@ -157,6 +157,8 @@ void sv_call_handler(void);
 void pend_sv_handler(void);
 void sys_tick_handler(void);
 
+void cm3_reset_handler(void);
+
 /* Those defined only on ARMv7 and above */
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
 void mem_manage_handler(void);

--- a/lib/cm3/vector.c
+++ b/lib/cm3/vector.c
@@ -61,6 +61,11 @@ vector_table_t vector_table = {
 
 void __attribute__ ((weak, naked)) reset_handler(void)
 {
+	cm3_reset_handler();
+}
+
+void cm3_reset_handler(void)
+{
 	volatile unsigned *src, *dest;
 	funcp_t *fp;
 


### PR DESCRIPTION
If app wishes to have its own reset_handler, e.g. do clock initialzation
or text relocation, it'll have to override the default one (declared as weak)
at link time, rewrite everything in reset_handler and can't reuse what's
already in libopencm3. This patch breaks reset_handler into 2: reset_handler
remains as weak and can be overriden by app, and cm3_reset_handler which
provides a generic reset handling and make it available to the app.