### PR TITLE
PROPOSAL: find common headers for doxygen

### DIFF
--- a/scripts/gendoxylist
+++ b/scripts/gendoxylist
@@ -17,6 +17,16 @@ for FN in $(find ${UNTRACKED_DIRS} -name '*.h'); do
 	printf "INPUT += ../%s\n" "$FN" >> ${ODIR}/${ONAME}
 done
 
+# Find header dependencies in the manufacturer-folder (eg. libopencm3/stm32)
+# and ../common folder (eg. libopencm3/stm32/common)
+printf "# Headers lying around..\n" >> ${ODIR}/${ONAME}
+SERIES_PATH="../include/libopencm3/${IPATH}"
+MANUFACTURER_PATH=$(dirname ${SERIES_PATH})
+COMMON_PATH="${MANUFACTURER_PATH}/common"
+INCLUDES=$(find "${MANUFACTURER_PATH}" "${SERIES_PATH}" -maxdepth 1 -name '*.h' | sed "s/^\(.*\)$/#include <\1>/")
+CC="gcc - -D__ARM_ARCH_7M__  -D$(echo $2 | tr '[:lower:]' '[:upper:]') -I../include -x c - -M -MG -MF-"
+echo "${INCLUDES}" | ${CC} 2>/dev/null | grep -o '[^ ]*.h' | grep -e "${COMMON_PATH}/[^/]*.h" | cut -d ':' -f2 | sort | uniq | sed "s#^#INPUT += #" >> ${ODIR}/${ONAME}
+
 # There will be duplicates here, but doxygen doesn't mind.
 printf "# Headers first\n" >> ${ODIR}/${ONAME}
 grep -o '[^ ]*.h' ${DDIR}/*.d | grep 'include/libopencm3' | cut -d ':' -f2 | sort | uniq | sed "s#^#INPUT += ${PATH_DELTA}/#" >> ${ODIR}/${ONAME}


### PR DESCRIPTION
Problem:
- The scripts/gendoxylist script does not detect headers which are not in the chip-series include folder,  when no c-sources reference them
Solution:
- Create a dummy source-code which includes all the header files in the manufacturer AND series folder
- Extract all header references by running the precompiler on the generated source code
Problems with the solution:
- Compilation requires some flags which should probably come as arguments, rather than a guessed (eg. gcc -D__ARM_ARCH_7M__ -DSTM32F7)

Etc:
- Maybe remove the "All headers for core/platform.." part and change `grep -e "${COMMON_PATH}/[^/]*.h"`
    - to `grep -e "${SERIES_PATH}/[^/]*.h" -e "${COMMON_PATH}/[^/]*.h"`
    - or even to `grep -e "${SERIES_PATH}/[^/]*.h" -e "${MANUFACTURER_PATH}/[^/]*.h" -e "${COMMON_PATH}/[^/]*.h"` to include "manufacturer"-header files too