### PR TITLE
doc: no need to call sed -s, unbreak make doc on os x

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,7 +33,7 @@ $(1)/doxy.sourcelist: $(1)/
 	@../scripts/gendoxylist ../lib/$(TARGET_SRC_DIR) $(1)
 
 $(1)/Doxyfile: templates/Doxyfile_Device | $(1)/
-	@cat $$< | sed -s s/#device#/$(1)/g > $$@
+	@cat $$< | sed s/#device#/$(1)/g > $$@
 
 $(1)/DoxygenLayout_$(1).xml: templates/DoxygenLayout_Device.xml | $(1)/
 	@../scripts/gendoxylayout.py --template $$< --out $$@ --target $(1) $$(TARGETS_DIRS)


### PR DESCRIPTION
Not sure how/why i pushed that, absolutely no need to call sed with -s
parameter. Fix build on os x / systems running non gnu sed.