### PR TITLE
Fix for 'flash config set twice' #1014.

### DIFF
--- a/lib/stm32/common/flash_common_all.c
+++ b/lib/stm32/common/flash_common_all.c
@@ -39,7 +39,7 @@ void flash_set_ws(uint32_t ws)
 
 	reg32 = FLASH_ACR;
 	reg32 &= ~(FLASH_ACR_LATENCY_MASK << FLASH_ACR_LATENCY_SHIFT);
-	reg32 |= (ws << FLASH_ACR_LATENCY_SHIFT);
+	reg32 |= (FLASH_ACR_LATENCY_MASK & ws) << FLASH_ACR_LATENCY_SHIFT;
 	FLASH_ACR = reg32;
 }
 

--- a/lib/stm32/f2/rcc.c
+++ b/lib/stm32/f2/rcc.c
@@ -367,6 +367,16 @@ void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock)
 	rcc_wait_for_osc_ready(RCC_PLL);
 
 	/* Configure flash settings. */
+	if (clock->flash_config & FLASH_ACR_DCEN) {
+		flash_dcache_enable();
+	} else {
+		flash_dcache_disable();
+	}
+	if (clock->flash_config & FLASH_ACR_ICEN) {
+		flash_icache_enable();
+	} else {
+		flash_icache_disable();
+	}
 	flash_set_ws(clock->flash_config);
 
 	/* Select PLL as SYSCLK source. */


### PR DESCRIPTION
The flash_set_ws() function didn't mask its input and it was possible
to set more bits in the FLASH_ACR register, than just the waitstate
bits. This caused the stm32f4 code to set the FLASH_ACR_DCEN and
FLASH_ACR_ICEN registers twice: Once before calling flash_set_ws() and
once inside flash_set_ws().

Once flash_set_ws() was changed to only set the waitstate bits of the
FLASH_ACR register, the rcc_clock_setup_hse_3v3() function for stm32f2
processors had to be modified to set/clear the FLASH_ACR_DCEN and
FLASH_ACR_ICEN registers, as it previously relied on the
flash_set_ws() function to do this.

The only processors that were affected by this feature and fix, was
the stm32f2 and stm32f4 processors, as they passed more than just the
waitstate bits to flash_set_ws().

flash_set_ws() now _only_ sets the waitstate bits of the FLASH_ACR
register.