### PR TITLE
Allow LDSCRIPT override

### DIFF
--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -21,7 +21,9 @@ ifeq ($(DEVICE),)
 $(warning no DEVICE specified for linker script generator)
 endif
 
+ifeq ($(LDSCRIPT),)
 LDSCRIPT	= generated.$(DEVICE).ld
+endif
 DEVICES_DATA = $(OPENCM3_DIR)/ld/devices.data
 
 genlink_family		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) FAMILY)


### PR DESCRIPTION
I managed to customize `LDSCRIPT` in a hacky way in my [project](https://github.com/fornellas/3dpkbd2/blob/321ef6eafaa3616f3571fdfe88835f5d1c9dac16/common.mk#L14-L20):

```c
ifeq ($(CUSTOM_LDSCRIPT),)
include $(OPENCM3_DIR)/mk/genlink-rules.mk
else
$(LDSCRIPT): $(CUSTOM_LDSCRIPT)
	@printf "  GENLNK  $(DEVICE) ($<)\n"
	$(Q)ln -s $< $@
endif
```

This PR allows `LDSCRIPT` to be externally defined, so people can override it more easily.

Closes #1117 .