### PR TITLE
lib: add stm32f103 low density devices

### DIFF
--- a/lib/stm32/f1/stm32f103x4.ld
+++ b/lib/stm32/f1/stm32f103x4.ld
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for STM32F103x4, 16k flash, 6k RAM. */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 16K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 6K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld
+

--- a/lib/stm32/f1/stm32f103x6.ld
+++ b/lib/stm32/f1/stm32f103x6.ld
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for STM32F103x6, 32k flash, 10k RAM. */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 32K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 10K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld
+


### PR DESCRIPTION
Add linker script for stm32f103x4 and stm32f103x6

Signed-off-by: Filipe Laíns <lains@archlinux.org>