### PR TITLE
stm32l0: add CRC support

### DIFF
--- a/include/libopencm3/stm32/crc.h
+++ b/include/libopencm3/stm32/crc.h
@@ -32,6 +32,8 @@
 #       include <libopencm3/stm32/f4/crc.h>
 #elif defined(STM32F7)
 #       include <libopencm3/stm32/f7/crc.h>
+#elif defined(STM32L0)
+#       include <libopencm3/stm32/l0/crc.h>
 #elif defined(STM32L1)
 #       include <libopencm3/stm32/l1/crc.h>
 #elif defined(STM32L4)

--- a/include/libopencm3/stm32/l0/crc.h
+++ b/include/libopencm3/stm32/l0/crc.h
@@ -1,0 +1,33 @@
+/** @defgroup crc_defines CRC Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32L0xx CRC Generator </b>
+ *
+ * @ingroup STM32L0xx_defines
+ *
+ * @date 11 October 2019
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_CRC_H
+#define LIBOPENCM3_CRC_H
+
+#include <libopencm3/stm32/common/crc_v2.h>
+
+#endif

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -35,6 +35,7 @@ TGT_CFLAGS	+= $(STANDARD_FLAGS)
 ARFLAGS		= rcs
 
 OBJS += adc_common_v2.o
+OBJS += crc_common_all.o crc_v2.o
 OBJS += crs_common_all.o
 OBJS += desig.o
 OBJS += dma_common_l1f013.o dma_common_csel.o


### PR DESCRIPTION
Compiles in the common CRC code and adds a header.

Tested on an STM32L021