### PR TITLE
Update Makefile.include

### DIFF
--- a/lib/Makefile.include
+++ b/lib/Makefile.include
@@ -34,7 +34,8 @@ all: $(SRCLIBDIR)/$(LIBNAME).a
 
 $(SRCLIBDIR)/$(LIBNAME).a: $(OBJS)
 	@printf "  AR      $(LIBNAME).a\n"
-	$(Q)$(AR) $(ARFLAGS) "$@" $(OBJS)
+	#$(Q)$(AR) $(ARFLAGS) "$@" $(OBJS)
+	$(Q)$(AR) $(ARFLAGS) $(LIBNAME).a $(OBJS)
 
 %.o: %.c
 	@printf "  CC      $(<F)\n"


### PR DESCRIPTION
Hi!
When I try to build Bootloader through the PX4 Toolchain on the command line through the 'make' or "make px4fmuv5_bl" commands, the compiler throws an error "cannot find -lopencm3_stm32f4"
I solved this problem by editing the Make files. I wonder how Bootloader generally compiles if there are a lot of errors in Make files.
In the file ... \ Bootloader \ libopencm3 \ lib \ Make.include, you need to fix the location of the library files and their extension. After attempting to compile, library files of the * .a type are compiled