### PR TITLE
.gitattributes: force LF line endings for bash scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for bash scripts (for correct running on Windows)
+scripts/*.sh          eol=lf
+scripts/gendoxylist   eol=lf


### PR DESCRIPTION
Force git running on Windows to use LF line endings for bash scripts. By default git package for Windows converts all pulled line endings to CRLF making lib's bash scripts inoperable (i.e. unable to `make doc`) for users with default `core.autocrlf true` setting. That should fix the problem independently of the user's git configuration.