### PR TITLE
gadget-zero: f4* fix deprecated calls to rcc_clock_setup_hse_3v3

### DIFF
--- a/tests/gadget-zero/main-stm32f429i-disco.c
+++ b/tests/gadget-zero/main-stm32f429i-disco.c
@@ -35,7 +35,7 @@
 
 int main(void)
 {
-	rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
+	rcc_clock_setup_pll(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
 	rcc_periph_clock_enable(RCC_GPIOB);
 	rcc_periph_clock_enable(RCC_OTGHS);
 


### PR DESCRIPTION
complete 43b6f333d2cbb85cb4b09f7a22e28c3e7dc144dc