### PR TITLE
Add .a suffix to LIBDEPS var in genlink-config

### DIFF
--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -65,7 +65,7 @@ endif
 endif
 
 LDLIBS += -l$(LIBNAME)
-LIBDEPS += $(OPENCM3_DIR)/lib/lib$(LIBNAME)
+LIBDEPS += $(OPENCM3_DIR)/lib/lib$(LIBNAME).a
 
 # only append to LDLIBS if the directory exists
 ifneq (,$(wildcard $(OPENCM3_DIR)/lib))


### PR DESCRIPTION
It looks like commit 96d094af13dab67709a252a39da164bde4d637e0
introduced a build failure to the gadget for the tilm4f120xl target,
which appears to be the only one to use genlink.

Adding back the `.a` suffix to the rule appears to fix the problem.