### PR TITLE
Enables DEVICES_DATA per project overrides

### DIFF
--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -22,7 +22,9 @@ $(warning no DEVICE specified for linker script generator)
 endif
 
 LDSCRIPT	= generated.$(DEVICE).ld
+ifeq ($(DEVICES_DATA),)
 DEVICES_DATA = $(OPENCM3_DIR)/ld/devices.data
+endif
 
 genlink_family		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) FAMILY)
 genlink_subfamily	:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) SUBFAMILY)

--- a/scripts/genlink.py
+++ b/scripts/genlink.py
@@ -33,7 +33,7 @@ mode = sys.argv[3].upper()
 
 device = {
     'info': {},
-    'defs': [],
+    'defs': {},
     'family': [],
 }
 
@@ -73,7 +73,8 @@ with open(data_file_path, 'r') as data_file:
                 device['info'][k.lower()] = v
                 continue
 
-            device['defs'].append((k, v))
+            if k not in device['defs']:
+                device['defs'][k] = v
 
         # if parent is +, there's more data for this pattern
         if parent == '+':
@@ -102,8 +103,8 @@ if mode in ('CPPFLAGS', 'DEFS'):
 
 # defines
 if mode == 'DEFS':
-    if len(device['defs']) > 0:
-        defs = ' '.join('-D_%s=%s' % d for d in device['defs'])
+    if device['defs']:
+        defs = ' '.join('-D_{}={}'.format(k, v)for k, v in device['defs'].items())
         sys.stdout.write(' ' + defs)
 
 # device family


### PR DESCRIPTION
- `scripts/genlink.py`:  allows for defines to be overridden, as opposed to just duplicating them.
- `mk/genlink-config.mk`: allows `DEVICES_DATA` to be externally defined.

I tested this at my new project https://github.com/fornellas/3dpkbd2, seems to work. There's `bootloader/` and `keyboard/`: each `Makefile` points to a different device, which translates to different ROM addresses, by using a `custom.devices.data`. It is worth confirming if this change makes sense, as despite the fact that `bootloader.bin` is <1k, the jump to main application only works, if it is offset by 16k from the start of the ROM (fails with anything less).

Closes #1117.