### PR TITLE
stm32l0: rcc: add some utils.

### DIFF
--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -695,6 +695,11 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
 
 void rcc_set_msi_range(uint32_t msi_range);
 
+void rcc_set_lptim1_sel(uint32_t lptim1_sel);
+void rcc_set_lpuart1_sel(uint32_t lpupart1_sel);
+void rcc_set_usart1_sel(uint32_t usart1_sel);
+void rcc_set_usart2_sel(uint32_t usart2_sel);
+
 END_DECLS
 
 /**@}*/

--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -693,6 +693,8 @@ void rcc_set_ppre1(uint32_t ppre1);
 void rcc_set_hpre(uint32_t hpre);
 void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
 
+void rcc_set_msi_range(uint32_t msi_range);
+
 END_DECLS
 
 /**@}*/

--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -695,6 +695,8 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
 
 void rcc_set_msi_range(uint32_t msi_range);
 
+void rcc_set_peripheral_clk_sel(uint32_t periph, uint32_t sel);
+
 void rcc_set_lptim1_sel(uint32_t lptim1_sel);
 void rcc_set_lpuart1_sel(uint32_t lpupart1_sel);
 void rcc_set_usart1_sel(uint32_t usart1_sel);

--- a/lib/stm32/l0/rcc.c
+++ b/lib/stm32/l0/rcc.c
@@ -402,6 +402,50 @@ void rcc_set_msi_range(uint32_t msi_range)
 	RCC_ICSCR = reg32 | (msi_range << RCC_ICSCR_MSIRANGE_SHIFT);
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief Set the LPTIM1 clock source
+*
+ * @param lptim1_sel peripheral clock source @ref rcc_ccpipr_lptim1sel
+ */
+void rcc_set_lptim1_sel(uint32_t lptim1_sel)
+{
+	RCC_CCIPR &= ~(RCC_CCIPR_LPTIM1SEL_MASK << RCC_CCIPR_LPTIM1SEL_SHIFT);
+	RCC_CCIPR |= (lptim1_sel << RCC_CCIPR_LPTIM1SEL_SHIFT);
+}
+
+
+/*---------------------------------------------------------------------------*/
+/** @brief Set the LPUART1 clock source
+*
+ * @param lpuart1_sel periphral clock source @ref rcc_ccpipr_lpuart1sel
+ */
+void rcc_set_lpuart1_sel(uint32_t lpuart1_sel)
+{
+	RCC_CCIPR &= ~(RCC_CCIPR_LPUART1SEL_MASK << RCC_CCIPR_LPTIM1SEL_SHIFT);
+	RCC_CCIPR |= (lpuart1_sel << RCC_CCIPR_LPTIM1SEL_SHIFT);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Set the USART1 clock source
+*
+ * @param usart1_sel periphral clock source @ref rcc_ccpipr_usart1sel
+ */
+void rcc_set_usart1_sel(uint32_t usart1_sel)
+{
+	RCC_CCIPR &= ~(RCC_CCIPR_USART1SEL_MASK << RCC_CCIPR_USART1SEL_SHIFT);
+	RCC_CCIPR |= (usart1_sel << RCC_CCIPR_USART1SEL_SHIFT);
+}
+/*---------------------------------------------------------------------------*/
+/** @brief Set the USART2 clock source
+*
+ * @param usart2_sel periphral clock source @ref rcc_ccpipr_usartxsel
+ */
+void rcc_set_usart2_sel(uint32_t usart2_sel)
+{
+	RCC_CCIPR &= ~(RCC_CCIPR_USART2SEL_MASK << RCC_CCIPR_USART2SEL_SHIFT);
+	RCC_CCIPR |= (usart2_sel << RCC_CCIPR_USART2SEL_SHIFT);
+}
+
 /**
  * Set up sysclock with PLL from HSI16
  * @param clock full struct with desired parameters

--- a/lib/stm32/l0/rcc.c
+++ b/lib/stm32/l0/rcc.c
@@ -391,6 +391,17 @@ void rcc_set_hpre(uint32_t hpre)
 	RCC_CFGR = reg | (hpre << RCC_CFGR_HPRE_SHIFT);
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief Set the range of the MSI oscillator
+*
+ * @param range desired range @ref rcc_icscr_msirange
+ */
+void rcc_set_msi_range(uint32_t msi_range)
+{
+	uint32_t reg32 = RCC_ICSCR & ~(RCC_ICSCR_MSIRANGE_MASK << RCC_ICSCR_MSIRANGE_SHIFT);
+	RCC_ICSCR = reg32 | (msi_range << RCC_ICSCR_MSIRANGE_SHIFT);
+}
+
 /**
  * Set up sysclock with PLL from HSI16
  * @param clock full struct with desired parameters

--- a/lib/stm32/l0/rcc.c
+++ b/lib/stm32/l0/rcc.c
@@ -435,6 +435,7 @@ void rcc_set_usart1_sel(uint32_t usart1_sel)
 	RCC_CCIPR &= ~(RCC_CCIPR_USART1SEL_MASK << RCC_CCIPR_USART1SEL_SHIFT);
 	RCC_CCIPR |= (usart1_sel << RCC_CCIPR_USART1SEL_SHIFT);
 }
+
 /*---------------------------------------------------------------------------*/
 /** @brief Set the USART2 clock source
 *
@@ -444,6 +445,55 @@ void rcc_set_usart2_sel(uint32_t usart2_sel)
 {
 	RCC_CCIPR &= ~(RCC_CCIPR_USART2SEL_MASK << RCC_CCIPR_USART2SEL_SHIFT);
 	RCC_CCIPR |= (usart2_sel << RCC_CCIPR_USART2SEL_SHIFT);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Set the peripheral clock source
+*
+ * @param sel periphral clock source
+ */
+void rcc_set_peripheral_clk_sel(uint32_t periph, uint32_t sel)
+{
+	uint8_t shift;
+	uint32_t mask;
+
+	switch (periph) {
+		case LPTIM1_BASE:
+			shift = RCC_CCIPR_LPTIM1SEL_SHIFT;
+			mask = RCC_CCIPR_LPTIM1SEL_MASK;
+			break;
+
+		case I2C3_BASE:
+			shift = RCC_CCIPR_I2C3SEL_SHIFT;
+			mask = RCC_CCIPR_I2C3SEL_MASK;
+			break;
+
+		case I2C1_BASE:
+			shift = RCC_CCIPR_I2C1SEL_SHIFT;
+			mask = RCC_CCIPR_I2C1SEL_MASK;
+			break;
+
+		case LPUART1_BASE:
+			shift = RCC_CCIPR_LPUART1SEL_SHIFT;
+			mask = RCC_CCIPR_LPUART1SEL_MASK;
+			break;
+
+		case USART2_BASE:
+			shift = RCC_CCIPR_USART2SEL_SHIFT;
+			mask = RCC_CCIPR_USART2SEL_MASK;
+			break;
+
+		case USART1_BASE:
+			shift = RCC_CCIPR_USART1SEL_SHIFT;
+			mask = RCC_CCIPR_USART1SEL_MASK;
+			break;
+
+		default:
+			return;
+	}
+
+	uint32_t reg32 = RCC_CCIPR & ~(mask << shift);
+	RCC_CCIPR = reg32 | (sel << shift);
 }
 
 /**


### PR DESCRIPTION
hi,

Here's a couple of patch regarding stm32 l0 rcc, adding some msi setup and peripheral clock source configuration.

The msi bit is similar to l1 afaik, but no shared rcc code yet, and can be found on l4, but with different config register, so as for most of rcc related code, no easy way to avoid "duplicating" code yet.

Regarding the rcc_set_periph_sel bits, i found nothing in the lib yet, despite that kind of logic being present on a lot of chips, so i'm open to suggestion to put some nicer higher level / generic API later, ie: rcc_set_peripheral_selection(uint32 peripheral, uint32 clock_selection), that could be used on other chips, instead of defining millions of functions.