### PR TITLE
stm32g0: use spi v2

### DIFF
--- a/include/libopencm3/stm32/g0/spi.h
+++ b/include/libopencm3/stm32/g0/spi.h
@@ -29,6 +29,6 @@
 #define LIBOPENCM3_SPI_H
 
 #include <libopencm3/stm32/common/spi_common_all.h>
-#include <libopencm3/stm32/common/spi_common_v1_frf.h>
+#include <libopencm3/stm32/common/spi_common_v2.h>
 
 #endif

--- a/lib/stm32/g0/Makefile
+++ b/lib/stm32/g0/Makefile
@@ -39,14 +39,14 @@ OBJS += dma_common_l1f013.o
 OBJS += dmamux.o
 OBJS += exti.o exti_common_all.o
 OBJS += flash.o flash_common_all.o
-OBJS += gpio_common_all.o gpio_common_f0234.o 
+OBJS += gpio_common_all.o gpio_common_f0234.o
 OBJS += i2c_common_v2.o
 OBJS += iwdg_common_all.o
 OBJS += lptimer_common_all.o
 OBJS += pwr.o
 OBJS += rcc.o rcc_common_all.o
 OBJS += rng_common_v1.o
-OBJS += spi_common_all.o spi_common_v1.o spi_common_v1_frf.o
+OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o
 OBJS += usart_common_all.o usart_common_v2.o
 


### PR DESCRIPTION
Seems like the STM32G0 family uses the new SPI version.