### PR TITLE
stm32: Fix adc_calibrate_async() 

### DIFF
--- a/lib/stm32/common/adc_common_v2.c
+++ b/lib/stm32/common/adc_common_v2.c
@@ -155,7 +155,7 @@ void adc_power_off(uint32_t adc)
  */
 void adc_calibrate_async(uint32_t adc)
 {
-	ADC_CR(adc) = ADC_CR_ADCAL;
+	ADC_CR(adc) |= ADC_CR_ADCAL;
 }
 
 /**


### PR DESCRIPTION
In adc_calibrate_async() we should only set the ADCAL bit and leave the rest alone. 

The old code set the entire register.