### PR TITLE
Added USB OTG support for F7

### DIFF
--- a/include/libopencm3/usb/dwc/otg_fs.h
+++ b/include/libopencm3/usb/dwc/otg_fs.h
@@ -28,7 +28,7 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_FS_BASE address */
-#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4)
+#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4) || defined(STM32F7)
 #	include <libopencm3/stm32/memorymap.h>
 #elif defined(EFM32HG)
 #	include <libopencm3/efm32/memorymap.h>

--- a/include/libopencm3/usb/dwc/otg_hs.h
+++ b/include/libopencm3/usb/dwc/otg_hs.h
@@ -28,7 +28,7 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_HS_BASE address */
-#if defined(STM32F2) || defined(STM32F4)
+#if defined(STM32F2) || defined(STM32F4) || defined(STM32F7)
 #	include <libopencm3/stm32/memorymap.h>
 #else
 #	error "device family not supported by dwc/otg_hs."

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -52,6 +52,9 @@ OBJS		+= rng_common_v1.o
 
 OBJS		+= usart_common_all.o usart_common_v2.o
 
+OBJS    += usb.o usb_standard.o usb_control.o usb_dwc_common.o \
+          usb_f107.o usb_f207.o usb_msc.o
+
 VPATH += ../../usb:../:../../cm3:../common
 VPATH += ../../ethernet
 


### PR DESCRIPTION
Verified that the CDC ACM peripheral example from F4 still works.