### PR TITLE
Include i2c_common_v2 for STM32F7 family

### DIFF
--- a/include/libopencm3/stm32/common/i2c_common_v2.h
+++ b/include/libopencm3/stm32/common/i2c_common_v2.h
@@ -46,6 +46,9 @@ specific memorymap.h header before including this header file.*/
 #ifdef I2C3_BASE
 #define I2C3				I2C3_BASE
 #endif
+#ifdef I2C4_BASE
+#define I2C4				I2C4_BASE
+#endif
 /**@}*/
 
 /* --- I2C registers ------------------------------------------------------- */

--- a/include/libopencm3/stm32/f7/i2c.h
+++ b/include/libopencm3/stm32/f7/i2c.h
@@ -1,0 +1,38 @@
+/** @defgroup i2c_defines I2C Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32F0xx I2C</b>
+ *
+ * @ingroup STM32F0xx_defines
+ *
+ * @version 1.0.0
+ *
+ * @date 11 July 2013
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_I2C_H
+#define LIBOPENCM3_I2C_H
+
+#include <libopencm3/stm32/common/i2c_common_v2.h>
+
+#endif
+

--- a/include/libopencm3/stm32/f7/i2c.h
+++ b/include/libopencm3/stm32/f7/i2c.h
@@ -13,8 +13,6 @@
 /*
  * This file is part of the libopencm3 project.
  *
- * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
- *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/include/libopencm3/stm32/f7/i2c.h
+++ b/include/libopencm3/stm32/f7/i2c.h
@@ -1,12 +1,12 @@
 /** @defgroup i2c_defines I2C Defines
  *
- * @brief <b>Defined Constants and Types for the STM32F0xx I2C</b>
+ * @brief <b>Defined Constants and Types for the STM32F7xx I2C</b>
  *
- * @ingroup STM32F0xx_defines
+ * @ingroup STM32F7xx_defines
  *
  * @version 1.0.0
  *
- * @date 11 July 2013
+ * @date 04 April 2019
  *
  * LGPL License Terms @ref lgpl_license
  */

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -50,6 +50,7 @@ OBJS		+= pwr.o rcc.o
 
 OBJS		+= rcc_common_all.o
 OBJS		+= rng_common_v1.o
+OBJS		+= i2c_common_v2.o
 OBJS		+= spi_common_all.o spi_common_v2.o
 OBJS		+= timer_common_all.o
 OBJS		+= usart_common_all.o usart_common_v2.o

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -46,11 +46,10 @@ OBJS		= desig.o
 OBJS		+= dma_common_f24.o
 OBJS		+= flash_common_all.o flash_common_f.o flash_common_f24.o flash.o
 OBJS		+= gpio.o gpio_common_all.o gpio_common_f0234.o
+OBJS		+= i2c_common_v2.o
 OBJS		+= pwr.o rcc.o
-
 OBJS		+= rcc_common_all.o
 OBJS		+= rng_common_v1.o
-OBJS		+= i2c_common_v2.o
 OBJS		+= spi_common_all.o spi_common_v2.o
 OBJS		+= timer_common_all.o
 OBJS		+= usart_common_all.o usart_common_v2.o


### PR DESCRIPTION
With the addition of a define for I2C4, the existing common i2c
functions seem to work out of the box on the F7 (tested on an
STM32F750).