### PR TITLE
Linker: Add definition for .heap to let malloc work

### DIFF
--- a/ld/linker.ld.S
+++ b/ld/linker.ld.S
@@ -132,6 +132,10 @@ SECTIONS
 		. = ALIGN(4);
 		_ebss = .;
 	} >ram
+	.heap : {
+		. = ALIGN(4);
+		_heap_start = .;
+	} >ram
 
 #if defined(_CCM)
 	.ccm : {


### PR DESCRIPTION
This adds a symbol (heap_start) at the end of allocated
RAM for the start of heap.