### PR TITLE
stm32h7: fixed flash impl from pretending to be stm32 f2/f4.

### DIFF
--- a/include/libopencm3/stm32/h7/flash.h
+++ b/include/libopencm3/stm32/h7/flash.h
@@ -27,27 +27,44 @@
 #define LIBOPENCM3_FLASH_H
 
 #include <libopencm3/stm32/common/flash_common_all.h>
-#include <libopencm3/stm32/common/flash_common_f.h>
-#include <libopencm3/stm32/common/flash_common_f24.h>
 
 /**@{*/
-
-/** @addtogroup flash_acr_values FLASH_ACR values
- * @ingroup flash_registers
+/** @defgroup flash_registers Flash Registers
+ * @ingroup flash_defines
 @{*/
-#define FLASH_ACR_WRHF_VOS1_70MHZ     (0 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS1_185MHZ    (1 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS1_225MHZ    (2 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS2_55MHZ     (0 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS2_165MHZ    (1 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS2_225MHZ    (2 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS3_45MHZ     (0 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS3_135MHZ    (1 << FLASH_ACR_WRHIGHFREQ_SHIFT)
-#define FLASH_ACR_WRHF_VOS3_225MHZ    (2 << FLASH_ACR_WRHIGHFREQ_SHIFT)
+/** Flash Access Control register */
+#define FLASH_ACR                     MMIO32(FLASH_MEM_INTERFACE_BASE + 0x00)
+/** Flash Key register */
+#define FLASH_KEYR                    MMIO32(FLASH_MEM_INTERFACE_BASE + 0x04)
+/** Flash Option bytes key register */
+#define FLASH_OPTKEYR                 MMIO32(FLASH_MEM_INTERFACE_BASE + 0x08)
 /*@}*/
-#define FLASH_ACR_WRHIGHFREQ_MASK     (0x3)
-#define FLASH_ACR_WRHIGHFREQ_SHIFT    (0x4)
 
+/** @defgroup flash_latency FLASH Wait States
+@ingroup flash_defines
+@{*/
+#define FLASH_ACR_LATENCY_SHIFT       0
+#define FLASH_ACR_LATENCY_MASK        0x0f
+#define FLASH_ACR_WRHIGHFREQ_MASK     0x3
+#define FLASH_ACR_WRHIGHFREQ_SHIFT    4
+/*@}*/
+
+/** @defgroup flash_acr_values FLASH_ACR values
+ * @ingroup flash_registers
+ * @brief Access Control register values
+ * @{*/
+/* The H7 doesn't support prefetch, so set a 0-value to make the prefetch enable/disable a no-op. */
+#define FLASH_ACR_PRFTEN              (0)
+/**@}*/
+
+/** @defgroup FLASH Key Values.
+@ingroup flash_defines
+@{*/
+#define FLASH_KEYR_KEY1               ((uint32_t)0x45670123)
+#define FLASH_KEYR_KEY2               ((uint32_t)0xcdef89ab)
+#define FLASH_OPTKEYR_KEY1            ((uint32_t)0x08192a3b)
+#define FLASH_OPTKEYR_KEY2            ((uint32_t)0x4c5d6e7f)
+/**@}*/
 /**@}*/
 
 #endif

--- a/lib/stm32/h7/Makefile
+++ b/lib/stm32/h7/Makefile
@@ -39,7 +39,7 @@ ARFLAGS		= rcs
 
 OBJS += dac_common_all.o
 OBJS += exti_common_all.o
-OBJS += flash_common_all.o flash_common_f.o flash_common_f24.o
+OBJS += flash_common_all.o
 OBJS += fmc_common_f47.o
 OBJS += gpio_common_all.o gpio_common_f0234.o
 OBJS += pwr.o rcc.o

--- a/lib/stm32/h7/rcc.c
+++ b/lib/stm32/h7/rcc.c
@@ -189,13 +189,8 @@ void rcc_clock_setup_pll(const struct rcc_pll_config *config) {
 	pwr_set_mode_ldo();
 	pwr_set_vos_scale(config->voltage_scale);
 
-	/* Set flash waitstates. Enable flash prefetch if we have at least 1WS */
+	/* Set flash waitstates. H7 doesn't support prefetch, so nothing to do WRT this. */
 	flash_set_ws(config->flash_waitstates);
-	if (config->flash_waitstates > FLASH_ACR_LATENCY_0WS) {
-		flash_prefetch_enable();
-	} else {
-		flash_prefetch_disable();
-	}
 
 	/* User has specified an external oscillator, make sure we turn it on. */
 	if (config->hse_frequency > 0) {


### PR DESCRIPTION
Added the minimum functionality required for general use (setting waitstates).