### PR TITLE
stm32f09: add register definitions for DMA2

### DIFF
--- a/include/libopencm3/stm32/common/dma_common_l1f013.h
+++ b/include/libopencm3/stm32/common/dma_common_l1f013.h
@@ -138,11 +138,6 @@ specific memorymap.h header before including this header file.*/
 #define DMA2_CMAR4			DMA2_CMAR(DMA_CHANNEL4)
 #define DMA2_CMAR5			DMA2_CMAR(DMA_CHANNEL5)
 
-/* DMA channel selection register (DMAx_CSELR) */
-#define DMA_CSELR(dma_base)		MMIO32((dma_base) + 0xA8)
-#define DMA1_CSELR			DMA_CSELR(DMA1)
-#define DMA2_CSELR			DMA_CSELR(DMA2)
-
 /* --- DMA_ISR values ------------------------------------------------------ */
 
 /* --- DMA Interrupt Flag offset values ------------------------------------- */

--- a/include/libopencm3/stm32/common/dma_common_l1f013.h
+++ b/include/libopencm3/stm32/common/dma_common_l1f013.h
@@ -138,6 +138,11 @@ specific memorymap.h header before including this header file.*/
 #define DMA2_CMAR4			DMA2_CMAR(DMA_CHANNEL4)
 #define DMA2_CMAR5			DMA2_CMAR(DMA_CHANNEL5)
 
+/* DMA channel selection register (DMAx_CSELR) */
+#define DMA_CSELR(dma_base)		MMIO32((dma_base) + 0xA8)
+#define DMA1_CSELR			DMA_CSELR(DMA1)
+#define DMA2_CSELR			DMA_CSELR(DMA2)
+
 /* --- DMA_ISR values ------------------------------------------------------ */
 
 /* --- DMA Interrupt Flag offset values ------------------------------------- */

--- a/include/libopencm3/stm32/f0/dma.h
+++ b/include/libopencm3/stm32/f0/dma.h
@@ -33,5 +33,10 @@
 
 #include <libopencm3/stm32/common/dma_common_l1f013.h>
 
+/* DMA channel selection register (DMAx_CSELR) */
+#define DMA_CSELR(dma_base)		MMIO32((dma_base) + 0xA8)
+#define DMA1_CSELR			DMA_CSELR(DMA1)
+#define DMA2_CSELR			DMA_CSELR(DMA2)
+
 #endif
 

--- a/include/libopencm3/stm32/f0/memorymap.h
+++ b/include/libopencm3/stm32/f0/memorymap.h
@@ -89,6 +89,7 @@
 #define DMA_BASE			(PERIPH_BASE_AHB1 + 0x0000)
 /* DMA is the name in the F0 refman, but all other stm32's use DMA1 */
 #define DMA1_BASE			DMA_BASE
+#define DMA2_BASE			(PERIPH_BASE_AHB1 + 0x0400)
 
 #define RCC_BASE			(PERIPH_BASE_AHB1 + 0x1000)
 

--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -244,6 +244,7 @@ Control</b>
 #define RCC_AHBENR_CRCEN			(1 << 6)
 #define RCC_AHBENR_FLTFEN			(1 << 4)
 #define RCC_AHBENR_SRAMEN			(1 << 2)
+#define RCC_AHBENR_DMA2EN			(1 << 1)
 #define RCC_AHBENR_DMAEN			(1 << 0)
 
 /* --- RCC_APB2ENR values -------------------------------------------------- */


### PR DESCRIPTION
Add missing register definitions for the DMA2 controller on the STM32F091 and similar. Code was tested with that core.

Source for the address values is ST Reference manual RM0091, which covers the STM32F0x1/STM32F0x2/STM32F0x8.