### PR TITLE
RCC improvements for STM32

### DIFF
--- a/include/libopencm3/stm32/f1/rcc.h
+++ b/include/libopencm3/stm32/f1/rcc.h
@@ -714,6 +714,7 @@ void rcc_clock_setup_in_hsi_out_48mhz(void);
 void rcc_clock_setup_in_hsi_out_24mhz(void);
 void rcc_clock_setup_in_hse_8mhz_out_24mhz(void);
 void rcc_clock_setup_in_hse_8mhz_out_72mhz(void);
+void rcc_clock_setup_in_hse_8mhz_out_72mhz_adc_12mhz(void);
 void rcc_clock_setup_in_hse_12mhz_out_72mhz(void);
 void rcc_clock_setup_in_hse_16mhz_out_72mhz(void);
 void rcc_clock_setup_in_hse_25mhz_out_72mhz(void);

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -628,7 +628,7 @@ void rcc_clock_setup_in_hsi_out_64mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);   /* Set. 64MHz Max. 72MHz */
@@ -681,7 +681,7 @@ void rcc_clock_setup_in_hsi_out_48mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);	/*Set.48MHz Max.72MHz */
@@ -735,7 +735,7 @@ void rcc_clock_setup_in_hsi_out_24mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV); /* Set. 24MHz Max. 24MHz */
@@ -793,7 +793,7 @@ void rcc_clock_setup_in_hse_8mhz_out_24mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);    /* Set. 24MHz Max. 72MHz */
@@ -857,7 +857,7 @@ void rcc_clock_setup_in_hse_8mhz_out_72mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);    /* Set. 72MHz Max. 72MHz */
@@ -921,7 +921,7 @@ void rcc_clock_setup_in_hse_12mhz_out_72mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);    /* Set. 72MHz Max. 72MHz */
@@ -985,7 +985,7 @@ void rcc_clock_setup_in_hse_16mhz_out_72mhz(void)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);    /* Set. 72MHz Max. 72MHz */
@@ -1050,7 +1050,7 @@ void rcc_clock_setup_in_hse_25mhz_out_72mhz(void)
 	flash_set_ws(FLASH_ACR_LATENCY_2WS);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);    /* Set. 72MHz Max. 72MHz */

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -902,6 +902,70 @@ void rcc_clock_setup_in_hse_8mhz_out_72mhz(void)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief RCC Set System Clock PLL at 72MHz (ADC at 12MHz) from HSE at 8MHz
+
+*/
+
+void rcc_clock_setup_in_hse_8mhz_out_72mhz_adc_12mhz(void)
+{
+	/* Enable internal high-speed oscillator. */
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
+
+	/* Enable external high-speed oscillator 8MHz. */
+	rcc_osc_on(RCC_HSE);
+	rcc_wait_for_osc_ready(RCC_HSE);
+	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSECLK);
+
+	/*
+	 * Set prescalers for AHB, ADC, APB1, APB2.
+	 * Do this before touching the PLL (TODO: why?).
+	 */
+	rcc_set_hpre(RCC_CFGR_HPRE_SYSCLK_NODIV);    /* Set. 72MHz Max. 72MHz */
+	rcc_set_adcpre(RCC_CFGR_ADCPRE_PCLK2_DIV6);  /* Set. 12MHz Max. 14MHz */
+	rcc_set_ppre1(RCC_CFGR_PPRE1_HCLK_DIV2);     /* Set. 36MHz Max. 36MHz */
+	rcc_set_ppre2(RCC_CFGR_PPRE2_HCLK_NODIV);    /* Set. 72MHz Max. 72MHz */
+
+	/*
+	 * Sysclk runs with 72MHz -> 2 waitstates.
+	 * 0WS from 0-24MHz
+	 * 1WS from 24-48MHz
+	 * 2WS from 48-72MHz
+	 */
+	flash_set_ws(FLASH_ACR_LATENCY_2WS);
+
+	/*
+	 * Set the PLL multiplication factor to 9.
+	 * 8MHz (external) * 9 (multiplier) = 72MHz
+	 */
+	rcc_set_pll_multiplication_factor(RCC_CFGR_PLLMUL_PLL_CLK_MUL9);
+
+	/* Select HSE as PLL source. */
+	rcc_set_pll_source(RCC_CFGR_PLLSRC_HSE_CLK);
+
+	/*
+	 * External frequency undivided before entering PLL
+	 * (only valid/needed for HSE).
+	 */
+	rcc_set_pllxtpre(RCC_CFGR_PLLXTPRE_HSE_CLK);
+
+	/* Enable PLL oscillator and wait for it to stabilize. */
+	rcc_osc_on(RCC_PLL);
+	rcc_wait_for_osc_ready(RCC_PLL);
+
+	/* Select PLL as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_PLLCLK);
+
+	/* Set the peripheral clock frequencies used */
+	rcc_ahb_frequency = 72000000;
+	rcc_apb1_frequency = 36000000;
+	rcc_apb2_frequency = 72000000;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief RCC Set System Clock PLL at 72MHz from HSE at 12MHz
 
 */

--- a/lib/stm32/f2/rcc.c
+++ b/lib/stm32/f2/rcc.c
@@ -348,7 +348,7 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	rcc_wait_for_osc_ready(RCC_HSE);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(clock->hpre);

--- a/lib/stm32/f3/rcc.c
+++ b/lib/stm32/f3/rcc.c
@@ -418,7 +418,7 @@ void __attribute__((deprecated)) rcc_clock_setup_hsi(const struct rcc_clock_scal
 	rcc_osc_on(RCC_PLL);
 	rcc_wait_for_osc_ready(RCC_PLL);
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(clock->hpre);

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -726,7 +726,7 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 	pwr_set_vos_scale(clock->voltage_scale);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(clock->hpre);

--- a/lib/stm32/f7/rcc.c
+++ b/lib/stm32/f7/rcc.c
@@ -396,7 +396,7 @@ void rcc_clock_setup_hse(const struct rcc_clock_scale *clock, uint32_t hse_mhz)
 	}
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(clock->hpre);
@@ -453,7 +453,7 @@ void rcc_clock_setup_hsi(const struct rcc_clock_scale *clock)
 	}
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(clock->hpre);

--- a/lib/stm32/l1/rcc.c
+++ b/lib/stm32/l1/rcc.c
@@ -439,7 +439,7 @@ void rcc_clock_setup_msi(const struct rcc_clock_scale *clock)
 	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_MSICLK);
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(clock->hpre);
@@ -520,7 +520,7 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 	}
 
 	/*
-	 * Set prescalers for AHB, ADC, ABP1, ABP2.
+	 * Set prescalers for AHB, ADC, APB1, APB2.
 	 * Do this before touching the PLL (TODO: why?).
 	 */
 	rcc_set_hpre(clock->hpre);


### PR DESCRIPTION
This patch series introduces next changes:

1. When working on my pet project, I had to copy-paste the rcc_clock_setup_in_hse_8mhz_out_72mhz() function and change ADC divisor to DIV6, in order to achieve max ADC clock frequency. As original rcc_clock_setup_in_hse_8mhz_out_72mhz() function can change in upstream, I'll need to track those changes and fix my internal function correspondingly, so it can be considered a bad practice. Better idea is to have such a function in upstream libopencm3, so everyone can call it directly.

2. Another thing I noticed along the way is a type (ABP -> APB) in mentioned function. So I fixed it tree-wide as well.