### PR TITLE
avoid creating blank linker script if gcc fails

### DIFF
--- a/mk/genlink-rules.mk
+++ b/mk/genlink-rules.mk
@@ -19,4 +19,4 @@
 
 $(LDSCRIPT): $(OPENCM3_DIR)/ld/linker.ld.S $(OPENCM3_DIR)/ld/devices.data
 	@printf "  GENLNK  $(DEVICE)\n"
-	$(Q)$(CPP) $(ARCH_FLAGS) $(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) DEFS) -P -E $< > $@
+	$(Q)$(CPP) $(ARCH_FLAGS) $(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) DEFS) -P -E $< -o $@


### PR DESCRIPTION
Redo of #1147 on correct branch

When piping to a file, if arm-none-eabi-gcc is not present in the path,
a blank linker script is created with genlink. After sourcing a bash
script to add GCC to the path, the linker script doesn't get rebuilt
due to a fresh timestamp despite failing to generate.

It may be possible that old GCCs didn't support the -o option here?