### PR TITLE
stm32g0: support++

### DIFF
--- a/include/libopencm3/stm32/crc.h
+++ b/include/libopencm3/stm32/crc.h
@@ -36,6 +36,8 @@
 #       include <libopencm3/stm32/l1/crc.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/crc.h>
+#elif defined(STM32G0)
+#       include <libopencm3/stm32/g0/crc.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/g0/crc.h
+++ b/include/libopencm3/stm32/g0/crc.h
@@ -1,0 +1,31 @@
+/** @defgroup crc_defines CRC Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx CRC Generator </b>
+ *
+ * @ingroup STM32G0xx_defines
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_CRC_H
+#define LIBOPENCM3_CRC_H
+
+#include <libopencm3/stm32/common/crc_v2.h>
+
+#endif

--- a/include/libopencm3/stm32/g0/exti.h
+++ b/include/libopencm3/stm32/g0/exti.h
@@ -75,9 +75,11 @@ void exti_reset_rising_request(uint32_t extis);
 void exti_reset_falling_request(uint32_t extis);
 
 END_DECLS
-/**@}*/
 
 #else
+/** @cond */
 #warning "exti_common_v1.h should not be included directly, only via exti.h"
 #endif
 /** @endcond */
+
+/**@}*/

--- a/include/libopencm3/stm32/g0/i2c.h
+++ b/include/libopencm3/stm32/g0/i2c.h
@@ -1,0 +1,34 @@
+/** @defgroup i2c_defines I2C Defines
+ *
+ * @ingroup STM32G0xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx I2C</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_I2C_H
+#define LIBOPENCM3_I2C_H
+
+#include <libopencm3/stm32/common/i2c_common_v2.h>
+
+#endif
+

--- a/include/libopencm3/stm32/g0/iwdg.h
+++ b/include/libopencm3/stm32/g0/iwdg.h
@@ -1,0 +1,33 @@
+/** @defgroup iwdg_defines IWDG Defines
+ *
+ * @ingroup STM32G0xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx Independent Watchdog Timer</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_IWDG_H
+#define LIBOPENCM3_IWDG_H
+
+#include <libopencm3/stm32/common/iwdg_common_v2.h>
+
+#endif

--- a/include/libopencm3/stm32/g0/rng.h
+++ b/include/libopencm3/stm32/g0/rng.h
@@ -1,5 +1,13 @@
-/* This provides unification of code over STM32 subfamilies */
-
+/** @defgroup rng_defines RNG Defines
+ *
+ * @ingroup STM32G0xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx EXTI Control</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
 /*
  * This file is part of the libopencm3 project.
  *
@@ -17,21 +25,16 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <libopencm3/cm3/common.h>
-#include <libopencm3/stm32/memorymap.h>
+/**@{*/
+#ifndef LIBOPENCM3_RNG_H
+#define LIBOPENCM3_RNG_H
 
-#if defined(STM32F2)
-#       include <libopencm3/stm32/f2/rng.h>
-#elif defined(STM32F4)
-#       include <libopencm3/stm32/f4/rng.h>
-#elif defined(STM32F7)
-#       include <libopencm3/stm32/f7/rng.h>
-#elif defined(STM32L0)
-#       include <libopencm3/stm32/l0/rng.h>
-#elif defined(STM32L4)
-#       include <libopencm3/stm32/l4/rng.h>
-#elif defined(STM32G0)
-#       include <libopencm3/stm32/g0/rng.h>
-#else
-#       error "stm32 family not defined."
+#include <libopencm3/stm32/common/rng_common_v1.h>
+
+/* --- RNG_CR values ------------------------------------------------------- */
+
+/** Clock error detection : CED = 0 : Detection Enabled */
+#define RNG_CR_CED		(1 << 5)
+
 #endif
+/**@}*/

--- a/include/libopencm3/stm32/g0/spi.h
+++ b/include/libopencm3/stm32/g0/spi.h
@@ -1,0 +1,34 @@
+/** @defgroup spi_defines SPI Defines
+ *
+ * @ingroup STM32G0xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx SPI</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_SPI_H
+#define LIBOPENCM3_SPI_H
+
+#include <libopencm3/stm32/common/spi_common_all.h>
+#include <libopencm3/stm32/common/spi_common_v1_frf.h>
+
+#endif

--- a/include/libopencm3/stm32/g0/timer.h
+++ b/include/libopencm3/stm32/g0/timer.h
@@ -1,0 +1,74 @@
+/** @defgroup timer_defines Timer Defines
+ *
+ * @ingroup STM32G0xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx Timers</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2019 Guillaume Revaillot <g.revaillot@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_TIMER_H
+#define LIBOPENCM3_TIMER_H
+
+#include <libopencm3/stm32/common/timer_common_all.h>
+
+/**@{*/
+
+/* Option Register (TIMx_OR1) */
+#define TIM_OR1(tim_base)		MMIO32((tim_base) + 0x50)
+#define TIM2_OR1			TIM_OR1(TIM2)
+#define TIM3_OR1			TIM_OR1(TIM3)
+
+/* Alternate Function (TIMx_AF1) */
+#define TIM_AF1(tim_base)		MMIO32((tim_base) + 0x60)
+#define TIM2_AF1			TIM_AF1(TIM2)
+#define TIM3_AF1			TIM_AF1(TIM3)
+#define TIM16_AF1			TIM_AF1(TIM16)
+#define TIM17_AF1			TIM_AF1(TIM17)
+
+/* Input Selection Register (TIMx_TISEL) */
+#define TIM_TISEL(tim_base)		MMIO32((tim_base) + 0x68)
+#define TIM2_TISEL			TIM_TISEL(TIM2)
+#define TIM3_TISEL			TIM_TISEL(TIM3)
+#define TIM14_TISEL			TIM_TISEL(TIM14)
+#define TIM16_TISEL			TIM_TISEL(TIM16)
+#define TIM17_TISEL			TIM_TISEL(TIM17)
+
+/* --- TIMx_OR1 values ---------------------------------------------------- */
+
+/* OCREF_CLR: ocref_clr Source Selection */
+#define TIM_OR1_OCREF_CLR			(1 << 0)
+
+/** @defgroup tim_or1_ocref_clr TIM_OR1_OCREF_CLR Source Selection
+@{*/
+#define TIM_OR1_OCREF_CLR_COMP1			(0)
+#define TIM_OR1_OCREF_CLR_COMP2			(1)
+/**@}*/
+
+BEGIN_DECLS
+
+END_DECLS
+
+/**@}*/
+
+#endif

--- a/include/libopencm3/stm32/g0/usart.h
+++ b/include/libopencm3/stm32/g0/usart.h
@@ -1,0 +1,48 @@
+/** @defgroup usart_defines USART Defines
+ *
+ * @ingroup STM32G0xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx USART</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_USART_H
+#define LIBOPENCM3_USART_H
+
+#include <libopencm3/stm32/common/usart_common_all.h>
+#include <libopencm3/stm32/common/usart_common_v2.h>
+
+/**@{*/
+
+/** @defgroup usart_reg_base USART register base addresses
+ * Holds all the U(S)ART peripherals supported.
+ * @{
+ */
+#define USART1				USART1_BASE
+#define USART2				USART2_BASE
+#define USART3				USART3_BASE
+#define USART4				USART4_BASE
+#define LPUART1				LPUART1_BASE
+/**@}*/
+
+/**@}*/
+#endif

--- a/include/libopencm3/stm32/i2c.h
+++ b/include/libopencm3/stm32/i2c.h
@@ -38,6 +38,8 @@
 #       include <libopencm3/stm32/l1/i2c.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/i2c.h>
+#elif defined(STM32G0)
+#       include <libopencm3/stm32/g0/i2c.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/iwdg.h
+++ b/include/libopencm3/stm32/iwdg.h
@@ -38,6 +38,8 @@
 #       include <libopencm3/stm32/l1/iwdg.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/iwdg.h>
+#elif defined(STM32G0)
+#       include <libopencm3/stm32/g0/iwdg.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/spi.h
+++ b/include/libopencm3/stm32/spi.h
@@ -38,6 +38,8 @@
 #       include <libopencm3/stm32/l1/spi.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/spi.h>
+#elif defined(STM32G0)
+#       include <libopencm3/stm32/g0/spi.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/timer.h
+++ b/include/libopencm3/stm32/timer.h
@@ -40,6 +40,8 @@
 #       include <libopencm3/stm32/l1/timer.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/timer.h>
+#elif defined(STM32G0)
+#       include <libopencm3/stm32/g0/timer.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/usart.h
+++ b/include/libopencm3/stm32/usart.h
@@ -38,6 +38,8 @@
 #       include <libopencm3/stm32/l1/usart.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/usart.h>
+#elif defined(STM32G0)
+#       include <libopencm3/stm32/g0/usart.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -44,6 +44,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 OBJS += spi_common_all.o spi_common_v1_frf.o
 OBJS += i2c_common_v2.o
 OBJS += rng_common_v1.o
+OBJS += crc_common_all.o
 
 VPATH +=../:../../cm3:../common
 

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -42,6 +42,7 @@ OBJS += rcc.o rcc_common_all.o
 OBJS += iwdg_common_all.o
 OBJS += usart_common_all.o usart_common_v2.o
 OBJS += spi_common_all.o spi_common_v1_frf.o
+OBJS += i2c_common_v2.o
 
 VPATH +=../:../../cm3:../common
 

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -43,6 +43,7 @@ OBJS += iwdg_common_all.o
 OBJS += usart_common_all.o usart_common_v2.o
 OBJS += spi_common_all.o spi_common_v1_frf.o
 OBJS += i2c_common_v2.o
+OBJS += rng_common_v1.o
 
 VPATH +=../:../../cm3:../common
 

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -45,6 +45,7 @@ OBJS += spi_common_all.o spi_common_v1_frf.o
 OBJS += i2c_common_v2.o
 OBJS += rng_common_v1.o
 OBJS += crc_common_all.o
+OBJS += timer_common_all.o
 
 VPATH +=../:../../cm3:../common
 

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -41,6 +41,7 @@ OBJS += pwr.o
 OBJS += rcc.o rcc_common_all.o
 OBJS += iwdg_common_all.o
 OBJS += usart_common_all.o usart_common_v2.o
+OBJS += spi_common_all.o spi_common_v1_frf.o
 
 VPATH +=../:../../cm3:../common
 

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -39,6 +39,7 @@ OBJS += flash.o flash_common_all.o
 OBJS += gpio_common_all.o gpio_common_f0234.o 
 OBJS += pwr.o
 OBJS += rcc.o rcc_common_all.o
+OBJS += iwdg_common_all.o
 
 VPATH +=../:../../cm3:../common
 

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -40,6 +40,7 @@ OBJS += gpio_common_all.o gpio_common_f0234.o
 OBJS += pwr.o
 OBJS += rcc.o rcc_common_all.o
 OBJS += iwdg_common_all.o
+OBJS += usart_common_all.o usart_common_v2.o
 
 VPATH +=../:../../cm3:../common
 

--- a/lib/stm32/g0/exti.c
+++ b/lib/stm32/g0/exti.c
@@ -1,4 +1,5 @@
-/** @addtogroup exti_file
+/** @defgroup exti_file EXTI peripheral API
+ * @ingroup peripheral_apis
  *
  * @author @htmlonly &copy; @endhtmlonly 2019 Guillaume Revaillot <g.revaillot@gmail.com>
  *


### PR DESCRIPTION
Hi,

Here's some more g0 support, making it a bit more usefull - adding iwdg/usart/spi/i2c/rng/crc and timer.
Not much new stuff here, a couple of new regs and bits for Timer and RNG but that's all.

I need to review adc and dma/dmamux stuff, but that will wait the next patchset