### PR TITLE
stm32l0: NVIC: channel 16 is tim3 on stm32l0x0, stm32l0x1 and stm32l0x2.

### DIFF
--- a/include/libopencm3/stm32/l0/irq.json
+++ b/include/libopencm3/stm32/l0/irq.json
@@ -16,7 +16,7 @@
         "lptim1", 
         "reserved1", 
         "tim2", 
-        "reserved2", 
+        "tim3", 
         "tim6_dac", 
         "reserved3", 
         "reserved4", 


### PR DESCRIPTION
tim3 interrupt is wired to nvic channel 16 if present. add it to irq.json definition.