### PR TITLE
Typo fix in STM32F4 rcc.h

### DIFF
--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -168,7 +168,7 @@
 @{*/
 /* MCO2: Microcontroller clock output 2 */
 #define RCC_CFGR_MCO2_SHIFT			30
-#define RCC_CFGR_MC02_MASK			0x3
+#define RCC_CFGR_MCO2_MASK			0x3
 #define RCC_CFGR_MCO2_SYSCLK			0x0
 #define RCC_CFGR_MCO2_PLLI2S			0x1
 #define RCC_CFGR_MCO2_HSE			0x2


### PR DESCRIPTION
Just a small typo I came across while trying to get MCO to work on my board. The define is not used in any other files as far as I can tell, but of course applications might break if they use the misspelt variant.