### PR TITLE
Adds ability to enable .eh_frame while generating linker script

### DIFF
--- a/ld/linker.ld.S
+++ b/ld/linker.ld.S
@@ -182,11 +182,9 @@ SECTIONS
 	} >nfcram
 #endif
 
-	/*
-	 * The .eh_frame section appears to be used for C++ exception handling.
-	 * You may need to fix this if you're using C++.
-	 */
+#ifndef _EH_FRAME
 	/DISCARD/ : { *(.eh_frame) }
+#endif
 
 	. = ALIGN(4);
 	end = .;


### PR DESCRIPTION
Usage: just pass ARCH_FLAGS=-D_EH_FRAME while run mk/*.mk files