### PR TITLE
stm32: exti: move register definition of all current stm32 devices to common_v1

### DIFF
--- a/include/libopencm3/stm32/common/exti_common_all.h
+++ b/include/libopencm3/stm32/common/exti_common_all.h
@@ -29,15 +29,6 @@
 #define LIBOPENCM3_EXTI_COMMON_ALL_H
 /**@{*/
 
-/* --- EXTI registers ------------------------------------------------------ */
-
-#define EXTI_IMR			MMIO32(EXTI_BASE + 0x00)
-#define EXTI_EMR			MMIO32(EXTI_BASE + 0x04)
-#define EXTI_RTSR			MMIO32(EXTI_BASE + 0x08)
-#define EXTI_FTSR			MMIO32(EXTI_BASE + 0x0c)
-#define EXTI_SWIER			MMIO32(EXTI_BASE + 0x10)
-#define EXTI_PR				MMIO32(EXTI_BASE + 0x14)
-
 /* EXTI number definitions */
 #define EXTI0				(1 << 0)
 #define EXTI1				(1 << 1)

--- a/include/libopencm3/stm32/common/exti_common_v1.h
+++ b/include/libopencm3/stm32/common/exti_common_v1.h
@@ -1,20 +1,7 @@
-/** @defgroup exti_defines EXTI Defines
- *
- * @brief <b>Defined Constants and Types for the STM32F0xx External Interrupts
- * </b>
- *
- * @ingroup STM32F0xx_defines
- *
- * @version 1.0.0
- *
- * @date 11 July 2013
- *
- * LGPL License Terms @ref lgpl_license
- */
+#pragma once
+
 /*
  * This file is part of the libopencm3 project.
- *
- * Copyright (C) 2013 Frantisek Burian <BuFran@seznam.cz>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -30,14 +17,28 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBOPENCM3_EXTI_H
-#define LIBOPENCM3_EXTI_H
+/** @cond */
+#if defined(LIBOPENCM3_EXTI_H)
+/** @endcond */
+
 /**@{*/
 
-#include <libopencm3/stm32/common/exti_common_all.h>
-#include <libopencm3/stm32/common/exti_common_v1.h>
+/* --- EXTI registers ------------------------------------------------------ */
 
+#define EXTI_IMR			MMIO32(EXTI_BASE + 0x00)
+#define EXTI_EMR			MMIO32(EXTI_BASE + 0x04)
+#define EXTI_RTSR			MMIO32(EXTI_BASE + 0x08)
+#define EXTI_FTSR			MMIO32(EXTI_BASE + 0x0c)
+#define EXTI_SWIER			MMIO32(EXTI_BASE + 0x10)
+#define EXTI_PR				MMIO32(EXTI_BASE + 0x14)
+
+BEGIN_DECLS
+
+END_DECLS
 
 /**@}*/
 
+#else
+#warning "exti_common_v1.h should not be included directly, only via exti.h"
 #endif
+/** @endcond */

--- a/include/libopencm3/stm32/f1/exti.h
+++ b/include/libopencm3/stm32/f1/exti.h
@@ -37,5 +37,6 @@
 #define LIBOPENCM3_EXTI_H
 
 #include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
 #endif

--- a/include/libopencm3/stm32/f2/exti.h
+++ b/include/libopencm3/stm32/f2/exti.h
@@ -37,5 +37,6 @@
 #define LIBOPENCM3_EXTI_H
 
 #include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
 #endif

--- a/include/libopencm3/stm32/f3/exti.h
+++ b/include/libopencm3/stm32/f3/exti.h
@@ -38,6 +38,7 @@
 /**@{*/
 
 #include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
 /* --- EXTI registers ------------------------------------------------------ */
 #define EXTI_IMR2			MMIO32(EXTI_BASE + 0x18)

--- a/include/libopencm3/stm32/f4/exti.h
+++ b/include/libopencm3/stm32/f4/exti.h
@@ -37,5 +37,6 @@
 #define LIBOPENCM3_EXTI_H
 
 #include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
 #endif

--- a/include/libopencm3/stm32/l0/exti.h
+++ b/include/libopencm3/stm32/l0/exti.h
@@ -37,5 +37,6 @@
 #define LIBOPENCM3_EXTI_H
 
 #include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
 #endif

--- a/include/libopencm3/stm32/l1/exti.h
+++ b/include/libopencm3/stm32/l1/exti.h
@@ -37,5 +37,6 @@
 #define LIBOPENCM3_EXTI_H
 
 #include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
 #endif

--- a/include/libopencm3/stm32/l4/exti.h
+++ b/include/libopencm3/stm32/l4/exti.h
@@ -19,5 +19,6 @@
 #define LIBOPENCM3_EXTI_H
 
 #include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
 #endif


### PR DESCRIPTION
Preparation for stm32g0 support, as this chip's exti register map evolved and is no longer common.. G0 exti header will redefine these, but will use regular code with minimal modifications.