### PR TITLE
Update comments and fix discrepancies in generic Cortex-M linker script

### DIFF
--- a/lib/cortex-m-generic.ld
+++ b/lib/cortex-m-generic.ld
@@ -112,4 +112,3 @@ SECTIONS
 
 /* Point to the very end of the RAM. */
 PROVIDE(_stack = ORIGIN(ram) + LENGTH(ram));
-

--- a/lib/cortex-m-generic.ld
+++ b/lib/cortex-m-generic.ld
@@ -43,15 +43,15 @@ ENTRY(reset_handler)
 SECTIONS
 {
 	.text : {
-		*(.vectors)	/* Vector table */
-		*(.text*)	/* Program code */
+		*(.vectors)	/* Vector table. */
+		*(.text*)	/* Program code. */
 		. = ALIGN(4);
-		*(.rodata*)	/* Read-only data */
+		*(.rodata*)	/* Read-only data. */
 		. = ALIGN(4);
 	} >rom
 
 	/* C++ Static constructors/destructors, also used for __attribute__
-	 * ((constructor)) and the likes */
+	 * ((constructor)) and the likes. */
 	.preinit_array : {
 		. = ALIGN(4);
 		__preinit_array_start = .;
@@ -73,10 +73,8 @@ SECTIONS
 		__fini_array_end = .;
 	} >rom
 
-	/*
-	 * Another section used by C++ stuff, appears when using newlib with
-	 * 64bit (long long) printf support
-	 */
+	/* Another section used by C++ stuff, appears when using newlib with
+	 * 64bit (long long) printf support. */
 	.ARM.extab : {
 		*(.ARM.extab*)
 	} >rom
@@ -91,28 +89,27 @@ SECTIONS
 
 	.data : {
 		_data = .;
-		*(.data*)	/* Read-write initialized data */
+		*(.data*)	/* Read-write initialized data. */
 		. = ALIGN(4);
 		_edata = .;
 	} >ram AT >rom
 	_data_loadaddr = LOADADDR(.data);
 
 	.bss : {
-		*(.bss*)	/* Read-write zero initialized data */
+		*(.bss*)	/* Read-write zero initialized data. */
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = .;
 	} >ram
 
-	/*
-	 * The .eh_frame section appears to be used for C++ exception handling.
-	 * You may need to fix this if you're using C++.
-	 */
+	/* The .eh_frame section appears to be used for C++ exception handling.
+	 * You may need to fix this if you're using C++. */
 	/DISCARD/ : { *(.eh_frame) }
 
 	. = ALIGN(4);
 	end = .;
 }
 
+/* Point to the very end of the RAM. */
 PROVIDE(_stack = ORIGIN(ram) + LENGTH(ram));
 

--- a/lib/cortex-m-generic.ld
+++ b/lib/cortex-m-generic.ld
@@ -33,7 +33,7 @@ INCLUDE cortex-m-generic.ld
 
 */
 
-/* Enforce emmition of the vector table. */
+/* Enforce visibility of the vector table. */
 EXTERN (vector_table)
 
 /* Define the entry point of the output file. */


### PR DESCRIPTION
Hi,

First, thanks for the great work! It is very much appreciated.

While using the `lib/cortex-m-generic.ld` for bare-metal ARM programming I noticed a few discrepancies in the comments layout. I appreciate to have relevant code blocks commented as a separation between them. I took the liberty to remove the extra empty line at the end of the linker script.

Hope this helps,
Cheers