### PR TITLE
stm32f0: adc: fix doc.

### DIFF
--- a/lib/stm32/f0/adc.c
+++ b/lib/stm32/f0/adc.c
@@ -278,7 +278,7 @@ bool adc_get_eoc_sequence_flag(uint32_t adc)
 }
 
 /*---------------------------------------------------------------------------*/
-/** @ brief ADC Clear Regular End-Of-Conversion Sequence Flag
+/** @brief ADC Clear Regular End-Of-Conversion Sequence Flag
  *
  * @param[in] adc Unsigned int32. ADC base address (@ref adc_reg_base)
  */
@@ -301,12 +301,12 @@ void adc_clear_eoc_sequence_flag(uint32_t adc)
  *@{*/
 
 /*---------------------------------------------------------------------------*/
-/** @brief ADC Set Clock Prescale
+/** @brief ADC Set Clock Source
  *
  * The ADC clock taken from the many sources.
  *
  * @param[in] adc Unsigned int32. ADC base address (@ref adc_reg_base)
- * @param[in] prescale Unsigned int32. Prescale value (@ref adc_api_clksource)
+ * @param[in] source Unsigned int32. Source (@ref adc_api_clksource)
  */
 
 void adc_set_clk_source(uint32_t adc, uint32_t source)


### PR DESCRIPTION
fix stm32f0 adc doc brief, bad copypaste.