### PR TITLE
stm32f0: adc: API call to clear EOS flag

### DIFF
--- a/lib/stm32/f0/adc.c
+++ b/lib/stm32/f0/adc.c
@@ -277,6 +277,16 @@ bool adc_get_eoc_sequence_flag(uint32_t adc)
 	return ADC_ISR(adc) & ADC_ISR_EOSEQ;
 }
 
+/*---------------------------------------------------------------------------*/
+/** @ brief ADC Clear Regular End-Of-Conversion Sequence Flag
+ *
+ * @param[in] adc Unsigned int32. ADC base address (@ref adc_reg_base)
+ */
+
+void adc_clear_eoc_sequence_flag(uint32_t adc)
+{
+	ADC_ISR(adc) = ADC_ISR_EOSEQ;
+}
 
 /**@}*/
 


### PR DESCRIPTION
Save me from directly manipulating registers in my code.