### PR TITLE
stm32: pll: disable before configuring

### DIFF
--- a/lib/stm32/f2/rcc.c
+++ b/lib/stm32/f2/rcc.c
@@ -355,6 +355,10 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	rcc_set_ppre1(clock->ppre1);
 	rcc_set_ppre2(clock->ppre2);
 
+	/* Disable PLL oscillator before changing its configuration. */
+	rcc_osc_off(RCC_PLL);
+
+	/* Configure the PLL oscillator. */
 	rcc_set_main_pll_hse(clock->pllm, clock->plln,
 			     clock->pllp, clock->pllq);
 

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -709,6 +709,10 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	rcc_set_ppre1(clock->ppre1);
 	rcc_set_ppre2(clock->ppre2);
 
+	/* Disable PLL oscillator before changing its configuration. */
+	rcc_osc_off(RCC_PLL);
+
+	/* Configure the PLL oscillator. */
 	rcc_set_main_pll_hse(clock->pllm, clock->plln,
 			clock->pllp, clock->pllq, clock->pllr);
 

--- a/lib/stm32/f7/rcc.c
+++ b/lib/stm32/f7/rcc.c
@@ -392,6 +392,10 @@ void rcc_clock_setup_hse(const struct rcc_clock_scale *clock, uint32_t hse_mhz)
 	rcc_set_ppre1(clock->ppre1);
 	rcc_set_ppre2(clock->ppre2);
 
+	/* Disable PLL oscillator before changing its configuration. */
+	rcc_osc_off(RCC_PLL);
+
+	/* Configure the PLL oscillator. */
 	rcc_set_main_pll_hse(pllm, clock->plln,
 			     clock->pllp, clock->pllq);
 

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -535,6 +535,10 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 	flash_prefetch_enable();
 	flash_set_ws(clock->flash_waitstates);
 
+	/* Disable PLL oscillator before changing its configuration. */
+	rcc_osc_off(RCC_PLL);
+
+	/* Configure the PLL oscillator. */
 	rcc_set_pll_configuration(clock->pll_source, clock->pll_mul,
 				  clock->pll_div);
 


### PR DESCRIPTION
This bug was found and fixed by a coworker. The clock configuration function for the STM32F427 failed to reconfigure the PLL correctly, because it did not disable the PLL before changing its configuration.

This has only been tested on the STM32F427. I ported the fix to the F2 and the F7 as they seem to share the same logic, but I admit that I haven't tested on those.