### PR TITLE
Add USB_CLASS_DFU

### DIFF
--- a/include/libopencm3/usb/dfu.h
+++ b/include/libopencm3/usb/dfu.h
@@ -38,6 +38,8 @@ LGPL License Terms @ref lgpl_license
 #ifndef __DFU_H
 #define __DFU_H
 
+#define USB_CLASS_DFU 0xFE
+
 enum dfu_req {
 	DFU_DETACH,
 	DFU_DNLOAD,


### PR DESCRIPTION
Add `USB_CLASS_DFU` from [USB DFU 1.1 at 4.2.3](https://www.usb.org/sites/default/files/DFU_1.1.pdf).