### PR TITLE
Add more USB endpoint defines

### DIFF
--- a/include/libopencm3/usb/usbstd.h
+++ b/include/libopencm3/usb/usbstd.h
@@ -226,6 +226,9 @@ struct usb_endpoint_descriptor {
 /* USB bEndpointAddress helper macros */
 #define USB_ENDPOINT_ADDR_OUT(x) (x)
 #define USB_ENDPOINT_ADDR_IN(x) (0x80 | (x))
+#define USB_ENDPOINT_DIR_OUT (0<<7)
+#define USB_ENDPOINT_DIR_IN (1<<7)
+#define USB_ENDPOINT_ADDR_GEN(direction, number) (direction | (number && 0xF))
 
 /* USB Endpoint Descriptor bmAttributes bit definitions - Table 9-13 */
 /* bits 1..0 : transfer type */


### PR DESCRIPTION
The [USB Endpoint Descriptor](https://www.beyondlogic.org/usbnutshell/usb5.shtml#EndpointDescriptors) `bEndpointAddress` attribute has things encoded in its bits:

> Bits 0..3b Endpoint Number.
> Bits 4..6b Reserved. Set to Zero
> Bits 7 Direction 0 = Out, 1 = In (Ignored for Control Endpoints)

This PR add a macro to allow the definition of the endpoint address using these components. Eg:

```c
#define HID_ENDPOINT_NUMBER 1
#define HID_ENDPOINT_IN_ADDR USB_ENDPOINT_ADDR_GEN(USB_ENDPOINT_DIR_IN, HID_ENDPOINT_NUMBER)
```