### PR TITLE
STM32H7 DAC Updates

### DIFF
--- a/include/libopencm3/stm32/h7/dac.h
+++ b/include/libopencm3/stm32/h7/dac.h
@@ -31,6 +31,7 @@ LGPL License Terms @ref lgpl_license
 #ifndef LIBOPENCM3_DAC_H
 #define LIBOPENCM3_DAC_H
 
+#define DAC_HAS_MODE_REG
 #include <libopencm3/stm32/common/dac_common_all.h>
 
 #endif


### PR DESCRIPTION
The DAC on the STM32H7 has an additional trigger bit for each channel
and some additional choices when it comes to low power operation. ST
therefore opted to give us a new DAC mode register and shift the trigger
channel in the CR register.

Account for this by checking to see if we should define the MCR register
and if so shift some things around and define a new set_mode function.

The old enable/disable buffering is emulated by setting the appropriate
new modes.