### PR TITLE
Enable running USB protocols in non-ISR context

### DIFF
--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -166,7 +166,40 @@ extern void usbd_register_set_altsetting_callback(usbd_device *usbd_dev,
 					usbd_set_altsetting_callback callback);
 
 /* Functions to be provided by the hardware abstraction layer */
+
+/**
+ * Event service routine to be used in a polled environment.
+ * 
+ * It will poll for pending USB events and appropriately dispatch
+ * to handlers when an interrupt is found
+ *
+ * @param the usb device handle returned from @ref usbd_init
+ */
 extern void usbd_poll(usbd_device *usbd_dev);
+
+/**
+ * Primary USB interrupt service routine (ISR).
+ * 
+ * This function is to be used in an interrupt environment where
+ * the interrupt is registered in an ISR, and then the result is dispatched
+ * to a secondary ISR where the handlers for the pending events are called
+ * in a non-ISR context.
+ *
+ * @param dev the usb device handle returned from @ref usbd_init
+ * @param int_stat Pointer to location where to save interrupt status
+ */
+extern void usbd_primary_isr(usbd_device *usbd_dev, uint32_t* int_stat);
+
+/**
+ * Secondary USB interrupt service routine (ISR).
+ * 
+ * This function should be called with the dispatched interrupt status
+ * from the primary ISR. 
+ *
+ * @param dev the usb device handle returned from @ref usbd_init
+ * @param int_stat interrupt status from @ref usbd_primary_isr
+ */
+extern void usbd_secondary_isr(usbd_device *usbd_dev, uint32_t int_stat);
 
 /** Disconnect, if supported by the driver
  *

--- a/lib/stm32/common/st_usbfs_core.h
+++ b/lib/stm32/common/st_usbfs_core.h
@@ -48,7 +48,39 @@ uint16_t st_usbfs_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
 				  const void *buf, uint16_t len);
 uint16_t st_usbfs_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
 				 void *buf, uint16_t len);
+/**
+ * Event service routine to be used in a polled environment.
+ * 
+ * It will poll for pending USB events and appropriately dispatch
+ * to handlers when an interrupt is found
+ *
+ * @param the usb device handle returned from @ref usbd_init
+ */
 void st_usbfs_poll(usbd_device *usbd_dev);
+
+/**
+ * Primary USB interrupt service routine (ISR).
+ * 
+ * This function is to be used in an interrupt environment where
+ * the interrupt is registered in an ISR, and then the result is dispatched
+ * to a secondary ISR where the handlers for the pending events are called
+ * in a non-ISR context.
+ *
+ * @param usbd_dev the usb device handle returned from @ref usbd_init
+ * @param int_stat Pointer to location where to save interrupt status
+ */
+void st_usbfs_primary_isr(usbd_device *usbd_dev, uint32_t* int_stat);
+
+/**
+ * Secondary USB interrupt service routine (ISR).
+ * 
+ * This function should be called with the dispatched interrupt status
+ * from the primary ISR. 
+ *
+ * @param usbd_dev the usb device handle returned from @ref usbd_init
+ * @param int_stat interrupt status from @ref usbd_primary_isr
+ */
+void st_usbfs_secondary_isr(usbd_device *usbd_dev, uint32_t int_stat);
 
 /* These must be implemented by the device specific driver */
 

--- a/lib/stm32/st_usbfs_v2.c
+++ b/lib/stm32/st_usbfs_v2.c
@@ -108,4 +108,6 @@ const struct _usbd_driver st_usbfs_v2_usb_driver = {
 	.ep_read_packet = st_usbfs_ep_read_packet,
 	.disconnect = st_usbfs_v2_disconnect,
 	.poll = st_usbfs_poll,
+	.primary_isr = st_usbfs_primary_isr,
+	.secondary_isr = st_usbfs_secondary_isr,
 };

--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -153,6 +153,8 @@ struct _usbd_driver {
 	uint16_t (*ep_read_packet)(usbd_device *usbd_dev, uint8_t addr,
 				   void *buf, uint16_t len);
 	void (*poll)(usbd_device *usbd_dev);
+	void (*primary_isr)(usbd_device *usbd_dev, uint32_t* int_stat);
+	void (*secondary_isr)(usbd_device *usbd_dev, uint32_t int_stat);
 	void (*disconnect)(usbd_device *usbd_dev, bool disconnected);
 	uint32_t base_address;
 	bool set_address_before_status;


### PR DESCRIPTION
Add functions for having a primary-ISR running in ISR context to register interrupts, and a secondary-ISR running at task context to parse interrupts and to call protocol handlers, thus enabling USB protocol handlers to run in task context.