### PR TITLE
stm32l0: enable iwdg, same peripheral as f0, f3, l4..

### DIFF
--- a/include/libopencm3/stm32/iwdg.h
+++ b/include/libopencm3/stm32/iwdg.h
@@ -30,6 +30,8 @@
 #       include <libopencm3/stm32/f3/iwdg.h>
 #elif defined(STM32F4)
 #       include <libopencm3/stm32/f4/iwdg.h>
+#elif defined(STM32L0)
+#       include <libopencm3/stm32/l0/iwdg.h>
 #elif defined(STM32L1)
 #       include <libopencm3/stm32/l1/iwdg.h>
 #elif defined(STM32L4)

--- a/include/libopencm3/stm32/l0/iwdg.h
+++ b/include/libopencm3/stm32/l0/iwdg.h
@@ -1,0 +1,55 @@
+/** @defgroup iwdg_defines IWDG Defines
+
+@brief <b>Defined Constants and Types for the STM32L0xx Independent Watchdog
+Timer</b>
+
+@ingroup STM32L0xx_defines
+
+@version 1.0.0
+
+@date 18 August 2012
+
+LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_IWDG_H
+#define LIBOPENCM3_IWDG_H
+
+#include <libopencm3/stm32/common/iwdg_common_all.h>
+
+/* --- IWDG registers ------------------------------------------------------ */
+
+/* Window register (IWDG_WINR) */
+#define IWDG_WINR				MMIO32(IWDG_BASE + 0x10)
+
+
+/* --- IWDG_SR values ------------------------------------------------------ */
+
+/* WVU: Watchdog counter window value update */
+#define IWDG_SR_WVU			(1 << 2)
+
+/* --- IWDG_WIN values ----------------------------------------------------- */
+
+/* Bits 11:0 WIN[11:0]: Watchdog counter window value */
+
+
+#endif
+

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -48,6 +48,7 @@ OBJS		+= flash.o flash_common_l01.o
 OBJS		+= i2c_common_v2.o
 OBJS		+= rng_common_v1.o
 OBJS		+= usart_common_all.o usart_common_v2.o
+OBJS		+= iwdg_common_all.o
 
 OBJS            += usb.o usb_control.o usb_standard.o
 OBJS            += st_usbfs_core.o st_usbfs_v2.o


### PR DESCRIPTION
Basically same peripheral than f0, f3, l4. tested and working, so same job as 
https://github.com/libopencm3/libopencm3/commit/c90c9fe801a6168518b411b3a829cc515e6c94ee