### PR TITLE
stm32: adc-v2: add adc_{en,dis}able_delayed_conversion_mode

### DIFF
--- a/include/libopencm3/stm32/common/adc_common_v2.h
+++ b/include/libopencm3/stm32/common/adc_common_v2.h
@@ -253,6 +253,8 @@ uint32_t adc_read_regular(uint32_t adc);
 void adc_start_conversion_regular(uint32_t adc);
 void adc_enable_dma_circular_mode(uint32_t adc);
 void adc_disable_dma_circular_mode(uint32_t adc);
+void adc_enable_delayed_conversion_mode(uint32_t adc);
+void adc_disable_delayed_conversion_mode(uint32_t adc);
 END_DECLS
 
 #endif

--- a/lib/stm32/common/adc_common_v2.c
+++ b/lib/stm32/common/adc_common_v2.c
@@ -409,4 +409,30 @@ void adc_disable_dma_circular_mode(uint32_t adc)
 	ADC_CFGR1(adc) &= ~ADC_CFGR1_DMACFG;
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief ADC Enable Delayed Conversion Mode
+ *
+ * @param[in] adc Unsigned int32. ADC block register address base @ref
+ * adc_reg_base
+ */
+
+void
+adc_enable_delayed_conversion_mode(uint32_t adc)
+{
+	ADC_CFGR1(adc) |= ADC_CFGR1_AUTDLY;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief ADC Enable Delayed Conversion Mode
+ *
+ * @param[in] adc Unsigned int32. ADC block register address base @ref
+ * adc_reg_base
+ */
+
+void
+adc_disable_delayed_conversion_mode(uint32_t adc)
+{
+	ADC_CFGR1(adc) &= ~ADC_CFGR1_AUTDLY;
+}
+
 /**@}*/


### PR DESCRIPTION
To control AUTODELAY feature of the ADC.