### PR TITLE
Set PLL source in rcc_clock_setup_pll() for STM32L0

### DIFF
--- a/lib/stm32/l0/rcc.c
+++ b/lib/stm32/l0/rcc.c
@@ -422,6 +422,7 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 	/* Set up the PLL */
 	rcc_set_pll_multiplier(clock->pll_mul);
 	rcc_set_pll_divider(clock->pll_div);
+	rcc_set_pll_source(clock->pll_source);
 
 	rcc_osc_on(RCC_PLL);
 	rcc_wait_for_osc_ready(RCC_PLL);


### PR DESCRIPTION
I discovered this bug when trying to use HSE as PLL source on the STM32L0. In the function rcc_clock_setup_pll() in l0/rcc.c, when the PLL source is not set correctly, it will get stuck in an endless loop waiting for the PLLON flag.