### PR TITLE
Repaired spi for the f7

### DIFF
--- a/include/libopencm3/stm32/f7/spi.h
+++ b/include/libopencm3/stm32/f7/spi.h
@@ -31,7 +31,14 @@ LGPL License Terms @ref lgpl_license
 #ifndef LIBOPENCM3_SPI_H
 #define LIBOPENCM3_SPI_H
 
-#include <libopencm3/stm32/common/spi_common_v1_frf.h>
+#include <libopencm3/stm32/common/spi_common_v2.h>
+
+/* --- SPI_CR2 values ------------------------------------------------------ */
+
+/* LDMA_TX: Last DMA transfer for transmission */
+#define SPI_CR2_FRF             (1 << 4)
+#define SPI_CR2_FRF_MOTOROLA    (0 << 4)
+#define SPI_CR2_FRF_TI         (1 << 4)
 
 #endif
 

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -50,7 +50,7 @@ OBJS		+= pwr.o rcc.o
 
 OBJS		+= rcc_common_all.o
 OBJS		+= rng_common_v1.o
-OBJS		+= spi_common_all.o spi_common_v1.o spi_common_v1_frf.o
+OBJS		+= spi_common_v2.o spi_common_all.o
 OBJS		+= timer_common_all.o
 OBJS		+= usart_common_all.o usart_common_v2.o
 


### PR DESCRIPTION
Fixes some SPI bugs:
- change from `spi_common_v1_fr.hf` to `spi_common_v2.h`
- add missing `SPI_CR2` definitions