### PR TITLE
bugfix flash STM32f24 dual bank devices with memoery of 2MB. No prope…

### DIFF
--- a/include/libopencm3/stm32/common/flash_common_f24.h
+++ b/include/libopencm3/stm32/common/flash_common_f24.h
@@ -88,6 +88,8 @@
 #define FLASH_CR_PROGRAM_X64		3
 /**@}*/
 
+#define FLASH_CR_SNB_BANK_BIT_OFFSET	0x04
+
 /* --- FLASH_OPTCR values -------------------------------------------------- */
 
 /* FLASH_OPTCR[27:16]: nWRP */
@@ -110,6 +112,9 @@
 
 #define FLASH_OPTKEYR_KEY1		((uint32_t)0x08192a3b)
 #define FLASH_OPTKEYR_KEY2		((uint32_t)0x4c5d6e7f)
+
+/* --- FLASH sector bank split --------------------------------------------- */
+#define FLASH_SECTOR_BANK2_START        12
 
 /* --- Function prototypes ------------------------------------------------- */
 
@@ -147,3 +152,4 @@ END_DECLS
 #warning "only via flash.h"
 #endif
 /** @endcond */
+

--- a/lib/stm32/common/flash_common_f24.c
+++ b/lib/stm32/common/flash_common_f24.c
@@ -359,6 +359,10 @@ void flash_erase_sector(uint8_t sector, uint32_t program_size)
 	flash_wait_for_last_operation();
 	flash_set_program_size(program_size);
 
+	/* assign bank 2 selection bit 7 for sectors 12 or higher */
+	if (sector >= FLASH_SECTOR_BANK2_START)
+		sector += FLASH_CR_SNB_BANK_BIT_OFFSET;
+
 	FLASH_CR &= ~(FLASH_CR_SNB_MASK << FLASH_CR_SNB_SHIFT);
 	FLASH_CR |= (sector & FLASH_CR_SNB_MASK) << FLASH_CR_SNB_SHIFT;
 	FLASH_CR |= FLASH_CR_SER;
@@ -412,3 +416,4 @@ void flash_program_option_bytes(uint32_t data)
 	flash_wait_for_last_operation();
 }
 /**@}*/
+


### PR DESCRIPTION
Proposed Bugfix flash STM32f24 dual bank devices with memory of 2MB. No proper sector assignment occurred.
The STM32F4 devices with dual bank 2MB memory use an additional bit in the FLASH_CR register.
This is bit 7, and the SNB bits is 0:4 and not only 0:3. But the definition is not given to this bit 7. So opted for a positive modification to the sector value to align it with the reference manual allowed value.

From reference manual
STM32 Doc ID DM00031020. Rev 17 Page 106:
SNB[3:0]: Sector number _<typo in STM32 reference manual should be [4:0]>_
These bits select the sector to erase.
0000: sector 0
0001: sector 1
...
01011: sector 11
01100: not allowed
01101: not allowed
01110: not allowed
01111: not allowed
10000: section 12
10001: section 13
...
11011 sector 23
11100: not allowed
11101: not allowed
11110: not allowed
11111: not allowed