### PR TITLE
stm32: i2c_common_v2: Add function to clear NACK flag

### DIFF
--- a/include/libopencm3/stm32/common/i2c_common_v2.h
+++ b/include/libopencm3/stm32/common/i2c_common_v2.h
@@ -431,6 +431,7 @@ bool i2c_is_start(uint32_t i2c);
 void i2c_enable_autoend(uint32_t i2c);
 void i2c_disable_autoend(uint32_t i2c);
 bool i2c_nack(uint32_t i2c);
+void i2c_clear_nack(uint32_t i2c);
 bool i2c_busy(uint32_t i2c);
 bool i2c_transmit_int_status(uint32_t i2c);
 bool i2c_transfer_complete(uint32_t i2c);

--- a/lib/stm32/common/i2c_common_v2.c
+++ b/lib/stm32/common/i2c_common_v2.c
@@ -301,6 +301,18 @@ bool i2c_nack(uint32_t i2c)
 	return (I2C_ISR(i2c) & I2C_ISR_NACKF);
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief I2C Clear Nack Flag.
+ *
+ * Clear the "Not Acknowledge received" flag in the I2C config register
+ *
+ * @param[in] i2c Unsigned int32. I2C register base address @ref i2c_reg_base.
+ */
+void i2c_clear_nack(uint32_t i2c)
+{
+	I2C_ICR(i2c) |= I2C_ICR_NACKCF;
+}
+
 bool i2c_busy(uint32_t i2c)
 {
 	return (I2C_ISR(i2c) & I2C_ISR_BUSY);


### PR DESCRIPTION
This commit adds a simple function to clear the "Not Acknowledge received" flag in the I2C config register.