### PR TITLE
F4 rcc

### DIFF
--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -1080,6 +1080,7 @@ void rcc_osc_on(enum rcc_osc osc);
 void rcc_osc_off(enum rcc_osc osc);
 void rcc_css_enable(void);
 void rcc_css_disable(void);
+void rcc_plli2s_config(uint16_t n, uint8_t r);
 void rcc_pllsai_config(uint16_t n, uint16_t p, uint16_t q, uint16_t r);
 void rcc_pllsai_postscalers(uint8_t q, uint8_t r);
 void rcc_set_sysclk_source(uint32_t clk);

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -756,18 +756,6 @@
 #define RCC_CKGATENR_AHB2APB1_CKEN		(1<<0)
 /*@}*/
 
-/* PLLSAI1 helper macros */
-static inline void rcc_pllsai_enable(void)
-{
-	RCC_CR |= RCC_CR_PLLSAION;
-}
-
-static inline bool rcc_pllsai_ready(void)
-{
-	return (RCC_CR & RCC_CR_PLLSAIRDY) != 0;
-}
-
-
 /* --- Variable definitions ------------------------------------------------ */
 extern uint32_t rcc_ahb_frequency;
 extern uint32_t rcc_apb1_frequency;

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -543,6 +543,18 @@ void rcc_css_disable(void)
 }
 
 /**
+ * Set the dividers for the PLLI2S clock outputs
+ * @param n valid range is 192..432
+ * @param r valid range is 2..7
+ */
+void rcc_plli2s_config(uint16_t n, uint8_t r)
+{
+	RCC_PLLI2SCFGR = (
+	  ((n & RCC_PLLI2SCFGR_PLLI2SN_MASK) << RCC_PLLI2SCFGR_PLLI2SN_SHIFT) |
+	  ((r & RCC_PLLI2SCFGR_PLLI2SR_MASK) << RCC_PLLI2SCFGR_PLLI2SR_SHIFT));
+}
+
+/**
  * Set the dividers for the PLLSAI clock outputs
  * divider p is only available on F4x9 parts, pass 0 for other parts.
  * @param n valid range is 49..432


### PR DESCRIPTION
I'm working on a project with the f401. i've come across a few things i thought worth changing / adding.

short explanation for the current commits:
* the removed functionality can be accessed through `rcc_osc_on(RCC_PLLSAI);` respectively `rcc_is_osc_ready(RCC_PLLSAI);`
* add short wrapper to configure the i2s pll available on the stm32f401