### PR TITLE
Makefile: allow specific targets to be built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,17 @@ space:=
 space+=
 SRCLIBDIR:= $(subst $(space),\$(space),$(realpath lib))
 
-TARGETS := stm32/f0 stm32/f1 stm32/f2 stm32/f3 stm32/f4 stm32/f7
-TARGETS += stm32/l0 stm32/l1 stm32/l4
-TARGETS += lpc13xx lpc17xx lpc43xx/m4 lpc43xx/m0
-TARGETS += lm3s lm4f
-TARGETS += efm32/tg efm32/g efm32/lg efm32/gg
-TARGETS += sam/3a sam/3n sam/3s sam/3u sam/3x
-TARGETS += sam/d
-TARGETS += vf6xx
+_DEFAULT_TARGETS := stm32/f0 stm32/f1 stm32/f2 stm32/f3 stm32/f4 stm32/f7
+_DEFAULT_TARGETS += stm32/l0 stm32/l1 stm32/l4
+_DEFAULT_TARGETS += lpc13xx lpc17xx lpc43xx/m4 lpc43xx/m0
+_DEFAULT_TARGETS += lm3s lm4f
+_DEFAULT_TARGETS += efm32/tg efm32/g efm32/lg efm32/gg
+_DEFAULT_TARGETS += sam/3a sam/3n sam/3s sam/3u sam/3x
+_DEFAULT_TARGETS += sam/d
+_DEFAULT_TARGETS += vf6xx
+
+TARGETS ?= $(_DEFAULT_TARGETS)
+
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)


### PR DESCRIPTION
If "TARGETS" is defined, use that; otherwise defaults to all targets.
Example : "make TARGETS=stm32/f0"