### PR TITLE
doc: fix typo

### DIFF
--- a/include/libopencm3/cm3/doc-cm3.h
+++ b/include/libopencm3/cm3/doc-cm3.h
@@ -21,6 +21,6 @@ LGPL License Terms @ref lgpl_license
 */
 
 /** @defgroup CM3_files Cortex Core Peripheral APIs
- * APIs for Coretex Core peripherals
+ * APIs for Cortex Core peripherals
  */
 

--- a/include/libopencm3/stm32/f4/doc-stm32f4.h
+++ b/include/libopencm3/stm32/f4/doc-stm32f4.h
@@ -4,7 +4,7 @@
 
 @date 7 September 2012
 
-API documentation for ST Microelectronics STM32F4 Cortex M3 series.
+API documentation for ST Microelectronics STM32F4 Cortex M4F series.
 
 LGPL License Terms @ref lgpl_license
 */


### PR DESCRIPTION
fix a couple of typos.

btw, doc-cm3.h mentions "Cortex M3", i guess it could be replaced by "Cortex M" ?