### PR TITLE
stm32: doc fixes.

### DIFF
--- a/include/libopencm3/stm32/common/adc_common_v2.h
+++ b/include/libopencm3/stm32/common/adc_common_v2.h
@@ -35,6 +35,8 @@ specific memorymap.h header before including this header file.*/
 #ifndef LIBOPENCM3_ADC_COMMON_V2_H
 #define LIBOPENCM3_ADC_COMMON_V2_H
 
+/** @defgroup adc_registers ADC registers
+@{*/
 /* ----- ADC registers  -----------------------------------------------------*/
 /** ADC interrupt and status register */
 #define ADC_ISR(adc)		MMIO32((adc) + 0x00)
@@ -56,6 +58,7 @@ specific memorymap.h header before including this header file.*/
 
 /** Common Configuration register */
 #define ADC_CCR(adc)		MMIO32((adc) + 0x300 + 0x8)
+/**@}*/
 
 /* --- Register values -------------------------------------------------------*/
 

--- a/include/libopencm3/stm32/common/adc_common_v2_multi.h
+++ b/include/libopencm3/stm32/common/adc_common_v2_multi.h
@@ -42,6 +42,8 @@ specific memorymap.h header before including this header file.*/
  * or only a much "simpler" version as found on (so far) f0 and l0.
  */
 
+/** @addtogroup adc_registers
+ *@{*/
 /* ----- ADC registers  -----------------------------------------------------*/
 /* Sample Time Register 2 */
 #define ADC_SMPR2(adc)		MMIO32((adc) + 0x18)
@@ -84,6 +86,7 @@ specific memorymap.h header before including this header file.*/
 /* ADC common (shared) registers */
 #define ADC_CSR(adc)		MMIO32((adc) + 0x300 + 0x0)
 #define ADC_CDR(adc)		MMIO32((adc) + 0x300 + 0xc)
+/**@}*/
 
 /* --- Register values ------------------------------------------------------*/
 /* ADC_ISR Values -----------------------------------------------------------*/

--- a/include/libopencm3/stm32/common/adc_common_v2_single.h
+++ b/include/libopencm3/stm32/common/adc_common_v2_single.h
@@ -68,7 +68,7 @@ specific memorymap.h header before including this header file.*/
 /**@}*/
 
 /* ADC_CHSELR Values --------------------------------------------------------*/
-/** @addtogroup adc_chselr
+/** @defgroup adc_chselr CHSELR ADC Channel Selection register
 @{*/
 #define ADC_CHSELR_CHSEL(x)		(1 << (x))
 /**@}*/

--- a/include/libopencm3/stm32/common/adc_common_v2_single.h
+++ b/include/libopencm3/stm32/common/adc_common_v2_single.h
@@ -42,9 +42,12 @@ specific memorymap.h header before including this header file.*/
 #ifndef LIBOPENCM3_ADC_COMMON_V2_SINGLE_H
 #define LIBOPENCM3_ADC_COMMON_V2_SINGLE_H
 
+/** @addtogroup adc_registers
+ *@{*/
 /* ----- ADC registers  -----------------------------------------------------*/
 /** Channel Select Register */
 #define ADC_CHSELR(adc)		MMIO32((adc) + 0x28)
+/**@}*/
 
 /* ----- ADC registers values -----------------------------------------------*/
 /* ADC_CFGR1 values */

--- a/include/libopencm3/stm32/g0/adc.h
+++ b/include/libopencm3/stm32/g0/adc.h
@@ -47,6 +47,8 @@
 #define ADC_CHANNEL_VBAT	14
 /**@}*/
 
+/** @addtogroup adc_registers
+ *@{*/
 /* ----- ADC registers  -----------------------------------------------------*/
 /** ADC_AWD1TR Watchdog 1 Threshold register */
 #define ADC_AWD1TR(adc)		MMIO32((adc) + 0x20)
@@ -65,6 +67,7 @@
 
 /** ADC_OR Option register */
 #define ADC_OR(adc)			MMIO32((adc) + 0xD0)
+/**@}*/
 
 /* --- Register values -------------------------------------------------------*/
 

--- a/include/libopencm3/stm32/g0/adc.h
+++ b/include/libopencm3/stm32/g0/adc.h
@@ -234,7 +234,7 @@
 
 /**@}*/
 
-/** @addtogroup adc_chselr CHSELR ADC Channel Selection register
+/** @addtogroup adc_chselr
 @{*/
 
 /** ADC_CHSELR_MAX_CHANNELS Maximum number of channel in regular sequence */

--- a/include/libopencm3/stm32/g0/flash.h
+++ b/include/libopencm3/stm32/g0/flash.h
@@ -174,8 +174,8 @@
 * @brief Read protection level
 @{*/
 #define FLASH_OPTR_RDP_LEVEL_0		0xAA
-#define FLASH_OPTR_RDP_LEVEL_1		0xBB
-#define FLASH_OPTR_RDP_LEVEL_2		0xCC /* or any other value. */
+#define FLASH_OPTR_RDP_LEVEL_1		0xBB /* or any other value. */
+#define FLASH_OPTR_RDP_LEVEL_2		0xCC
 /**@}*/
 
 BEGIN_DECLS

--- a/include/libopencm3/stm32/g0/rcc.h
+++ b/include/libopencm3/stm32/g0/rcc.h
@@ -33,8 +33,8 @@
 
 #include <libopencm3/stm32/pwr.h>
 
-/* --- RCC registers ------------------------------------------------------- */
-
+/** @defgroup rcc_registers Reset and Clock Control Register
+@{*/
 #define RCC_CR				MMIO32(RCC_BASE + 0x00)
 #define RCC_ICSCR			MMIO32(RCC_BASE + 0x04)
 #define RCC_CFGR			MMIO32(RCC_BASE + 0x08)
@@ -69,11 +69,10 @@
 #define RCC_CCIPR			MMIO32(RCC_BASE + 0x54)
 #define RCC_BDCR			MMIO32(RCC_BASE + 0x5c)
 #define RCC_CSR				MMIO32(RCC_BASE + 0x60)
+/**@}*/
 
-
-
-/* --- RCC_CR values ------------------------------------------------------- */
-
+/** @defgroup rcc_cr CR Clock control Register
+@{*/
 #define RCC_CR_PLLRDY			(1 << 25)
 #define RCC_CR_PLLON			(1 << 24)
 #define RCC_CR_CSSON			(1 << 19)
@@ -100,16 +99,20 @@
 #define RCC_CR_HSIRDY			(1 << 10)
 #define RCC_CR_HSIKERON			(1 << 9)
 #define RCC_CR_HSION			(1 << 8)
+/**@}*/
 
-/* --- RCC_ICSCR values ---------------------------------------------------- */
 
+/** @defgroup rcc_icscr ICSCR Internal Clock Source Calibration Register
+@{*/
 #define RCC_ICSCR_HSITRIM_SHIFT		8
 #define RCC_ICSCR_HSITRIM_MASK		0x1f
 #define RCC_ICSCR_HSICAL_SHIFT		0
 #define RCC_ICSCR_HSICAL_MASK		0xff
+/**@}*/
 
-/* --- RCC_CFGR values ----------------------------------------------------- */
 
+/** @defgroup rcc_cfgr CFGR Configuration Register
+@{*/
 #define RCC_CFGR_MCOPRE_SHIFT	    28
 #define RCC_CFGR_MCOPRE_MASK	    0x7
 /** @defgroup rcc_cfgr_mcopre MCO Pre
@@ -188,7 +191,7 @@
 
 #define RCC_CFGR_SW_MASK			0x3
 #define RCC_CFGR_SW_SHIFT			0
-/** @defgroup rcc_cfgr_sws SW
+/** @defgroup rcc_cfgr_sw SW
  * @brief System clock switch
 @sa rcc_cfgr_sw
 @{*/
@@ -198,9 +201,12 @@
 #define RCC_CFGR_SW_LSI				0x3
 #define RCC_CFGR_SW_LSE				0x4
 /**@}*/
+/**@}*/
 
-/* --- RCC_PLLCFGR - PLL Configuration Register */
 
+
+/** @defgroup rcc_pllcfgr PLLCFGR PLL Configuration Register
+@{*/
 #define RCC_PLLCFGR_PLLR_SHIFT		29
 #define RCC_PLLCFGR_PLLR_MASK		0x7
 /** @defgroup rcc_pllcfgr_pllr PLLR
@@ -260,17 +266,19 @@
 #define RCC_PLLCFGR_PLLSRC_HSI16	2
 #define RCC_PLLCFGR_PLLSRC_HSE		3
 /**@}*/
+/**@}*/
 
-/* --- RCC_CIER - Clock interrupt enable register */
-
+/** @defgroup rcc_cier CIER Clock Interrupt Enable Register
+@{*/
 #define RCC_CIER_PLLRDYIE			(1 << 5)
 #define RCC_CIER_HSERDYIE			(1 << 4)
 #define RCC_CIER_HSIRDYIE			(1 << 3)
 #define RCC_CIER_LSERDYIE			(1 << 1)
 #define RCC_CIER_LSIRDYIE			(1 << 0)
+/**@}*/
 
-/* --- RCC_CIFR - Clock interrupt flag register */
-
+/** @defgroup rcc_cifr CIFR Clock Interrupt Flag Register
+@{*/
 #define RCC_CIFR_LSECSSF			(1 << 9)
 #define RCC_CIFR_CSSF				(1 << 8)
 #define RCC_CIFR_PLLRDYF			(1 << 5)
@@ -278,9 +286,10 @@
 #define RCC_CIFR_HSIRDYF			(1 << 3)
 #define RCC_CIFR_LSERDYF			(1 << 1)
 #define RCC_CIFR_LSIRDYF			(1 << 0)
+/**@}*/
 
-/* --- RCC_CICR - Clock interrupt flag register */
-
+/** @defgroup rcc_cicr CICR Clock Interrupt Clear Register
+@{*/
 #define RCC_CICR_LSECSSC			(1 << 9)
 #define RCC_CICR_CSSC				(1 << 8)
 #define RCC_CICR_PLLRDYC			(1 << 5)
@@ -288,6 +297,7 @@
 #define RCC_CICR_HSIRDYC			(1 << 3)
 #define RCC_CICR_LSERDYC			(1 << 1)
 #define RCC_CICR_LSIRDYC			(1 << 0)
+/**@}*/
 
 /** @defgroup rcc_ahbrstr_rst RCC_AHBRSTR reset values
 @{*/
@@ -388,8 +398,6 @@
 /**@}*/
 /**@}*/
 
-/* --- RCC_AHBSMENR values ------------------------------------------------- */
-
 /** @defgroup rcc_aphbsmenr_en RCC_AHBSMENR enable in sleep/stop mode values
 @{*/
 #define RCC_AHBSMENR_RNGSMEN			(1 << 18)
@@ -399,8 +407,6 @@
 #define RCC_AHBSMENR_FLASHSMEN			(1 << 8)
 #define RCC_AHBSMENR_DMASMEN			(1 << 0)
 /**@}*/
-
-/* --- RCC_APBSMENR1 values ------------------------------------------------- */
 
 /** @defgroup rcc_apbsmenr_en RCC_APBSMENR1 enable in sleep/stop mode values
 @{*/
@@ -427,8 +433,6 @@
 #define RCC_APBSMENR1_TIM2SMEN			(1 << 0)
 /**@}*/
 
-/* --- RCC_APBSMENR2 values ------------------------------------------------- */
-
 /** @defgroup rcc_apbsmenr2_en RCC_APBSMENR2 enable in sleep/stop mode values
 @{*/
 #define RCC_APBSMENR2_ADCSMEN			(1 << 20)
@@ -443,8 +447,9 @@
 #define RCC_APBSMENR2_SYSCFGSMEN		(1 << 0)
 /**@}*/
 
-/* --- RCC_CCIPR - Peripherals independent clock config register ----------- */
 
+/** @defgroup rcc_ccipr CCIPR Peripherals Independent Clock Config Register
+@{*/
 #define RCC_CCIPR_ADCSEL_MASK		0x3
 #define RCC_CCIPR_ADCSEL_SHIFT		30
 /** @defgroup rcc_ccipr_adcsel ADCSEL
@@ -566,9 +571,10 @@
 #define RCC_CCIPR_USART1SEL_HSI16 		2
 #define RCC_CCIPR_USART1SEL_LSE			3
 /**@}*/
+/**@}*/
 
-/* --- RCC_BDCR - PLL Configuration Register */
-
+/** @defgroup rcc_bdcr BDCR Backup Domain Control Register
+@{*/
 #define RCC_BDCR_LSCOSEL		(1 << 25)
 #define RCC_BDCR_LSCOEN			(1 << 24)
 #define RCC_BDCR_BDRST			(1 << 16)
@@ -597,9 +603,10 @@
 #define RCC_BDCR_LSEBYP				(1 << 2)
 #define RCC_BDCR_LSERDY				(1 << 1)
 #define RCC_BDCR_LSEON				(1 << 0)
+/**@}*/
 
-/* --- RCC_CSR - Control/Status register ----------------------------------- */
-
+/** @defgroup rcc_csr CSR Control and Status Register
+@{*/
 #define RCC_CSR_LPWRRSTF			(1 << 31)
 #define RCC_CSR_WWDGRSTF			(1 << 30)
 #define RCC_CSR_IWDGRSTF			(1 << 29)
@@ -610,6 +617,7 @@
 #define RCC_CSR_RMVF				(1 << 23)
 #define RCC_CSR_LSIRDY				(1 << 1)
 #define RCC_CSR_LSION				(1 << 0)
+/**@}*/
 
 /* --- Variable definitions ------------------------------------------------ */
 

--- a/include/libopencm3/stm32/g0/rng.h
+++ b/include/libopencm3/stm32/g0/rng.h
@@ -2,7 +2,7 @@
  *
  * @ingroup STM32G0xx_defines
  *
- * @brief <b>Defined Constants and Types for the STM32G0xx EXTI Control</b>
+ * @brief <b>Defined Constants and Types for the STM32G0xx RNG Control</b>
  *
  * @version 1.0.0
  *

--- a/lib/stm32/common/lptimer_common_all.c
+++ b/lib/stm32/common/lptimer_common_all.c
@@ -176,7 +176,7 @@ void lptimer_set_prescaler(uint32_t lptimer_peripheral, uint32_t prescaler)
 /** @brief Enable lptimer External Trigger
  *
  * @param[in] lptimer_peripheral lptimer base address (@ref lptim_reg_base)
- * @param[in] trigger Trigger selector (@ref lptim_cfgr_trigsel)
+ * @param[in] trigen Enable Trigger
  */
 void lptimer_enable_trigger(uint32_t lptimer_peripheral, uint32_t trigen)
 {
@@ -190,7 +190,7 @@ void lptimer_enable_trigger(uint32_t lptimer_peripheral, uint32_t trigen)
  * Select timer external trigger source.
  *
  * @param[in] lptimer_peripheral lptimer base address (@ref lptim_reg_base)
- * @param[in] trigger Trigger selector (@ref lptim_cfgr_trigsel)
+ * @param[in] trigger_source Trigger selector (@ref lptim_cfgr_trigsel)
  */
 void lptimer_select_trigger_source(uint32_t lptimer_peripheral, uint32_t trigger_source)
 {

--- a/lib/stm32/g0/pwr.c
+++ b/lib/stm32/g0/pwr.c
@@ -3,8 +3,6 @@
  *
  * @author @htmlonly &copy; @endhtmlonly 2019 Guillaume Revaillot <g.revaillot@gmail.com>
  *
- * @ingroup peripheral_apis
- *
  * @brief <b>libopencm3 STM32G0xx Power Control</b>
  *
  * @version 1.0.0


### PR DESCRIPTION
hi,

here's a bunch of patches fixing documentation for stm32 adc and lptimer peripherals, and a couple of fixes/enhancements for g0.