### PR TITLE
Add RTC headers to STM32L0

### DIFF
--- a/include/libopencm3/stm32/l0/rtc.h
+++ b/include/libopencm3/stm32/l0/rtc.h
@@ -1,4 +1,15 @@
-/* This provides unification of code over STM32 subfamilies */
+/** @defgroup rtc_defines RTC Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32L0xx RTC</b>
+ *
+ * @ingroup STM32L0xx_defines
+ *
+ * @version 1.0.0
+ *
+ * @date 5 December 2012
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
 
 /*
  * This file is part of the libopencm3 project.
@@ -17,24 +28,9 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_RTC_H
+#define LIBOPENCM3_RTC_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/rtc.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/rtc.h>
-#elif defined(STM32F2)
-#       include <libopencm3/stm32/f2/rtc.h>
-#elif defined(STM32F4)
-#       include <libopencm3/stm32/f4/rtc.h>
-#elif defined(STM32L0)
-#       include <libopencm3/stm32/l0/rtc.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/rtc.h>
-#elif defined(STM32L4)
-#       include <libopencm3/stm32/l4/rtc.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/rtc_common_l1f024.h>
+
 #endif
-

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -51,6 +51,7 @@ OBJS		+= i2c_common_v2.o
 OBJS		+= rng_common_v1.o
 OBJS		+= usart_common_all.o usart_common_v2.o
 OBJS		+= iwdg_common_all.o
+OBJS            += rtc_common_l1f024.o
 
 OBJS            += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS            += st_usbfs_core.o st_usbfs_v2.o


### PR DESCRIPTION
This makes the RTC register definitions available for STM32L0