### PR TITLE
common: add assembler support

### DIFF
--- a/include/libopencm3/cm3/common.h
+++ b/include/libopencm3/cm3/common.h
@@ -20,6 +20,8 @@
 #ifndef LIBOPENCM3_CM3_COMMON_H
 #define LIBOPENCM3_CM3_COMMON_H
 
+#ifndef __ASSEMBLER__
+
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -58,6 +60,29 @@
 
 #define BBIO_PERIPH(addr, bit) \
 	MMIO32((((uint32_t)addr) & 0x0FFFFF) * 32 + 0x42000000 + (bit) * 4)
+
+#else
+
+/* Basic Assembler support */
+
+/* Skip all C/C++ declarations */
+#define BEGIN_DECLS .if 0
+#define END_DECLS .endif
+
+/* All addresses are just numbers */
+#define MMIO8(addr) (addr)
+#define MMIO16(addr) (addr)
+#define MMIO32(addr) (addr)
+#define MMIO64(addr) (addr)
+
+/* Generic bit-band I/O accessor functions */
+#define BBIO_SRAM(addr, bit) \
+	(((addr) & 0x0FFFFF) * 32 + 0x22000000 + (bit) * 4)
+
+#define BBIO_PERIPH(addr, bit) \
+	(((addr) & 0x0FFFFF) * 32 + 0x42000000 + (bit) * 4)
+
+#endif
 
 /* Generic bit definition */
 #define BIT0  (1<<0)


### PR DESCRIPTION
When using gcc as an assembler:
- the C/C++ declarations are skipped
- the macros are adapted (when needed)

The definition `__ASSEMBLER__` is automatically added when gcc is invoked as a assembler, e.g. `gcc test.S`.

Once this is merged I'll update the Makefile and add a small example to the template.