### PR TITLE
Add missing USARTs for STM32F7

### DIFF
--- a/include/libopencm3/stm32/f7/usart.h
+++ b/include/libopencm3/stm32/f7/usart.h
@@ -45,6 +45,9 @@
 #define USART3				USART3_BASE
 #define UART4				UART4_BASE
 #define UART5				UART5_BASE
+#define USART6				USART6_BASE
+#define UART7				UART7_BASE
+#define UART8				UART8_BASE
 /**@}*/
 
 BEGIN_DECLS


### PR DESCRIPTION
Need to access these three USARTs on an STM32F7 microcontroller.