### PR TITLE
stm32f7: added desig to Makefile

### DIFF
--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -43,6 +43,7 @@ TGT_CFLAGS	+= $(STANDARD_FLAGS)
 ARFLAGS		= rcs
 
 OBJS		= flash_common_all.o flash_common_f.o flash_common_f24.o flash.o
+OBJS		+= desig.o
 OBJS		+= gpio.o gpio_common_all.o gpio_common_f0234.o
 OBJS		+= pwr.o rcc.o
 


### PR DESCRIPTION
desig_get_unique_id_as_dfu() returns same ID as DFU.