### PR TITLE
stm32: timer_common: add timer21-22, found on stm32l0 chips.

### DIFF
--- a/include/libopencm3/stm32/common/timer_common_all.h
+++ b/include/libopencm3/stm32/common/timer_common_all.h
@@ -81,6 +81,12 @@ specific memorymap.h header before including this header file.*/
 #if defined(TIM17_BASE)
 # define TIM17				TIM17_BASE
 #endif
+#if defined(TIM21_BASE)
+# define TIM21				TIM21_BASE
+#endif
+#if defined(TIM22_BASE)
+# define TIM22				TIM22_BASE
+#endif
 /**@}*/
 
 /* --- Timer registers ----------------------------------------------------- */


### PR DESCRIPTION
stm32l0 devices have tim21 and tim22, 16bit general purpose timer with two IC/OC/PWM channels, add them to timer_common_all.h.