### PR TITLE
exti: prepare for stm32g0 exti.

### DIFF
--- a/include/libopencm3/stm32/common/syscfg_common_l1f234.h
+++ b/include/libopencm3/stm32/common/syscfg_common_l1f234.h
@@ -50,6 +50,10 @@ specific memorymap.h header before including this header file.*/
 
 #define SYSCFG_CMPCR			MMIO32(SYSCFG_BASE + 0x20)
 
+/* --- SYSCFG_EXTICR Values -------------------------------------------------*/
+
+#define SYSCFG_EXTICR_FIELDSIZE		4
+
 #endif
 /**@}*/
 

--- a/include/libopencm3/stm32/f0/syscfg.h
+++ b/include/libopencm3/stm32/f0/syscfg.h
@@ -91,7 +91,7 @@
 
 /* SYSCFG_EXTICR Values -- --------------------------------------------------*/
 
-#define SYSCFG_EXTICR_SKIP		4
+#define SYSCFG_EXTICR_FIELDSIZE		4
 #define SYSCFG_EXTICR_GPIOA		0
 #define SYSCFG_EXTICR_GPIOB		1
 #define SYSCFG_EXTICR_GPIOC		2

--- a/include/libopencm3/stm32/f1/gpio.h
+++ b/include/libopencm3/stm32/f1/gpio.h
@@ -933,10 +933,10 @@ Line Devices only
 
 /**@}*/
 
-/* --- AFIO_EXTICR1 values ------------------------------------------------- */
-/* --- AFIO_EXTICR2 values ------------------------------------------------- */
-/* --- AFIO_EXTICR3 values ------------------------------------------------- */
-/* --- AFIO_EXTICR4 values ------------------------------------------------- */
+/* --- AFIO_EXTICRx values ------------------------------------------------- */
+
+/** EXTICR port selection bits  */
+#define AFIO_EXTICR_FIELDSIZE			4
 
 /** @defgroup afio_exti Alternate Function EXTI pin number
 @ingroup gpio_defines

--- a/include/libopencm3/stm32/l0/syscfg.h
+++ b/include/libopencm3/stm32/l0/syscfg.h
@@ -111,6 +111,7 @@
 
 /* SYSCFG_EXTICR Values -- --------------------------------------------------*/
 
+#define SYSCFG_EXTICR_FIELDSIZE		4
 #define SYSCFG_EXTICR_GPIOA		0
 #define SYSCFG_EXTICR_GPIOB		1
 #define SYSCFG_EXTICR_GPIOC		2

--- a/include/libopencm3/stm32/l4/syscfg.h
+++ b/include/libopencm3/stm32/l4/syscfg.h
@@ -81,6 +81,7 @@
 
 /* --- SYSCFG_EXTICR Values -------------------------------------------------*/
 
+#define SYSCFG_EXTICR_FIELDSIZE		4
 #define SYSCFG_EXTICR_GPIOA		0
 #define SYSCFG_EXTICR_GPIOB		1
 #define SYSCFG_EXTICR_GPIOC		2

--- a/lib/stm32/common/exti_common_all.c
+++ b/lib/stm32/common/exti_common_all.c
@@ -80,7 +80,12 @@ void exti_disable_request(uint32_t extis)
  */
 void exti_reset_request(uint32_t extis)
 {
+#if defined(EXTI_RPR1) && defined(EXTI_FPR1)
+	EXTI_RPR1 = extis;
+	EXTI_FPR1 = extis;
+#else
 	EXTI_PR = extis;
+#endif
 }
 
 /*
@@ -88,7 +93,11 @@ void exti_reset_request(uint32_t extis)
  * */
 uint32_t exti_get_flag_status(uint32_t exti)
 {
+#if defined(EXTI_RPR1) && defined(EXTI_FPR1)
+	return (EXTI_RPR1 & exti) | (EXTI_FPR1 & exti);
+#else
 	return EXTI_PR & exti;
+#endif
 }
 
 /*


### PR DESCRIPTION
Hi,

Here's a first patchset for g0 merge, regarding exti common code :  basically ST moved again the AFIO/SYSCFG_EXTICR bits, made the gpio bank selection on 8 bits instead of previously 4, and splitted the EXTI_PR into EXTI_FPR (Failing Edge) and EXTI_RPR (Rising Edge).
I attempted to patch current common code to support these features and aligned devices header to have them export their EXTICR gpio bank selection mux bit sized defined via SYSCFG_EXTICR_SKIP (naming might not be totally obvious, but it was defined as it on f0, so i kept it for consistency).

BR

Guillaume