### PR TITLE
stm32l4: Fix typo impacting uart4 and uart5

### DIFF
--- a/include/libopencm3/stm32/l4/usart.h
+++ b/include/libopencm3/stm32/l4/usart.h
@@ -37,8 +37,8 @@
 #define USART1				USART1_BASE
 #define USART2				USART2_BASE
 #define USART3				USART3_BASE
-#define UART4				USART4_BASE
-#define UART5				USART5_BASE
+#define UART4				UART4_BASE
+#define UART5				UART5_BASE
 #define LPUART1				LPUART1_BASE
 /**@}*/
 


### PR DESCRIPTION
UART4 and UART5 are mistakenly defined to USART4 and USART5 where it should be UART4 and UART5.