### PR TITLE
gadget0 : fix deprecation warning by updating openocd cfg to use "stlink.cfg"

### DIFF
--- a/tests/gadget-zero/openocd.efm32hg309-generic.cfg
+++ b/tests/gadget-zero/openocd.efm32hg309-generic.cfg
@@ -1,5 +1,5 @@
 # Generic efm32hg309 on Tomu board, using stm32l053-disco as debugger
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 transport select hla_swd
 adapter_khz 1000
 set CHIPNAME efm32hg309

--- a/tests/gadget-zero/openocd.stm32f072disco.cfg
+++ b/tests/gadget-zero/openocd.stm32f072disco.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 set WORKAREASIZE 0x4000
 source [find target/stm32f0x.cfg]
 

--- a/tests/gadget-zero/openocd.stm32f103-generic.cfg
+++ b/tests/gadget-zero/openocd.stm32f103-generic.cfg
@@ -1,6 +1,6 @@
 # Unfortunately, with no f103 disco, we're currently
 # using a separate disco board
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 set WORKAREASIZE 0x2000
 source [find target/stm32f1x.cfg]
 

--- a/tests/gadget-zero/openocd.stm32f3-disco.cfg
+++ b/tests/gadget-zero/openocd.stm32f3-disco.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 set WORKAREASIZE 0x4000
 source [find target/stm32f3x.cfg]
 

--- a/tests/gadget-zero/openocd.stm32f429i-disco.cfg
+++ b/tests/gadget-zero/openocd.stm32f429i-disco.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 set WORKAREASIZE 0x4000
 source [find target/stm32f4x.cfg]
 

--- a/tests/gadget-zero/openocd.stm32f4disco.cfg
+++ b/tests/gadget-zero/openocd.stm32f4disco.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 set WORKAREASIZE 0x4000
 source [find target/stm32f4x.cfg]
 

--- a/tests/gadget-zero/openocd.stm32l053disco.cfg
+++ b/tests/gadget-zero/openocd.stm32l053disco.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 set WORKAREASIZE 0x1000
 source [find target/stm32l0.cfg]
 

--- a/tests/gadget-zero/openocd.stm32l1-generic.cfg
+++ b/tests/gadget-zero/openocd.stm32l1-generic.cfg
@@ -1,5 +1,5 @@
 # l1 generic, using a l4 disco board
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 set WORKAREASIZE 0x2000
 source [find target/stm32l1.cfg]
 


### PR DESCRIPTION
Since openocd 31c58c (committed 2017), all stlink configuration files are merged into a single
"stlink.cfg" file that covers all versions of stlink hardware.
