### PR TITLE
Add USART Trasmission Complete enable/disable interrupt functions for STM32F

### DIFF
--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -120,6 +120,8 @@ void usart_enable_rx_interrupt(uint32_t usart);
 void usart_disable_rx_interrupt(uint32_t usart);
 void usart_enable_tx_interrupt(uint32_t usart);
 void usart_disable_tx_interrupt(uint32_t usart);
+void usart_enable_tx_complete_interrupt(uint32_t usart);
+void usart_disable_tx_complete_interrupt(uint32_t usart);
 void usart_enable_error_interrupt(uint32_t usart);
 void usart_disable_error_interrupt(uint32_t usart);
 bool usart_get_flag(uint32_t usart, uint32_t flag);

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -351,6 +351,32 @@ void usart_disable_tx_interrupt(uint32_t usart)
 }
 
 /*---------------------------------------------------------------------------*/
+/**
+ * @brief USART Transmission Complete Interrupt Enable
+ * 
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+ */
+
+void usart_enable_tx_complete_interrupt(uint32_t usart)
+{
+	USART_CR1(usart) |= USART_CR1_TCIE;
+}
+
+/*---------------------------------------------------------------------------*/
+/**
+ * @brief USART Transmission Complete Interrupt Disable
+ * 
+ * @param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+ */
+
+void usart_disable_tx_complete_interrupt(uint32_t usart)
+{
+	USART_CR1(usart) &= ~USART_CR1_TCIE;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Error Interrupt Enable.
 
 @param[in] usart unsigned 32 bit. USART block register address base @ref


### PR DESCRIPTION
I'm adding usart_enable/disable_tx_complete_interrupt() functions for STM32F.