### PR TITLE
stm32l[01]: flash common: add flash_unlock_acr

### DIFF
--- a/include/libopencm3/stm32/common/flash_common_l01.h
+++ b/include/libopencm3/stm32/common/flash_common_l01.h
@@ -120,6 +120,8 @@ void flash_unlock_progmem(void);
 void flash_lock_progmem(void);
 void flash_lock_option_bytes(void);
 
+void flash_unlock_acr(void);
+
 void eeprom_program_word(uint32_t address, uint32_t data);
 void eeprom_program_words(uint32_t address, uint32_t *data, int length_in_words);
 

--- a/lib/stm32/common/flash_common_l01.c
+++ b/lib/stm32/common/flash_common_l01.c
@@ -89,6 +89,14 @@ void flash_lock(void)
 	flash_lock_pecr();
 }
 
+/** @brief Unlock RUN_PD bit from FLASH_ACR register.
+ */
+void flash_unlock_acr(void)
+{
+	FLASH_PDKEYR = FLASH_PDKEYR_PDKEY1;
+	FLASH_PDKEYR = FLASH_PDKEYR_PDKEY2;
+}
+
 /** @brief Write a word to eeprom
  *
  * @param address assumed to be in the eeprom space, no checking


### PR DESCRIPTION
flash_unlock_acr allows to unlock RUN_PD bit from FLASH_ACR register. Relock is done automatically
when writing 0 to RUN_PD, so no flash_lock_acr method.

Code is common to l0 and l1 devices.