### PR TITLE
stm32f4: support inclusion into assembly files

### DIFF
--- a/include/libopencm3/stm32/common/crypto_common_f24.h
+++ b/include/libopencm3/stm32/common/crypto_common_f24.h
@@ -240,6 +240,8 @@ specific memorymap.h header before including this header file.*/
  */
 /**@{*/
 
+#if !defined(__ASSEMBLER__)
+
 enum crypto_mode {
 	ENCRYPT_TDES_ECB = CRYP_CR_ALGOMODE_TDES_ECB,
 	ENCRYPT_TDES_CBC = CRYP_CR_ALGOMODE_TDES_CBC,
@@ -268,6 +270,8 @@ enum crypto_datatype {
 	CRYPTO_DATA_8BIT,
 	CRYPTO_DATA_BIT,
 };
+
+#endif
 
 BEGIN_DECLS
 void crypto_wait_busy(void);

--- a/include/libopencm3/stm32/common/dac_common_all.h
+++ b/include/libopencm3/stm32/common/dac_common_all.h
@@ -377,6 +377,8 @@ Unmask bits [(n-1)..0] of LFSR/Triangle Amplitude equal to (2**(n+1)-1
 #define DAC_DOR2_DACC2DOR_LSB		(1 << 0)
 #define DAC_DOR2_DACC2DOR_MSK		(0x0FFF << 0)
 
+#if !defined(__ASSEMBLER__)
+
 /** DAC channel identifier */
 typedef enum {
 	CHANNEL_1, CHANNEL_2, CHANNEL_D
@@ -386,6 +388,8 @@ typedef enum {
 typedef enum {
 	RIGHT8, RIGHT12, LEFT12
 } data_align;
+
+#endif
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/common/exti_common_all.h
+++ b/include/libopencm3/stm32/common/exti_common_all.h
@@ -70,12 +70,14 @@
 #define EXTI36				(1 << 4)
 #define EXTI37				(1 << 5)
 
+#if !defined(__ASSEMBLER__)
 /* Trigger types */
 enum exti_trigger_type {
 	EXTI_TRIGGER_RISING,
 	EXTI_TRIGGER_FALLING,
 	EXTI_TRIGGER_BOTH,
 };
+#endif
 
 BEGIN_DECLS
 

--- a/include/libopencm3/stm32/common/i2c_common_v1.h
+++ b/include/libopencm3/stm32/common/i2c_common_v1.h
@@ -34,8 +34,10 @@ specific memorymap.h header before including this header file.*/
 #ifndef LIBOPENCM3_I2C_COMMON_V1_H
 #define LIBOPENCM3_I2C_COMMON_V1_H
 
+#if !defined (__ASSEMBLER__)
 #include <stddef.h>
 #include <stdint.h>
+#endif
 
 /* --- Convenience macros -------------------------------------------------- */
 
@@ -378,6 +380,7 @@ specific memorymap.h header before including this header file.*/
 
 /* --- I2C function prototypes---------------------------------------------- */
 
+#if !defined(__ASSEMBLER__)
 /**
  * I2C speed modes.
  */
@@ -387,6 +390,7 @@ enum i2c_speeds {
 	i2c_speed_fmp_1m,
 	i2c_speed_unknown
 };
+#endif
 
 BEGIN_DECLS
 

--- a/include/libopencm3/stm32/common/rng_common_v1.h
+++ b/include/libopencm3/stm32/common/rng_common_v1.h
@@ -29,7 +29,9 @@ specific memorymap.h header before including this header file.*/
 #define LIBOPENCM3_RNG_V1_H
 
 #include <stdbool.h>
+#if !defined (__ASSEMBLER__)
 #include <stdint.h>
+#endif
 
 /**@{*/
 

--- a/include/libopencm3/stm32/common/timer_common_all.h
+++ b/include/libopencm3/stm32/common/timer_common_all.h
@@ -1084,6 +1084,7 @@ depending on the level of the complementary input. */
 
 /* DMAB[15:0]: DMA register for burst accesses */
 
+#if !defined(__ASSEMBLER__)
 /* --- TIMx convenience defines -------------------------------------------- */
 
 /** Output Compare channel designators */
@@ -1171,6 +1172,7 @@ enum tim_et_pol {
 	TIM_ET_RISING,
 	TIM_ET_FALLING,
 };
+#endif
 
 /* --- TIM function prototypes --------------------------------------------- */
 

--- a/include/libopencm3/stm32/common/timer_common_f24.h
+++ b/include/libopencm3/stm32/common/timer_common_f24.h
@@ -88,12 +88,14 @@ Only available in F2 and F4 series.
 /**@}*/
 #define TIM5_OR_TI4_RMP_MASK		(0x3 << 6)
 
+#if !defined(__ASSEMBLER__)
 /** Input Capture input polarity */
 enum tim_ic_pol {
 	TIM_IC_RISING,
 	TIM_IC_FALLING,
 	TIM_IC_BOTH,
 };
+#endif
 
 /* --- Function prototypes ------------------------------------------------- */
 

--- a/include/libopencm3/stm32/f4/crypto.h
+++ b/include/libopencm3/stm32/f4/crypto.h
@@ -77,6 +77,8 @@
  */
 /**@{*/
 
+#if !defined(__ASSEMBLER__)
+
 enum crypto_mode_mac {
 	ENCRYPT_GCM = CRYP_CR_ALGOMODE_TDES_ECB | CRYP_CR_ALGOMODE3,
 	ENCRYPT_CCM = CRYP_CR_ALGOMODE_TDES_CBC | CRYP_CR_ALGOMODE3,
@@ -85,6 +87,8 @@ enum crypto_mode_mac {
 	DECRYPT_CCM = CRYP_CR_ALGOMODE_TDES_CBC | CRYP_CR_ALGOMODE3 |
 		      CRYP_CR_ALGODIR,
 };
+
+#endif
 
 BEGIN_DECLS
 

--- a/include/libopencm3/stm32/f4/dma2d.h
+++ b/include/libopencm3/stm32/f4/dma2d.h
@@ -33,7 +33,9 @@
  */
 
 #include <libopencm3/stm32/memorymap.h>
+#if !defined (__ASSEMBLER__)
 #include <stdint.h>
+#endif
 
 #ifndef DMA2D_H
 #define DMA2D_H

--- a/include/libopencm3/stm32/f4/fmc.h
+++ b/include/libopencm3/stm32/f4/fmc.h
@@ -211,6 +211,7 @@ error "This file should not be included directly, it is included with fsmc.h"
 /* RE: Refresh Error */
 #define FMC_SDSR_RE			(1 << 0)
 
+#if !defined(__ASSEMBLER__)
 /* Helper function for setting the timing parameters */
 struct sdram_timing {
 	int trcd;		/* RCD Delay */
@@ -221,6 +222,7 @@ struct sdram_timing {
 	int txsr;		/* Exit Self Refresh Time */
 	int tmrd;		/* Load to Active delay */
 };
+#endif
 
 /* Mode register parameters */
 #define SDRAM_MODE_BURST_LENGTH_1		((uint16_t)0x0000)
@@ -235,10 +237,12 @@ struct sdram_timing {
 #define SDRAM_MODE_WRITEBURST_MODE_PROGRAMMED	((uint16_t)0x0000)
 #define SDRAM_MODE_WRITEBURST_MODE_SINGLE	((uint16_t)0x0200)
 
+#if !defined(__ASSEMBLER__)
 enum fmc_sdram_bank { SDRAM_BANK1, SDRAM_BANK2, SDRAM_BOTH_BANKS };
 enum fmc_sdram_command { SDRAM_CLK_CONF, SDRAM_NORMAL, SDRAM_PALL,
 			 SDRAM_AUTO_REFRESH, SDRAM_LOAD_MODE,
 			 SDRAM_SELF_REFRESH, SDRAM_POWER_DOWN };
+#endif
 
 /* Send an array of timing parameters (indices above) to create SDTR register
  * value

--- a/include/libopencm3/stm32/f4/ltdc.h
+++ b/include/libopencm3/stm32/f4/ltdc.h
@@ -22,7 +22,9 @@
 #define LIBOPENCM3_STM32_F4_LTDC_H_
 
 
+#if !defined (__ASSEMBLER__)
 #include <stdint.h>
+#endif
 #include <libopencm3/stm32/rcc.h>
 
 /**
@@ -357,6 +359,7 @@
 #define LTDC_LxCLUTWR_BLUE_SHIFT        0
 #define LTDC_LxCLUTWR_BLUE_MASK         0xff
 
+#if !defined(__ASSEMBLER__)
 /**
  * simple helper macros
  */
@@ -506,5 +509,6 @@ static inline uint16_t ltdc_get_rgb888_from_rgb565(uint16_t rgb888)
 	       | ((((rgb888) & 0x001F) <<  (8-0))/31)<<0;
 }
 
+#endif
 
 #endif /* LIBOPENCM3_STM32_F4_LTDC_H_ */

--- a/include/libopencm3/stm32/f4/pwr.h
+++ b/include/libopencm3/stm32/f4/pwr.h
@@ -73,11 +73,13 @@ LGPL License Terms @ref lgpl_license
 
 /* --- Function prototypes ------------------------------------------------- */
 
+#if !defined(__ASSEMBLER__)
 enum pwr_vos_scale {
 	PWR_SCALE1 = 0x3,
 	PWR_SCALE2 = 0x2,
 	PWR_SCALE3 = 0x1,
 };
+#endif
 
 BEGIN_DECLS
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -746,6 +746,7 @@
 #define RCC_CKGATENR_AHB2APB1_CKEN		(1<<0)
 /*@}*/
 
+#if !defined(__ASSEMBLER__)
 /* PLLSAI1 helper macros */
 static inline void rcc_pllsai_enable(void)
 {
@@ -1066,6 +1067,8 @@ enum rcc_periph_rst {
 };
 
 #undef _REG_BIT
+
+#endif
 
 #include <libopencm3/stm32/common/rcc_common_all.h>
 


### PR DESCRIPTION
This makes all stm32f4 includes compatible to be included from assembly.
