### PR TITLE
stm32h7: fix inverted VOS settings for Vcore.

### DIFF
--- a/include/libopencm3/stm32/h7/pwr.h
+++ b/include/libopencm3/stm32/h7/pwr.h
@@ -88,9 +88,9 @@ LGPL License Terms @ref lgpl_license
 #define PWR_D3CR_VOS_SHIFT        14
 #define PWR_D3CR_VOSRDY           BIT13
 
-#define PWR_D3CR_VOS_SCALE_3      (0x3)
+#define PWR_D3CR_VOS_SCALE_3      (0x1)
 #define PWR_D3CR_VOS_SCALE_2      (0x2)
-#define PWR_D3CR_VOS_SCALE_1      (0x1)
+#define PWR_D3CR_VOS_SCALE_1      (0x3)
 #define PWR_D3CR_VOS_MASK         (0x03)
 
 enum pwr_svos_scale {


### PR DESCRIPTION
The scaling values for Vcore were flipped, which caused the MCU to not run reliably at higher frequencies. With this fix, the system is now running happily at the full 480MHz rated frequency.