### PR TITLE
Connect up additional libraries for STM32F7 series

### DIFF
--- a/include/libopencm3/ethernet/mac.h
+++ b/include/libopencm3/ethernet/mac.h
@@ -37,6 +37,8 @@
 #       include <libopencm3/ethernet/mac_stm32fxx7.h>
 #elif defined(STM32F4)
 #       include <libopencm3/ethernet/mac_stm32fxx7.h>
+#elif defined(STM32F7)
+#       include <libopencm3/ethernet/mac_stm32fxx7.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/f7/crc.h
+++ b/include/libopencm3/stm32/f7/crc.h
@@ -1,5 +1,16 @@
-/* This provides unification of code over STM32 subfamilies */
-
+/** @defgroup crc_defines CRC Defines
+ *
+ * @brief <b>libopencm3 Defined Constants and Types for the STM32F7xx CRC
+ * Generator </b>
+ *
+ * @ingroup STM32F7xx_defines
+ *
+ * @version 1.0.0
+ *
+ * @date 11 Apr 2019
+ *
+ *LGPL License Terms @ref lgpl_license
+ */
 /*
  * This file is part of the libopencm3 project.
  *
@@ -17,26 +28,9 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+#ifndef LIBOPENCM3_CRC_H
+#define LIBOPENCM3_CRC_H
 
-#if defined(STM32F0)
-#       include <libopencm3/stm32/f0/crc.h>
-#elif defined(STM32F1)
-#       include <libopencm3/stm32/f1/crc.h>
-#elif defined(STM32F2)
-#       include <libopencm3/stm32/f2/crc.h>
-#elif defined(STM32F3)
-#       include <libopencm3/stm32/f3/crc.h>
-#elif defined(STM32F4)
-#       include <libopencm3/stm32/f4/crc.h>
-#elif defined(STM32F7)
-#       include <libopencm3/stm32/f7/crc.h>
-#elif defined(STM32L1)
-#       include <libopencm3/stm32/l1/crc.h>
-#elif defined(STM32L4)
-#       include <libopencm3/stm32/l4/crc.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/crc_v2.h>
+
 #endif
-

--- a/include/libopencm3/stm32/f7/iwdg.h
+++ b/include/libopencm3/stm32/f7/iwdg.h
@@ -1,0 +1,36 @@
+/** @defgroup iwdg_defines IWDG Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32F7xx Independent Watchdog
+ * Timer</b>
+ *
+ * @ingroup STM32F7xx_defines
+ *
+ * @version 1.0.0
+ *
+ * @date 11 April 2018
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_IWDG_H
+#define LIBOPENCM3_IWDG_H
+
+#include <libopencm3/stm32/common/iwdg_common_v2.h>
+
+#endif

--- a/include/libopencm3/stm32/f7/syscfg.h
+++ b/include/libopencm3/stm32/f7/syscfg.h
@@ -1,0 +1,36 @@
+/** @defgroup syscfg_defines SYSCFG Defines
+ *
+ * @ingroup STM32F7xx_defines
+ *
+ * @brief Defined Constants and Types for the STM32F7xx Sysconfig
+ *
+ * @version 1.0.0
+ *
+ * @date 11 April 2019
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_SYSCFG_H
+#define LIBOPENCM3_SYSCFG_H
+
+#include <libopencm3/stm32/common/syscfg_common_l1f234.h>
+
+#endif

--- a/include/libopencm3/stm32/iwdg.h
+++ b/include/libopencm3/stm32/iwdg.h
@@ -30,6 +30,8 @@
 #       include <libopencm3/stm32/f3/iwdg.h>
 #elif defined(STM32F4)
 #       include <libopencm3/stm32/f4/iwdg.h>
+#elif defined(STM32F7)
+#       include <libopencm3/stm32/f7/iwdg.h>
 #elif defined(STM32L0)
 #       include <libopencm3/stm32/l0/iwdg.h>
 #elif defined(STM32L1)

--- a/include/libopencm3/stm32/syscfg.h
+++ b/include/libopencm3/stm32/syscfg.h
@@ -28,6 +28,8 @@
 #       include <libopencm3/stm32/f3/syscfg.h>
 #elif defined(STM32F4)
 #       include <libopencm3/stm32/f4/syscfg.h>
+#elif defined(STM32F7)
+#       include <libopencm3/stm32/f7/syscfg.h>
 #elif defined(STM32L0)
 #       include <libopencm3/stm32/l0/syscfg.h>
 #elif defined(STM32L1)

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -57,6 +57,9 @@ OBJS		+= spi_common_all.o spi_common_v2.o
 OBJS		+= timer_common_all.o
 OBJS		+= usart_common_all.o usart_common_v2.o
 
+# Ethernet
+OBJS		+= mac.o phy.o mac_stm32fxx7.o phy_ksz80x1.o
+
 VPATH += ../../usb:../:../../cm3:../common
 VPATH += ../../ethernet
 

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -44,6 +44,7 @@ ARFLAGS		= rcs
 
 OBJS		= desig.o
 OBJS		+= dma_common_f24.o
+OBJS		+= crc_common_all.o crc_v2.o
 OBJS		+= flash_common_all.o flash_common_f.o flash_common_f24.o flash.o
 OBJS		+= gpio.o gpio_common_all.o gpio_common_f0234.o
 OBJS		+= i2c_common_v2.o

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -44,6 +44,7 @@ ARFLAGS		= rcs
 
 OBJS		= desig.o
 OBJS		+= dma_common_f24.o
+OBJS		+= can.o
 OBJS		+= crc_common_all.o crc_v2.o
 OBJS		+= flash_common_all.o flash_common_f.o flash_common_f24.o flash.o
 OBJS		+= gpio.o gpio_common_all.o gpio_common_f0234.o

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -47,6 +47,7 @@ OBJS		+= dma_common_f24.o
 OBJS		+= flash_common_all.o flash_common_f.o flash_common_f24.o flash.o
 OBJS		+= gpio.o gpio_common_all.o gpio_common_f0234.o
 OBJS		+= i2c_common_v2.o
+OBJS		+= iwdg_common_all.o
 OBJS		+= pwr.o rcc.o
 OBJS		+= rcc_common_all.o
 OBJS		+= rng_common_v1.o


### PR DESCRIPTION
Update includes & objects for 
- IWDG
- CRC
- Syscfg (header only)
- CAN (header didn't have include guard, but wasn't included in link list)
- Ethernet

All tested on STM32F745 and 750 cores.