### PR TITLE
STM32L4: USART: Fix baudrate calculation for LPUART1

### DIFF
--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -48,7 +48,13 @@ usart_reg_base
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud)
 {
-	uint32_t clock = rcc_apb1_frequency;
+#ifdef LPUART1
+	uint64_t clock;
+#else
+	uint32_t clock;
+#endif
+
+	clock = rcc_apb1_frequency;
 
 #if defined USART1
 	if ((usart == USART1)
@@ -69,7 +75,14 @@ void usart_set_baudrate(uint32_t usart, uint32_t baud)
 	 * Note: We round() the value rather than floor()ing it, for more
 	 * accurate divisor selection.
 	 */
-	USART_BRR(usart) = ((2 * clock) + baud) / (2 * baud);
+	clock *= 2;
+#ifdef LPUART1
+	if (usart == LPUART1) {
+		clock *= 256;
+	}
+#endif
+
+	USART_BRR(usart) = (clock + baud) / (2 * baud);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
LPUART1 needs BRR to be 256 times the normal value.

To calculate this correctly with rounding, the best answer
is to use 64 bit values: A clock of say 20 MHz times 256 is
already 5e9 MHz, which doesn't fit in 32 bits.

There are probably some tricks using GCD, fixed point math
or something, but really, a little 64 bit math wont hurt.
This is setup code, which usually is not performance
critical.