### PR TITLE
Update checkpatch.pl with changes to the Linux Kernel Coding Style

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -33,7 +33,7 @@ my %ignore_type = ();
 my @ignore = ();
 my $help = 0;
 my $configuration_file = ".checkpatch.conf";
-my $max_line_length = 80;
+my $max_line_length = 100;
 
 sub help {
 	my ($exitcode) = @_;


### PR DESCRIPTION
The Linux kernel just deprecated the 80 character line limit.
This was always a mild issue of mine because of operations on lengthily-named registers that go just over the 80 character limit.
https://www.phoronix.com/scan.php?page=news_item&px=Linux-Kernel-Deprecates-80-Col