### PR TITLE
L4: Fix USART3 definition/typo

### DIFF
--- a/include/libopencm3/stm32/l4/usart.h
+++ b/include/libopencm3/stm32/l4/usart.h
@@ -37,7 +37,7 @@
  */
 #define USART1				USART1_BASE
 #define USART2				USART2_BASE
-#define USART3				USART2_BASE
+#define USART3				USART3_BASE
 #define UART4				USART4_BASE
 #define UART5				USART5_BASE
 #define LPUART1				LPUART1_BASE


### PR DESCRIPTION
USART*3* should point to *3* not *2*.