### PR TITLE
Add STM32L0 to dispatch/irqhandlers.h

### DIFF
--- a/include/libopencmsis/dispatch/irqhandlers.h
+++ b/include/libopencmsis/dispatch/irqhandlers.h
@@ -10,6 +10,8 @@
 #	include <libopencmsis/stm32/f4/irqhandlers.h>
 #elif defined(STM32L1)
 #	include <libopencmsis/stm32/l1/irqhandlers.h>
+#elif defined(STM32L0)
+#	include <libopencmsis/stm32/l0/irqhandlers.h>
 
 #elif defined(EFM32TG)
 #	include <libopencmsis/efm32/efm32tg/irqhandlers.h>


### PR DESCRIPTION
The interrupt dispatch header file was missing support for STM32L0.