### PR TITLE
pac55xx: fixing gpio alternate function settings.

### DIFF
--- a/include/libopencm3/pac55xx/ccs.h
+++ b/include/libopencm3/pac55xx/ccs.h
@@ -65,6 +65,9 @@
 #define CCS_PFMUXSELR CCS_MUXSELR(CCS_PORTF)
 #define CCS_PGMUXSELR CCS_MUXSELR(CCS_PORTG)
 #define CCS_MUXSELR_MASK 0x7
+#define CCS_MUXSELR_MASK_PIN(pin) (CCS_MUXSELR_MASK << ((pin) * 4))
+#define CCS_MUXSELR_VAL(pin, muxsel) (((muxsel) & CCS_MUXSELR_MASK) << ((pin) * 4))
+
 /* Enum type for port function setting for type specificity. */
 typedef enum {
 	CCS_MUXSEL_GPIO = 0,
@@ -117,7 +120,7 @@ typedef enum {
 #define CCS_PFDSR CCS_DSR(CCS_PORTF)
 #define CCS_PGDSR CCS_DSR(CCS_PORTG)
 #define CCS_DSR_MASK 0x7
-#define CCS_DSR_MASK_PIN(pin) (CCS_DSR_MASK << ((pin)) * 4)
+#define CCS_DSR_MASK_PIN(pin) (CCS_DSR_MASK << ((pin) * 4))
 #define CCS_DSR_DS_VAL(pin, ds) (((ds)&CCS_DSR_MASK) << ((pin)*4))
 #define CCS_DSR_SCHMIDT_PIN(pin) (BIT0 << (((pin)*4) + 3))
 

--- a/lib/pac55xx/gpio.c
+++ b/lib/pac55xx/gpio.c
@@ -110,10 +110,9 @@ void gpio_set_af(uint32_t gpioport, ccs_muxsel_func_t muxsel, uint16_t gpios) {
 	int ffs = __builtin_ffs(gpios);
 	while (ffs) {
 		const int pin = ffs - 1;
-		const int shift = pin * 4;
 
-		reg &= CCS_MUXSELR_MASK << shift;
-		reg |= muxsel << shift;
+		reg &= ~CCS_MUXSELR_MASK_PIN(pin);
+		reg |= CCS_MUXSELR_VAL(pin, muxsel);
 
 		/* Set the pinmux configurations for the pull-up / pull-down. */
 		gpios ^= (1 << pin); /* Clear the bit we just serviced. */


### PR DESCRIPTION
pac55xx: fixing gpio_set_af for pin alternate function settings. register bits were not cleared before setting. refactored to be similar to how the drive strength register is being set.