### PR TITLE
stm32f4: add HSI clock scale configurations

### DIFF
--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -794,6 +794,7 @@ extern const struct rcc_clock_scale rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_12mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_END];
 extern const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END];
+extern const struct rcc_clock_scale rcc_hsi_3v3[RCC_CLOCK_3V3_END];
 
 enum rcc_osc {
 	RCC_PLL,

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -381,6 +381,89 @@ const struct rcc_clock_scale rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_END] = {
 	},
 };
 
+const struct rcc_clock_scale rcc_hsi_3v3[RCC_CLOCK_3V3_END] = {
+	{ /* 48MHz */
+		.pllm = 16,
+		.plln = 96,
+		.pllp = 2,
+		.pllq = 2,
+		.pllr = 0,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.voltage_scale = PWR_SCALE1,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN |
+				FLASH_ACR_LATENCY_1WS,
+		.ahb_frequency  = 48000000,
+		.apb1_frequency = 12000000,
+		.apb2_frequency = 24000000,
+	},
+	{ /* 84MHz */
+		.pllm = 16,
+		.plln = 336,
+		.pllp = 4,
+		.pllq = 7,
+		.pllr = 0,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_2,
+		.ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+		.voltage_scale = PWR_SCALE1,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN |
+				FLASH_ACR_LATENCY_2WS,
+		.ahb_frequency  = 84000000,
+		.apb1_frequency = 42000000,
+		.apb2_frequency = 84000000,
+	},
+	{ /* 120MHz */
+		.pllm = 16,
+		.plln = 240,
+		.pllp = 2,
+		.pllq = 5,
+		.pllr = 0,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.voltage_scale = PWR_SCALE1,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN |
+				FLASH_ACR_LATENCY_3WS,
+		.ahb_frequency  = 120000000,
+		.apb1_frequency = 30000000,
+		.apb2_frequency = 60000000,
+	},
+	{ /* 168MHz */
+		.pllm = 16,
+		.plln = 336,
+		.pllp = 2,
+		.pllq = 7,
+		.pllr = 0,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.voltage_scale = PWR_SCALE1,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN |
+				FLASH_ACR_LATENCY_5WS,
+		.ahb_frequency  = 168000000,
+		.apb1_frequency = 42000000,
+		.apb2_frequency = 84000000,
+	},
+	{ /* 180MHz */
+		.pllm = 16,
+		.plln = 360,
+		.pllp = 2,
+		.pllq = 8,
+		.pllr = 0,
+		.hpre = RCC_CFGR_HPRE_DIV_NONE,
+		.ppre1 = RCC_CFGR_PPRE_DIV_4,
+		.ppre2 = RCC_CFGR_PPRE_DIV_2,
+		.voltage_scale = PWR_SCALE1,
+		.flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN |
+				FLASH_ACR_LATENCY_5WS,
+		.ahb_frequency  = 180000000,
+		.apb1_frequency = 45000000,
+		.apb2_frequency = 90000000,
+	},
+};
+
 void rcc_osc_ready_int_clear(enum rcc_osc osc)
 {
 	switch (osc) {


### PR DESCRIPTION
I defined `rcc_hsi_3v3` as an exact copy of `rcc_hse_16mhz_3v3`. Please, tell me if there is a better way to avoid duplicated code.