### PR TITLE
Fixed typo in macro def (RTC_DR_MT_MASK)

### DIFF
--- a/include/libopencm3/stm32/common/rtc_common_l1f024.h
+++ b/include/libopencm3/stm32/common/rtc_common_l1f024.h
@@ -152,9 +152,9 @@ specific memorymap.h header before including this header file.*/
 /** Weekday units mask */
 #define RTC_DR_WDU_MASK   (0x7)
 /** Month tens in BCD format shift */
-#define RTC_DR_MT         (1<<12)
-/** Month tens in BCD format mask */
 #define RTC_DR_MT_SHIFT   (12)
+/** Month tens in BCD format mask */
+#define RTC_DR_MT_MASK    (1<<12)
 /** Month units in BCD format shift */
 #define RTC_DR_MU_SHIFT   (8)
 /** Month units in BCD format mask */


### PR DESCRIPTION
It's trivial, feel free to fix it manually.