### PR TITLE
add STM32L0xx4 w/ 16K flash

### DIFF
--- a/lib/stm32/l0/stm32l0xx4.ld
+++ b/lib/stm32/l0/stm32l0xx4.ld
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2012 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for STM32L0xx4, 16K flash, 2K RAM. */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 16K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 2K
+	eep (r) : ORIGIN = 0x08080000, LENGTH = 512
+}
+
+/* Include the common ld script. */
+INCLUDE libopencm3_stm32l0.ld
+


### PR DESCRIPTION
I've added a load script for the smaller STM32L011 series with 16 KB flash.
This is also a test to find out how you want to get new pull requests, and whether it can be accepted.

My reason for doing this is to then try and improve the µC support a bit further in PlatformIO.
It's rather limited right now, see https://platformio.org/boards?filter%5Bframeworks%5D=libopencm3