### PR TITLE
Add DMA support to STM32L0

### DIFF
--- a/include/libopencm3/stm32/l0/dma.h
+++ b/include/libopencm3/stm32/l0/dma.h
@@ -1,4 +1,15 @@
-/* This provides unification of code over STM32 subfamilies */
+/** @defgroup dma_defines DMA Defines
+ *
+ * @ingroup STM32L0xx_defines
+ *
+ * @brief Defined Constants and Types for the STM32L0xx DMA Controller
+ *
+ * @version 1.0.0
+ *
+ * @date 29 April 2018
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
 
 /*
  * This file is part of the libopencm3 project.
@@ -17,26 +28,10 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_DMA_H
+#define LIBOPENCM3_DMA_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/dma.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/dma.h>
-#elif defined(STM32F2)
-#       include <libopencm3/stm32/f2/dma.h>
-#elif defined(STM32F3)
-#       include <libopencm3/stm32/f3/dma.h>
-#elif defined(STM32F4)
-#       include <libopencm3/stm32/f4/dma.h>
-#elif defined(STM32L0)
-#       include <libopencm3/stm32/l0/dma.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/dma.h>
-#elif defined(STM32L4)
-#       include <libopencm3/stm32/l4/dma.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/dma_common_l1f013.h>
+
 #endif
 

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -50,6 +50,7 @@ OBJS		+= i2c_common_v2.o
 OBJS		+= rng_common_v1.o
 OBJS		+= usart_common_all.o usart_common_v2.o
 OBJS		+= iwdg_common_all.o
+OBJS            += dma_common_l1f013.o
 
 OBJS            += usb.o usb_control.o usb_standard.o
 OBJS            += st_usbfs_core.o st_usbfs_v2.o


### PR DESCRIPTION
STM32L0 uses the same DMA peripheral as STM32F0, F1, L1 and others
with some differences. Those are mostly in the number of supported
controllers and channels.

This patch enables the basic support with no attempt to only expose
the available controllers / channels.

For more information see the ST Application Note AN2548.

This should fix #914 