### PR TITLE
stm32:L4:flash: Add erase bank2 flash function.

### DIFF
--- a/lib/stm32/l4/flash.c
+++ b/lib/stm32/l4/flash.c
@@ -160,6 +160,10 @@ void flash_erase_page(uint32_t page)
 
 	/* page and bank are contiguous bits */
 	FLASH_CR &= ~((FLASH_CR_PNB_MASK << FLASH_CR_PNB_SHIFT) | FLASH_CR_BKER);
+	if(page>255)
+	{
+		FLASH_CR |= FLASH_CR_BKER;
+	}
 	FLASH_CR |= page << FLASH_CR_PNB_SHIFT;
 	FLASH_CR |= FLASH_CR_PER;
 	FLASH_CR |= FLASH_CR_START;


### PR DESCRIPTION
I have compared several different flash reference manuals for the L4 series, which I think is necessary.

😀