### PR TITLE
CM3: fix SCS_DWT_LSR and SCS_DWT_LAR definitions

### DIFF
--- a/include/libopencm3/cm3/scs.h
+++ b/include/libopencm3/cm3/scs.h
@@ -316,9 +316,9 @@
 #define SCS_DWT_PCSR		MMIO32(DWT_BASE + 0x18)
 
 /* CoreSight Lock Status Register for this peripheral */
-#define SCS_DWT_LSR		MMIO32(SCS_DWT_BASE + 0xFB4)
+#define SCS_DWT_LSR		MMIO32(DWT_BASE + 0xFB4)
 /* CoreSight Lock Access Register for this peripheral */
-#define SCS_DWT_LAR		MMIO32(SCS_DWT_BASE + 0xFB0)
+#define SCS_DWT_LAR		MMIO32(DWT_BASE + 0xFB0)
 
 /* --- SCS_DWT_CTRL values ------------------------------------------------- */
 /*


### PR DESCRIPTION
SCS_DWT_BASE as base address used by SCS_DWT_LSR and SCS_DWT_LAR
is not defined, but DWT_BASE is.