### PR TITLE
stm32: iwdg: fix typo in (unused) register name

### DIFF
--- a/include/libopencm3/stm32/f3/iwdg.h
+++ b/include/libopencm3/stm32/f3/iwdg.h
@@ -43,7 +43,7 @@
 /* --- IWDG_SR values ------------------------------------------------------ */
 
 /* WVU: Watchdog counter window value update */
-#define IWGD_SR_WVU                     (1 << 2)
+#define IWDG_SR_WVU			(1 << 2)
 
 /* --- IWDG_WIN values ----------------------------------------------------- */
 

--- a/include/libopencm3/stm32/l4/iwdg.h
+++ b/include/libopencm3/stm32/l4/iwdg.h
@@ -42,7 +42,7 @@
 /* --- IWDG_SR values ------------------------------------------------------ */
 
 /* WVU: Watchdog counter window value update */
-#define IWGD_SR_WVU                     (1 << 2)
+#define IWDG_SR_WVU                     (1 << 2)
 
 /* --- IWDG_WIN values ----------------------------------------------------- */
 


### PR DESCRIPTION
well, that's it. no code uses iwdg_sr_wvu yet (window watchdoh), but at least keep naming correct