### PR TITLE
add usb audio, cdc, and midi stub files for doxy

### DIFF
--- a/include/libopencm3/usb/audio.h
+++ b/include/libopencm3/usb/audio.h
@@ -40,6 +40,8 @@ LGPL License Terms @ref lgpl_license
 #ifndef LIBOPENCM3_USB_AUDIO_H
 #define LIBOPENCM3_USB_AUDIO_H
 
+#include <stdint.h>
+
 /*
  * Definitions from the USB_AUDIO_ or usb_audio_ namespace come from:
  * "Universal Serial Bus Class Definitions for Audio Devices, Revision 1.0"

--- a/include/libopencm3/usb/cdc.h
+++ b/include/libopencm3/usb/cdc.h
@@ -38,6 +38,8 @@ LGPL License Terms @ref lgpl_license
 #ifndef __CDC_H
 #define __CDC_H
 
+#include <stdint.h>
+
 /* Definitions of Communications Device Class from
  * "Universal Serial Bus Class Definitions for Communications Devices
  * Revision 1.2"

--- a/include/libopencm3/usb/midi.h
+++ b/include/libopencm3/usb/midi.h
@@ -38,6 +38,8 @@ LGPL License Terms @ref lgpl_license
 #ifndef LIBOPENCM3_USB_MIDI_H
 #define LIBOPENCM3_USB_MIDI_H
 
+#include <stdint.h>
+
 /*
  * Definitions from the USB_MIDI_ or usb_midi_ namespace come from:
  * "Universal Serial Bus Class Definitions for MIDI Devices, Revision 1.0"

--- a/lib/efm32/ezr32wg/Makefile
+++ b/lib/efm32/ezr32wg/Makefile
@@ -57,6 +57,7 @@ OBJS += wdog_common.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_efm32.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/efm32/hg/Makefile
+++ b/lib/efm32/hg/Makefile
@@ -44,6 +44,7 @@ OBJS += timer_common.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_dwc_common.o usb_efm32hg.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/efm32/lg/Makefile
+++ b/lib/efm32/lg/Makefile
@@ -57,6 +57,7 @@ OBJS += wdog_common.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_efm32.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/efm32/wg/Makefile
+++ b/lib/efm32/wg/Makefile
@@ -57,6 +57,7 @@ OBJS += wdog_common.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_efm32.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/lm4f/Makefile
+++ b/lib/lm4f/Makefile
@@ -45,6 +45,7 @@ OBJS += vector.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_lm4f.o
 
 VPATH += ../usb:../cm3

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -56,6 +56,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += st_usbfs_core.o st_usbfs_v2.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/stm32/f1/Makefile
+++ b/lib/stm32/f1/Makefile
@@ -57,6 +57,7 @@ OBJS += phy.o phy_ksz80x1.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_dwc_common.o usb_f107.o
 OBJS += st_usbfs_core.o st_usbfs_v1.o
 

--- a/lib/stm32/f2/Makefile
+++ b/lib/stm32/f2/Makefile
@@ -54,6 +54,7 @@ OBJS += usart_common_all.o usart_common_f124.o
 
 OBJS += usb.o usb_standard.o usb_control.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_dwc_common.o usb_f107.o usb_f207.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/stm32/f3/Makefile
+++ b/lib/stm32/f3/Makefile
@@ -54,6 +54,7 @@ OBJS += usart_common_v2.o usart_common_all.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += st_usbfs_core.o st_usbfs_v1.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/stm32/f4/Makefile
+++ b/lib/stm32/f4/Makefile
@@ -66,6 +66,7 @@ OBJS += usart_common_all.o usart_common_f124.o
 
 OBJS += usb.o usb_standard.o usb_control.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += usb_dwc_common.o usb_f107.o usb_f207.o
 
 OBJS += mac.o phy.o mac_stm32fxx7.o phy_ksz80x1.o

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -55,6 +55,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += st_usbfs_core.o st_usbfs_v2.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/stm32/l1/Makefile
+++ b/lib/stm32/l1/Makefile
@@ -54,6 +54,7 @@ OBJS += usart_common_all.o usart_common_f124.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += st_usbfs_core.o st_usbfs_v1.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/stm32/l4/Makefile
+++ b/lib/stm32/l4/Makefile
@@ -57,6 +57,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
+OBJS += usb_audio.o usb_cdc.o usb_midi.o
 OBJS += st_usbfs_core.o st_usbfs_v2.o
 
 VPATH += ../../usb:../:../../cm3:../common

--- a/lib/usb/usb_audio.c
+++ b/lib/usb/usb_audio.c
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/usb/audio.h>
+
+/* This stub exists just to trick doxygen. */

--- a/lib/usb/usb_cdc.c
+++ b/lib/usb/usb_cdc.c
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/usb/cdc.h>
+
+/* This stub exists just to trick doxygen. */

--- a/lib/usb/usb_midi.c
+++ b/lib/usb/usb_midi.c
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/usb/midi.h>
+
+/* This stub exists just to trick doxygen. */


### PR DESCRIPTION
- add stub files to relevant makefiles
- include <stdint.h> in respective headers to fix compilation

I didn't add a stub for DFU because #1220 does it, although it also makes some other changes. Perhaps it would be better to separate the Doxygen stub addition from the other documentation and implementation changes?

Fixes #1219 
