### PR TITLE
Enable PWREN bit

### DIFF
--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -722,7 +722,7 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 	}
 
 	/* Set the VOS scale mode */
-	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_PWR);
+	rcc_periph_clock_enable(RCC_PWR);
 	pwr_set_vos_scale(clock->voltage_scale);
 
 	/*


### PR DESCRIPTION
Original "**rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_PWR)** " insert PWR register value into APB1ENR where enable different peripherials.
In my case (STM32F407): TIM4, TIM5, TIM6 and WWDG