### PR TITLE
genlink: Add LIBDEPS for libopencm3 itself

### DIFF
--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -56,9 +56,11 @@ endif
 # where those are provided by different means
 ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(genlink_family).a))
 LDLIBS += -lopencm3_$(genlink_family)
+LIBDEPS += $(OPENCM3_DIR)/lib/libopencm3_$(genlink_family).a
 else
 ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(genlink_subfamily).a))
 LDLIBS += -lopencm3_$(genlink_subfamily)
+LIBDEPS += $(OPENCM3_DIR)/lib/libopencm3_$(genlink_subfamily).a
 else
 $(warning $(OPENCM3_DIR)/lib/libopencm3_$(genlink_family).a library variant for the selected device does not exist.)
 endif


### PR DESCRIPTION
If $(OPENCM3_DIR)/lib/libopencm3_*.a exists, it will be linked in.
If we do that, we should also add it to the deps.
That way a newer *.a will result in a relink.