### PR TITLE
gadget0: avoid using double to save flash

### DIFF
--- a/tests/gadget-zero/delay.c
+++ b/tests/gadget-zero/delay.c
@@ -33,7 +33,7 @@ void delay_setup(void)
 	/* set up a microsecond free running timer for ... things... */
 	rcc_periph_clock_enable(RCC_TIM6);
 	/* microsecond counter */
-	timer_set_prescaler(TIM6, rcc_apb1_frequency / 1e6 - 1);
+	timer_set_prescaler(TIM6, rcc_apb1_frequency / (int) 1e6 - 1);
 	timer_set_period(TIM6, 0xffff);
 	timer_one_shot_mode(TIM6);
 }


### PR DESCRIPTION
In [the following](https://github.com/libopencm3/libopencm3/blob/master/tests/gadget-zero/delay.c#L36) line of code from the gadget-zero test, the C compiler assumes that 1e6 is a `double`.
```c
	timer_set_prescaler(TIM6, rcc_apb1_frequency / 1e6 - 1);
```
None of the microcontrollers supported by gadget-zero have a double precision FPU so the compiler will add runtime library functions to handle the calculation in software. This can increase the size of the `text` segment quite a bit. For example, for a Cortex-M4F which has a single precision FPU, the compiler will add approximately 2kB of functions and for Cortex-M0+ it will add approximately 4kB of functions.

This can be avoided by casting 1e6 to an int.
```c
	timer_set_prescaler(TIM6, rcc_apb1_frequency / (int) 1e6 - 1);
```
