### PR TITLE
stm32h7: added minimal stm32h7 exti defs, which share with G0.

### DIFF
--- a/include/libopencm3/stm32/common/exti_common_v2.h
+++ b/include/libopencm3/stm32/common/exti_common_v2.h
@@ -44,17 +44,6 @@
 
 /** EXTI Software Interrupt Event Register */
 #define EXTI_SWIER1			MMIO32(EXTI_BASE + 0x08)
-/** EXTI Rising Edge Pending Register */
-#define EXTI_RPR1			MMIO32(EXTI_BASE + 0x0c)
-/** EXTI Falling Edge Pending Register */
-#define EXTI_FPR1			MMIO32(EXTI_BASE + 0x10)
-
-/** EXTI External Interrupt Selection Registers */
-#define EXTI_EXTICR(i)		MMIO32(EXTI_BASE + 0x60 + (i)*4)
-#define EXTI_EXTICR1		MMIO32(EXTI_BASE + 0x60)
-#define EXTI_EXTICR2		MMIO32(EXTI_BASE + 0x64)
-#define EXTI_EXTICR3		MMIO32(EXTI_BASE + 0x68)
-#define EXTI_EXTICR4		MMIO32(EXTI_BASE + 0x6c)
 
 /** EXTI Interrupt Mask Registers 1 */
 #define EXTI_IMR1			MMIO32(EXTI_BASE + 0x80)

--- a/include/libopencm3/stm32/exti.h
+++ b/include/libopencm3/stm32/exti.h
@@ -42,6 +42,8 @@
 #       include <libopencm3/stm32/l4/exti.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/exti.h>
+#elif defined(STM32H7)
+#       include <libopencm3/stm32/h7/exti.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/h7/exti.h
+++ b/include/libopencm3/stm32/h7/exti.h
@@ -1,8 +1,8 @@
 /** @defgroup exti_defines EXTI Defines
  *
- * @ingroup STM32G0xx_defines
+ * @ingroup STM32H7xx_defines
  *
- * @brief <b>Defined Constants and Types for the STM32G0xx EXTI Control</b>
+ * @brief <b>Defined Constants and Types for the STM32H7xx EXTI Control</b>
  *
  * @version 1.0.0
  *
@@ -24,7 +24,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 /**@{*/
 #ifndef LIBOPENCM3_EXTI_H
 #define LIBOPENCM3_EXTI_H
@@ -32,26 +31,13 @@
 #include <libopencm3/stm32/common/exti_common_all.h>
 #include <libopencm3/stm32/common/exti_common_v2.h>
 
-/** EXTI External Interrupt Selection Registers */
-#define EXTI_EXTICR(i)    MMIO32(EXTI_BASE + 0x60 + (i)*4)
-#define EXTI_EXTICR1    MMIO32(EXTI_BASE + 0x60)
-#define EXTI_EXTICR2    MMIO32(EXTI_BASE + 0x64)
-#define EXTI_EXTICR3    MMIO32(EXTI_BASE + 0x68)
-#define EXTI_EXTICR4    MMIO32(EXTI_BASE + 0x6c)
-
-/** EXTI Rising Edge Pending Register */
-#define EXTI_RPR1     MMIO32(EXTI_BASE + 0x0c)
-/** EXTI Falling Edge Pending Register */
-#define EXTI_FPR1     MMIO32(EXTI_BASE + 0x10)
+/** EXTI CPU Event Pending Register 1 */
+#define EXTI_CPUPR1	MMIO32(EXTI_BASE + 0x88)
+#define EXTI_PR 	EXTI_CPUPR1
 
 BEGIN_DECLS
 
 END_DECLS
 
-#else
-/** @cond */
-#warning "exti_common_v1.h should not be included directly, only via exti.h"
-#endif
-/** @endcond */
-
+#endif  /* LIBOPENCM3_EXTI_H */
 /**@}*/

--- a/include/libopencm3/stm32/h7/syscfg.h
+++ b/include/libopencm3/stm32/h7/syscfg.h
@@ -37,6 +37,7 @@
 /**@defgroup syscfg_registers SYSCFG Registers
 ￼  @{*/
 #define SYSCFG_PMCR				MMIO32(SYSCFG_BASE + 0x04)
+#define SYSCFG_EXTICR(i)			MMIO32(SYSCFG_BASE + 0x08 + (i)*4)
 #define SYSCFG_EXTICR1			MMIO32(SYSCFG_BASE + 0x08)
 #define SYSCFG_EXTICR2			MMIO32(SYSCFG_BASE + 0x0C)
 #define SYSCFG_EXTICR3			MMIO32(SYSCFG_BASE + 0x10)
@@ -48,7 +49,11 @@
 #define SYSCFG_PWRCR				MMIO32(SYSCFG_BASE + 0x2C)
 #define SYSCFG_PKGR				MMIO32(SYSCFG_BASE + 0x124)
 #define SYSCFG_UR(n)      MMIO32(SYSCFG_BASE + 0x300 + (4 * (n)))
+
+#define SYSCFG_EXTICR_FIELDSIZE		4
 /**@}*/
+
+
 
 /** @defgroup syscfg_pwrcr PWRCR SYSCFG configuration register
  * @ingroup syscfg_registers

--- a/lib/stm32/h7/Makefile
+++ b/lib/stm32/h7/Makefile
@@ -38,6 +38,7 @@ TGT_CFLAGS	+= $(STANDARD_FLAGS)
 ARFLAGS		= rcs
 
 OBJS += dac_common_all.o
+OBJS += exti_common_all.o
 OBJS += flash_common_all.o flash_common_f.o flash_common_f24.o
 OBJS += fmc_common_f47.o
 OBJS += gpio_common_all.o gpio_common_f0234.o


### PR DESCRIPTION
Separated definitions that did not seem consistent between the "v2" EXTI platforms. Added SYSCFG defs needed for EXTICR settings.