### PR TITLE
Add a couple of ld scripts for stm32f4

### DIFF
--- a/lib/stm32/f4/stm32f405xe.ld
+++ b/lib/stm32/f4/stm32f405xe.ld
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2019 Miguel Sánchez de León Peque <peque@neosit.es>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for STM32F405xE */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+	ccm (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld

--- a/lib/stm32/f4/stm32f405xg.ld
+++ b/lib/stm32/f4/stm32f405xg.ld
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2019 Miguel Sánchez de León Peque <peque@neosit.es>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for STM32F405xG */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
+	ccm (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld


### PR DESCRIPTION
There is currently an `stm32f405x6.ld` script, but there is no STM32F405X6 as far as I know. Should it be removed? Or am I missing something?