### PR TITLE
EFM32HG: Add USHFRCODIV2 clock

### DIFF
--- a/include/libopencm3/efm32/hg/cmu.h
+++ b/include/libopencm3/efm32/hg/cmu.h
@@ -352,6 +352,7 @@
 #define CMU_CMD_HFCLKSEL_HFXO		CMU_CMD_HFCLKSEL(2)
 #define CMU_CMD_HFCLKSEL_LFRCO		CMU_CMD_HFCLKSEL(3)
 #define CMU_CMD_HFCLKSEL_LFXO		CMU_CMD_HFCLKSEL(4)
+#define CMU_CMD_HFCLKSEL_USHFRCODIV2	CMU_CMD_HFCLKSEL(5)
 
 /* CMU_LFCLKSEL */
 /* Bits 31:21 - Reserved */
@@ -633,6 +634,7 @@ enum cmu_osc {
 	LFXO, /**< External, 32.768kHz */
 	AUXHFRCO, /**< Internal, 1-28Mhz */
 	USHFRCO, /**< Internal, 48MHz */
+	USHFRCODIV2, /**< Internal, 24MHz */
 };
 
 /* --- Function prototypes ------------------------------------------------- */

--- a/lib/efm32/hg/cmu.c
+++ b/lib/efm32/hg/cmu.c
@@ -105,6 +105,9 @@ void cmu_osc_on(enum cmu_osc osc)
 	case AUXHFRCO:
 		CMU_OSCENCMD = CMU_OSCENCMD_AUXHFRCOEN;
 		break;
+	default:
+		/* not applicable */
+		break;
 	}
 }
 
@@ -132,6 +135,9 @@ void cmu_osc_off(enum cmu_osc osc)
 		break;
 	case AUXHFRCO:
 		CMU_OSCENCMD = CMU_OSCENCMD_AUXHFRCODIS;
+		break;
+	default:
+		/* not applicable */
 		break;
 	}
 }
@@ -163,6 +169,9 @@ bool cmu_osc_ready_flag(enum cmu_osc osc)
 	case AUXHFRCO:
 		return (CMU_STATUS & CMU_STATUS_AUXHFRCORDY) != 0;
 		break;
+	default:
+		/* not applicable */
+		break;
 	}
 
 	return false;
@@ -193,6 +202,9 @@ void cmu_wait_for_osc_ready(enum cmu_osc osc)
 	case AUXHFRCO:
 		while ((CMU_STATUS & CMU_STATUS_AUXHFRCORDY) == 0);
 		break;
+	default:
+		/* not applicable */
+		break;
 	}
 }
 
@@ -218,6 +230,9 @@ void cmu_set_hfclk_source(enum cmu_osc osc)
 	case LFRCO:
 		CMU_CMD = CMU_CMD_HFCLKSEL_LFRCO;
 		break;
+	case USHFRCODIV2:
+		CMU_CMD = CMU_CMD_HFCLKSEL_USHFRCODIV2;
+		break;
 	default:
 		/* not applicable */
 		return;
@@ -239,6 +254,8 @@ enum cmu_osc cmu_get_hfclk_source(void)
 		return HFXO;
 	} else if (status & CMU_STATUS_HFRCOSEL) {
 		return HFRCO;
+	} else if (status & CMU_STATUS_USHFRCODIV2SEL) {
+		return USHFRCODIV2;
 	}
 
 	/* never reached */


### PR DESCRIPTION
The USHFRCODIV2 clock is derived from a 48 MHz PLL that is trimmed using clock recovery from USB.  It is the most accurate PLL on the EFM32HG, and should be used if any vaguely timing-accurate clocks are necessary.

This patchset adds a definition for it, enables switching the HFCLK to derive the core clock from it, and fixes some warnings for things like oscillator enabling, where the new USHFRCODIV2 clock can't really be enabled separately.