### PR TITLE
avoid creating blank linker script if gcc fails

### DIFF
--- a/lib/stm32/common/st_usbfs_core.c
+++ b/lib/stm32/common/st_usbfs_core.c
@@ -252,7 +252,6 @@ void st_usbfs_poll(usbd_device *dev)
 			/* OUT or SETUP? */
 			if (*USB_EP_REG(ep) & USB_EP_SETUP) {
 				type = USB_TRANSACTION_SETUP;
-				st_usbfs_ep_read_packet(dev, ep, &dev->control_state.req, 8);
 			} else {
 				type = USB_TRANSACTION_OUT;
 			}

--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -228,6 +228,11 @@ void _usbd_control_setup(usbd_device *usbd_dev, uint8_t ea)
 
 	usbd_ep_nak_set(usbd_dev, 0, 1);
 
+	if (usbd_ep_read_packet(usbd_dev, 0, req, 8) != 8) {
+		stall_transaction(usbd_dev);
+		return;
+	}
+
 	if (req->wLength == 0) {
 		usb_control_setup_read(usbd_dev, req);
 	} else if (req->bmRequestType & 0x80) {

--- a/lib/usb/usb_dwc_common.c
+++ b/lib/usb/usb_dwc_common.c
@@ -358,11 +358,6 @@ void dwc_poll(usbd_device *usbd_dev)
 		uint32_t rxstsp = REBASE(OTG_GRXSTSP);
 		uint32_t pktsts = rxstsp & OTG_GRXSTSP_PKTSTS_MASK;
 		uint8_t ep = rxstsp & OTG_GRXSTSP_EPNUM_MASK;
-
-		if (pktsts == OTG_GRXSTSP_PKTSTS_SETUP_COMP) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_SETUP] (usbd_dev, ep);
-		}
-
 		if (pktsts == OTG_GRXSTSP_PKTSTS_OUT_COMP
 			|| pktsts == OTG_GRXSTSP_PKTSTS_SETUP_COMP)  {
 			REBASE(OTG_DOEPTSIZ(ep)) = usbd_dev->doeptsiz[ep];
@@ -395,9 +390,7 @@ void dwc_poll(usbd_device *usbd_dev)
 		/* Save packet size for dwc_ep_read_packet(). */
 		usbd_dev->rxbcnt = (rxstsp & OTG_GRXSTSP_BCNT_MASK) >> 4;
 
-		if (type == USB_TRANSACTION_SETUP) {
-			dwc_ep_read_packet(usbd_dev, ep, &usbd_dev->control_state.req, 8);
-		} else if (usbd_dev->user_callback_ctr[ep][type]) {
+		if (usbd_dev->user_callback_ctr[ep][type]) {
 			usbd_dev->user_callback_ctr[ep][type] (usbd_dev, ep);
 		}
 

--- a/lib/usb/usb_lm4f.c
+++ b/lib/usb/usb_lm4f.c
@@ -503,9 +503,7 @@ static void lm4f_poll(usbd_device *usbd_dev)
 				usbd_dev->control_state.state != LAST_DATA_OUT)
 				? USB_TRANSACTION_SETUP :
 				  USB_TRANSACTION_OUT;
-			if (type == USB_TRANSACTION_SETUP) {
-				lm4f_ep_read_packet(usbd_dev, 0, &usbd_dev->control_state.req, 8);
-			}
+
 			if (usbd_dev->user_callback_ctr[0][type]) {
 				usbd_dev->
 					user_callback_ctr[0][type](usbd_dev, 0);

--- a/mk/genlink-rules.mk
+++ b/mk/genlink-rules.mk
@@ -19,4 +19,4 @@
 
 $(LDSCRIPT): $(OPENCM3_DIR)/ld/linker.ld.S $(OPENCM3_DIR)/ld/devices.data
 	@printf "  GENLNK  $(DEVICE)\n"
-	$(Q)$(CPP) $(ARCH_FLAGS) $(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) DEFS) -P -E $< > $@
+	$(Q)$(CPP) $(ARCH_FLAGS) $(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) DEFS) -P -E $< -o $@


### PR DESCRIPTION
When piping to a file, if arm-none-eabi-gcc is not present in the path,
a blank linker script is created with genlink. After sourcing a bash
script to add GCC to the path, the linker script doesn't get rebuilt
due to a fresh timestamp despite failing to generate.

It may be possible that old GCCs didn't support the -o option here?