### PR TITLE
stm32: fix spi_init_master documentation.

### DIFF
--- a/lib/stm32/common/spi_common_all.c
+++ b/lib/stm32/common/spi_common_all.c
@@ -19,9 +19,8 @@ used at the same time on the same peripheral.
 Example: Clk/4, positive clock polarity, leading edge trigger, 8-bit words,
 LSB first.
 @code
-	spi_init_master(SPI1, SPI_CR1_BR_FPCLK_DIV_4, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE,
-			SPI_CR1_CPHA_CLK_TRANSITION_1, SPI_CR1_DFF_8BIT,
-			SPI_CR1_LSBFIRST);
+	spi_init_master(SPI1, SPI_CR1_BAUDRATE_FPCLK_DIV_4, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE,
+			SPI_CR1_CPHA_CLK_TRANSITION_1, SPI_CR1_DFF_8BIT, SPI_CR1_LSBFIRST);
 	spi_write(SPI1, 0x55);		// 8-bit write
 	spi_write(SPI1, 0xaa88);	// 16-bit write
 	reg8 = spi_read(SPI1);		// 8-bit read

--- a/lib/stm32/common/spi_common_f03.c
+++ b/lib/stm32/common/spi_common_f03.c
@@ -19,9 +19,8 @@ used at the same time on the same peripheral.
 Example: Clk/4, positive clock polarity, leading edge trigger, 8-bit words,
 LSB first.
 @code
-	spi_init_master(SPI1, SPI_CR1_BR_FPCLK_DIV_4, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE,
-			SPI_CR1_CPHA_CLK_TRANSITION_1, SPI_CR1_CRCL_8BIT,
-			SPI_CR1_LSBFIRST);
+	spi_init_master(SPI1, SPI_CR1_BAUDRATE_FPCLK_DIV_4, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE,
+			SPI_CR1_CPHA_CLK_TRANSITION_1, SPI_CR1_CRCL_8BIT, SPI_CR1_LSBFIRST);
 	spi_write(SPI1, 0x55);		// 8-bit write
 	spi_write(SPI1, 0xaa88);	// 16-bit write
 	reg8 = spi_read(SPI1);		// 8-bit read

--- a/lib/stm32/common/spi_common_l1f124.c
+++ b/lib/stm32/common/spi_common_l1f124.c
@@ -19,9 +19,8 @@ used at the same time on the same peripheral.
 Example: Clk/4, positive clock polarity, leading edge trigger, 8-bit words,
 LSB first.
 @code
-	spi_init_master(SPI1, SPI_CR1_BR_FPCLK_DIV_4, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE,
-			SPI_CR1_CPHA_CLK_TRANSITION_1, SPI_CR1_DFF_8BIT,
-			SPI_CR1_LSBFIRST);
+	spi_init_master(SPI1, SPI_CR1_BAUDRATE_FPCLK_DIV_4, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE,
+			SPI_CR1_CPHA_CLK_TRANSITION_1, SPI_CR1_DFF_8BIT, SPI_CR1_LSBFIRST);
 	spi_write(SPI1, 0x55);		// 8-bit write
 	spi_write(SPI1, 0xaa88);	// 16-bit write
 	reg8 = spi_read(SPI1);		// 8-bit read


### PR DESCRIPTION
Doc mentions SPI_CR_BR_FPCLK_*, but spi_init_master needs offseted register value (SPI_CR_BAUDRATE_FPCLK_*). 
Align documentation with code - make documentation work.