### PR TITLE
USB MSC: fix for scsi command READ_FORMAT_CAPACITIES and INQUIRY SERIAL NUMBER

### DIFF
--- a/lib/usb/usb_msc.c
+++ b/lib/usb/usb_msc.c
@@ -435,6 +435,13 @@ static void scsi_mode_sense_6(usbd_mass_storage *ms,
 	}
 }
 
+
+static const uint8_t _spc3_inquiry_sn_response[20] = {
+	0x00, 0x80, 0x00, 0x10,
+	't','h','i','r','d',' ','p','i','n',' ','1','2','3','4','5','6'
+};
+
+
 static void scsi_inquiry(usbd_mass_storage *ms,
 			 struct usb_msc_trans *trans,
 			 enum trans_event event)
@@ -469,12 +476,37 @@ static void scsi_inquiry(usbd_mass_storage *ms,
 				sizeof(_spc3_inquiry_response);
 
 			set_sbc_status_good(ms);
+		else if (1 == evpd) {
+			trans->bytes_to_write = sizeof(_spc3_inquiry_sn_response);
+			memcpy(trans->msd_buf, _spc3_inquiry_sn_response, 
+						sizeof(_spc3_inquiry_sn_response));
+			trans->csw.csw.dCSWDataResidue = sizeof(_spc3_inquiry_sn_response);
+			set_sbc_status_good(ms);
 		} else {
 			/* TODO: Add VPD 0x83 support */
 			/* TODO: Add VPD 0x00 support */
 		}
 	}
 }
+
+static void scsi_read_format_capacities(usbd_mass_storage *ms, struct usb_msc_trans *trans, enum trans_event event)
+{
+	if (EVENT_CBW_VALID == event) {
+		trans->msd_buf[3] = 0x08;
+		trans->msd_buf[4] = ms->block_count >> 24;
+		trans->msd_buf[5] = 0xff & (ms->block_count >> 16);
+		trans->msd_buf[6] = 0xff & (ms->block_count >> 8);
+		trans->msd_buf[7] = 0xff & ms->block_count;
+
+		trans->msd_buf[8] =  0x02;
+		trans->msd_buf[9] = 0;
+		trans->msd_buf[10] = 0x02;
+		trans->msd_buf[11] = 0;
+		trans->bytes_to_write = 9;
+		set_sbc_status_good(ms);
+	}
+}
+
 
 static void scsi_command(usbd_mass_storage *ms,
 			 struct usb_msc_trans *trans,
@@ -525,6 +557,9 @@ static void scsi_command(usbd_mass_storage *ms,
 		break;
 	case SCSI_WRITE_10:
 		scsi_write_10(ms, trans, event);
+		break;
+	case SCSI_READ_FORMAT_CAPACITIES:
+		scsi_read_format_capacities(ms, trans, event);
 		break;
 	default:
 		set_sbc_status(ms, SBC_SENSE_KEY_ILLEGAL_REQUEST,


### PR DESCRIPTION
Fix the subj. Original patch get there https://github.com/thirdpin/libopencm3

Before patch work with the device is not possible.
FreeBSD11 dmesg ouput
----
umass0 on uhub0
umass0: <Black Sphere Technologies MSC Demo, class 0/0, rev 1.10/2.00, addr 6> on usbus0
ugen0.3: <Black Sphere Technologies MSC Demo> at usbus0 (disconnected)
umass0: at uhub0, port 2, addr 6 (disconnected)
(da0:umass-sim0:0:0:0): got CAM status 0x44
(da0:umass-sim0:0:0:0): fatal error, failed to attach to device
----

After patch:
ugen0.3: <Black Sphere Technologies MSC Demo> at usbus0 (disconnected)
umass0: at uhub0, port 2, addr 16 (disconnected)
da0 at umass-sim0 bus 0 scbus1 target 0 lun 0
da0: <VendorID ProductID 0.00> s/n DEMO detached

The device works fine:

# ls -l /media/RAMDISK/
total 128
-rwxr-xr-x  1 root  wheel  65536  6 Dec  2012 ramdisk.dat
# cat /media/RAMDISK/ramdisk.dat
USB Mass Storage Class example. USB Mass Storage Class example. ...

Check with https://github.com/libopencm3/libopencm3-examples/tree/master/examples/stm32/f4/stm32f4-discovery/usb_msc on STM32F407

 
