### PR TITLE
Fully const config descriptors

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -96,7 +96,7 @@ extern const usbd_driver lm4f_usb_driver;
  */
 extern usbd_device * usbd_init(const usbd_driver *driver,
 			       const struct usb_device_descriptor *dev,
-			       const struct usb_config_descriptor *conf,
+			       const struct usb_config_descriptor **conf,
 			       const char * const *strings, int num_strings,
 			       uint8_t *control_buffer,
 			       uint16_t control_buffer_size);

--- a/include/libopencm3/usb/usbstd.h
+++ b/include/libopencm3/usb/usbstd.h
@@ -154,16 +154,6 @@ struct usb_device_qualifier_descriptor {
 	uint8_t bReserved;
 } __attribute__((packed));
 
-/* This is only defined as a top level named struct to improve c++
- * compatibility.  You should never need to instance this struct
- * in user code! */
-struct usb_interface {
-	uint8_t *cur_altsetting;
-	uint8_t num_altsetting;
-	const struct usb_iface_assoc_descriptor *iface_assoc;
-	const struct usb_interface_descriptor *altsetting;
-};
-
 /* USB Standard Configuration Descriptor - Table 9-10 */
 struct usb_config_descriptor {
 	uint8_t bLength;
@@ -174,9 +164,6 @@ struct usb_config_descriptor {
 	uint8_t iConfiguration;
 	uint8_t bmAttributes;
 	uint8_t bMaxPower;
-
-	/* Descriptor ends here.  The following are used internally: */
-	const struct usb_interface *interface;
 } __attribute__((packed));
 #define USB_DT_CONFIGURATION_SIZE		9
 
@@ -200,11 +187,6 @@ struct usb_interface_descriptor {
 	uint8_t bInterfaceSubClass;
 	uint8_t bInterfaceProtocol;
 	uint8_t iInterface;
-
-	/* Descriptor ends here.  The following are used internally: */
-	const struct usb_endpoint_descriptor *endpoint;
-	const void *extra;
-	int extralen;
 } __attribute__((packed));
 #define USB_DT_INTERFACE_SIZE			9
 
@@ -216,10 +198,6 @@ struct usb_endpoint_descriptor {
 	uint8_t bmAttributes;
 	uint16_t wMaxPacketSize;
 	uint8_t bInterval;
-
-	/* Descriptor ends here.  The following are used internally: */
-	const void *extra;
-	int extralen;
 } __attribute__((packed));
 #define USB_DT_ENDPOINT_SIZE		7
 

--- a/lib/usb/usb.c
+++ b/lib/usb/usb.c
@@ -41,7 +41,7 @@ LGPL License Terms @ref lgpl_license
 
 usbd_device *usbd_init(const usbd_driver *driver,
 		       const struct usb_device_descriptor *dev,
-		       const struct usb_config_descriptor *conf,
+		       const struct usb_config_descriptor **conf,
 		       const char * const *strings, int num_strings,
 		       uint8_t *control_buffer, uint16_t control_buffer_size)
 {

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -43,10 +43,25 @@ LGPL License Terms @ref lgpl_license
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
+/**
+ * Maximum number of interface for memory to allocate.
+ * The allocated memory is used keep track of the SET_INTERFACE setting
+ * If the value is 0, no memory is allocated
+ *
+ * @note If a value could not be stored
+ *  (due to no memory allocated OR allocate memory not enought to store the value),
+ * then the following behavour apply:
+ *  - SET_INTEFACE for other than alternate-setting = 0 will always result in STALL.
+ *  - GET_INTEFACE will always result in STALL
+ */
+#if !defined(USBD_INTERFACE_MAX)
+# define USBD_INTERFACE_MAX 8
+#endif
+
 /** Internal collection of device information. */
 struct _usbd_device {
 	const struct usb_device_descriptor *desc;
-	const struct usb_config_descriptor *config;
+	const struct usb_config_descriptor **config;
 	const char * const *strings;
 	int num_strings;
 
@@ -57,6 +72,8 @@ struct _usbd_device {
 	uint8_t current_config;
 
 	uint16_t pm_top;    /**< Top of allocated endpoint buffer memory */
+
+	const struct usb_interface_descriptor *current_iface[USBD_INTERFACE_MAX];
 
 	/* User callback functions for various USB events */
 	void (*user_callback_reset)(void);


### PR DESCRIPTION
I hope I'm doing this right, it wouldn't let me choose a new branch, so I chose master.

This implements the const USB descriptor support (fully in ROM).

gadget0 is also updated to use those.

Note that two of the gadget0 tests fail, but they failed before my fork so I believe it works fine.

Some careful inspection needs to be taken when it's going through the descriptors, I believe it should be fine, but there is a chance it will overrun.