### PR TITLE
Double buffering for stm32f0

### DIFF
--- a/include/libopencm3/stm32/common/st_usbfs_common.h
+++ b/include/libopencm3/stm32/common/st_usbfs_common.h
@@ -160,6 +160,7 @@ LGPL License Terms @ref lgpl_license
 
 #define USB_EP_SETUP		0x0800 /* Setup transaction completed */
 #define USB_EP_TYPE		0x0600 /* Endpoint type */
+#define USB_EP_TYPE_OFFSET	9      /* Endpoint type offset */
 #define USB_EP_KIND		0x0100 /* Endpoint kind.
 				* When set and type=bulk    -> double buffer
 				* When set and type=control -> status out
@@ -242,6 +243,9 @@ LGPL License Terms @ref lgpl_license
 		(USB_EP_NTOGGLE_MSK & \
 		(~USB_EP_TYPE))) | TYPE)
 
+#define USB_GET_EP_TYPE(EP) \
+	((GET_REG(USB_EP_REG(EP)) & USB_EP_TYPE) >> USB_EP_TYPE_OFFSET)
+
 #define USB_SET_EP_KIND(EP) \
 	SET_REG(USB_EP_REG(EP), \
 		(GET_REG(USB_EP_REG(EP)) & \
@@ -273,6 +277,55 @@ LGPL License Terms @ref lgpl_license
 		GET_REG(USB_EP_REG(EP)) & \
 		(USB_EP_NTOGGLE_MSK | USB_EP_RX_DTOG))
 
+/* Macros for toggling DTOG bits */
+#define USB_TGL_EP_TX_DTOG(EP) \
+	SET_REG(USB_EP_REG(EP), \
+		(GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK & \
+		(~USB_EP_TX_DTOG))) | USB_EP_TX_DTOG)
+
+#define USB_TGL_EP_RX_DTOG(EP) \
+	SET_REG(USB_EP_REG(EP), \
+		(GET_REG(USB_EP_REG(EP)) & \
+		(USB_EP_NTOGGLE_MSK & \
+		(~USB_EP_RX_DTOG))) | USB_EP_RX_DTOG)
+
+/* Macros for double buffered bulk endpoints */
+#define SW_BUF_TX	USB_EP_RX_DTOG
+#define SW_BUF_RX	USB_EP_TX_DTOG
+#define HW_BUF_TX	USB_EP_TX_DTOG
+#define HW_BUF_RX	USB_EP_RX_DTOG
+
+#define USB_GET_EP_SW_BUF_TX(EP)	(*USB_EP_REG(EP) & SW_BUF_TX)
+#define USB_GET_EP_SW_BUF_RX(EP)	(*USB_EP_REG(EP) & SW_BUF_RX)
+#define USB_GET_EP_HW_BUF_TX(EP)	(*USB_EP_REG(EP) & HW_BUF_TX)
+#define USB_GET_EP_HW_BUF_RX(EP)	(*USB_EP_REG(EP) & HW_BUF_RX)
+
+#define USB_TGL_EP_TX_SW_BUF(EP)	USB_TGL_EP_RX_DTOG(EP)
+#define USB_TGL_EP_RX_SW_BUF(EP)	USB_TGL_EP_TX_DTOG(EP)
+
+#define USB_TGL_EP_TX_HW_BUF(EP)	USB_TGL_EP_TX_DTOG(EP)
+#define USB_TGL_EP_RX_HW_BUF(EP)	USB_TGL_EP_RX_DTOG(EP)
+
+#define USB_GET_EP_TX_BUFF_0(EP)	USB_GET_EP_TX_BUFF(EP)
+#define USB_GET_EP_TX_BUFF_1(EP)	USB_GET_EP_RX_BUFF(EP)
+#define USB_GET_EP_RX_BUFF_0(EP)	USB_GET_EP_TX_BUFF(EP)
+#define USB_GET_EP_RX_BUFF_1(EP)	USB_GET_EP_RX_BUFF(EP)
+
+#define USB_GET_EP_TX_COUNT_0(EP)	USB_GET_EP_TX_COUNT(EP)
+#define USB_GET_EP_TX_COUNT_1(EP)	USB_GET_EP_RX_COUNT(EP)
+#define USB_GET_EP_RX_COUNT_0(EP)	USB_GET_EP_TX_COUNT(EP)
+#define USB_GET_EP_RX_COUNT_1(EP)	USB_GET_EP_RX_COUNT(EP)
+
+#define USB_SET_EP_TX_COUNT_0(EP, LEN)	USB_SET_EP_TX_COUNT(EP, LEN)
+#define USB_SET_EP_TX_COUNT_1(EP, LEN)	USB_SET_EP_RX_COUNT(EP, LEN)
+#define USB_SET_EP_RX_COUNT_0(EP, LEN)	USB_SET_EP_TX_COUNT(EP, LEN)
+#define USB_SET_EP_RX_COUNT_1(EP, LEN)	USB_SET_EP_RX_COUNT(EP, LEN)
+
+#define USB_SET_EP_TX_ADDR_0(EP, ADDR)	USB_SET_EP_TX_ADDR(EP, ADDR)
+#define USB_SET_EP_TX_ADDR_1(EP, ADDR)	USB_SET_EP_RX_ADDR(EP, ADDR)
+#define USB_SET_EP_RX_ADDR_0(EP, ADDR)	USB_SET_EP_TX_ADDR(EP, ADDR)
+#define USB_SET_EP_RX_ADDR_1(EP, ADDR)	USB_SET_EP_RX_ADDR(EP, ADDR)
 
 /* --- USB BTABLE registers ------------------------------------------------ */
 

--- a/include/libopencm3/stm32/common/st_usbfs_common.h
+++ b/include/libopencm3/stm32/common/st_usbfs_common.h
@@ -219,6 +219,10 @@ LGPL License Terms @ref lgpl_license
 	TOG_SET_REG_BIT_MSK_AND_SET(USB_EP_REG(EP), \
 		USB_EP_TX_STAT_TOG_MSK, STAT, USB_EP_RX_CTR | USB_EP_TX_CTR)
 
+#define USB_GET_EP_RX_STAT(EP) *USB_EP_REG(EP) & USB_EP_RX_STAT
+
+#define USB_GET_EP_TX_STAT(EP) *USB_EP_REG(EP) & USB_EP_TX_STAT
+
 /*
  * Macros for clearing and setting USB endpoint register bits that do
  * not use the toggle mechanism.

--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -56,6 +56,7 @@ extern const usbd_driver st_usbfs_v1_usb_driver;
 extern const usbd_driver stm32f107_usb_driver;
 extern const usbd_driver stm32f207_usb_driver;
 extern const usbd_driver st_usbfs_v2_usb_driver;
+extern const usbd_driver st_usbfs_double_usb_driver;
 #define otgfs_usb_driver stm32f107_usb_driver
 #define otghs_usb_driver stm32f207_usb_driver
 extern const usbd_driver efm32lg_usb_driver;

--- a/include/libopencm3/usb/usbd.h
+++ b/include/libopencm3/usb/usbd.h
@@ -56,7 +56,7 @@ extern const usbd_driver st_usbfs_v1_usb_driver;
 extern const usbd_driver stm32f107_usb_driver;
 extern const usbd_driver stm32f207_usb_driver;
 extern const usbd_driver st_usbfs_v2_usb_driver;
-extern const usbd_driver st_usbfs_double_usb_driver;
+extern const usbd_driver st_usbfs_v2_double_usb_driver;
 #define otgfs_usb_driver stm32f107_usb_driver
 #define otghs_usb_driver stm32f207_usb_driver
 extern const usbd_driver efm32lg_usb_driver;

--- a/lib/stm32/common/st_usbfs_core.h
+++ b/lib/stm32/common/st_usbfs_core.h
@@ -33,6 +33,8 @@
 #define USBD_PM_TOP 0x40
 
 void st_usbfs_set_address(usbd_device *dev, uint8_t addr);
+uint16_t st_usbfs_calc_ep_rx_bufsize(usbd_device *dev, uint32_t size,
+		uint32_t *out_size);
 uint16_t st_usbfs_set_ep_rx_bufsize(usbd_device *dev, uint8_t ep, uint32_t size);
 
 void st_usbfs_ep_setup(usbd_device *usbd_dev, uint8_t addr,

--- a/lib/stm32/common/st_usbfs_v2.h
+++ b/lib/stm32/common/st_usbfs_v2.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2014 Kuldeep Singh Dhaka <kuldeepdhaka9@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __ST_USBFS_V2_H
+#define __ST_USBFS_V2_H
+
+#include <libopencm3/usb/usbd.h>
+
+BEGIN_DECLS
+
+/**
+ * Initialize the USB device controller hardware of the STM32.
+ */
+usbd_device *st_usbfs_v2_usbd_init(void);
+
+/**
+ * Controll the embedded pull-up on the DP line.
+ *
+ * @param usbd_dev usb device to operate upon
+ * @param disconnected The value to set the embedded DP pull-up. Setting this to
+ *                     false can be used to signalize disconnect to the host.
+ */
+void st_usbfs_v2_disconnect(usbd_device *usbd_dev, bool disconnected);
+
+END_DECLS
+
+#endif

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -56,7 +56,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
-OBJS += st_usbfs_core.o st_usbfs_v2.o
+OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_double.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/f0/Makefile
+++ b/lib/stm32/f0/Makefile
@@ -56,7 +56,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
-OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_double.o
+OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_v2_double.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -55,7 +55,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
-OBJS += st_usbfs_core.o st_usbfs_v2.o
+OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_double.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/l0/Makefile
+++ b/lib/stm32/l0/Makefile
@@ -55,7 +55,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
-OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_double.o
+OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_v2_double.o
 
 VPATH += ../../usb:../:../../cm3:../common
 

--- a/lib/stm32/l4/Makefile
+++ b/lib/stm32/l4/Makefile
@@ -57,7 +57,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
-OBJS += st_usbfs_core.o st_usbfs_v2.o
+OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_double.o
 
 VPATH += ../../usb:../:../../cm3:../common
 VPATH += ../../ethernet

--- a/lib/stm32/l4/Makefile
+++ b/lib/stm32/l4/Makefile
@@ -57,7 +57,7 @@ OBJS += usart_common_all.o usart_common_v2.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o
-OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_double.o
+OBJS += st_usbfs_core.o st_usbfs_v2.o st_usbfs_v2_double.o
 
 VPATH += ../../usb:../:../../cm3:../common
 VPATH += ../../ethernet

--- a/lib/stm32/st_usbfs_double.c
+++ b/lib/stm32/st_usbfs_double.c
@@ -142,6 +142,17 @@ static void st_usbfs_double_ep_setup(usbd_device *usb_dev, uint8_t addr,
 		USB_SET_EP_TX_ADDR_1(addr, usb_dev->pm_top);
 		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_DISABLED);
 		usb_dev->pm_top += max_size;
+
+		/*
+		 * This buffer needs a size initialising as though it were an RX
+		 * buffer, otherwise it seems to use a very large value for this
+		 * count on first usage (instead of the count written to it).
+		 *
+		 * The size written here doesn't actually matter. So long as one
+		 * is written at this step it will then use the correct size in
+		 * the future.
+		 */
+		USB_SET_EP_TX_COUNT_1(addr, max_size);
 	}
 
 	if (!dir) {

--- a/lib/stm32/st_usbfs_double.c
+++ b/lib/stm32/st_usbfs_double.c
@@ -1,0 +1,182 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/st_usbfs.h>
+#include <libopencm3/stm32/tools.h>
+#include <libopencm3/usb/usbd.h>
+#include "../usb/usb_private.h"
+#include "common/st_usbfs_core.h"
+#include "common/st_usbfs_v2.h"
+
+/*
+ * Double buffering flow control only kicks in after the first transaction
+ * following double buffering configuration. If the endpoint described in
+ * register set n has not completed its first double buffering transmission, then
+ * the n'th most significnt bit in this byte will be 1. The bit isn't needed for
+ * reception.
+ */
+static uint8_t first_double_run;
+
+static uint16_t st_usbfs_double_ep_write_packet(usbd_device *dev, uint8_t addr,
+		const void *buf, uint16_t len)
+{
+	addr &= 0x7F;
+
+	/* only bulk endpoints can be double buffered. Otherwise fall back to
+	   the single buffered implementation */
+	if (USB_GET_EP_TYPE(addr) != USB_EP_TYPE_BULK) {
+		return st_usbfs_ep_write_packet(dev, addr, buf, len);
+	}
+
+	if (USB_GET_EP_SW_BUF_TX(addr)) {
+		/* buffer 1 */
+		st_usbfs_copy_to_pm(USB_GET_EP_TX_BUFF_1(addr), buf, len);
+		USB_SET_EP_TX_COUNT_1(addr, len);
+
+		USB_TGL_EP_TX_SW_BUF(addr);
+
+		/*
+		 * Block until hardware is done sending the previous buffer.
+		 * If we don't wait then this function could be called again
+		 * and will st_usbfs_copy_to_pm into that buffer before it is
+		 * all sent.
+		 */
+		while(!USB_GET_EP_HW_BUF_TX(addr));
+	} else {
+		/* buffer 0 */
+		st_usbfs_copy_to_pm(USB_GET_EP_TX_BUFF_0(addr), buf, len);
+		USB_SET_EP_TX_COUNT_0(addr, len);
+
+		USB_TGL_EP_TX_SW_BUF(addr);
+
+		/* block until hardware is done sending the previous buffer */
+		while(USB_GET_EP_HW_BUF_TX(addr));
+	}
+
+	/* the double buffering flow control only kicks in after the first send */
+	if (first_double_run & (1 << addr)) {
+		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_VALID);
+		USB_TGL_EP_TX_HW_BUF(addr);
+		first_double_run &= ~(1 << addr);
+	}
+
+	return len;
+}
+
+static uint16_t st_usbfs_double_ep_read_packet(usbd_device *dev, uint8_t addr,
+					 void *buf, uint16_t len)
+{
+	/* only bulk endpoints can be double buffered. Otherwise fall back to
+	   the single buffered implementation */
+	if (USB_GET_EP_TYPE(addr) != USB_EP_TYPE_BULK) {
+		return st_usbfs_ep_read_packet(dev, addr, buf, len);
+	}
+
+	if (USB_GET_EP_SW_BUF_RX(addr)) {
+		/* buffer 1 */
+		len = MIN(USB_GET_EP_RX_COUNT_1(addr) & 0x3ff, len);
+		st_usbfs_copy_from_pm(buf, USB_GET_EP_RX_BUFF_1(addr), len);
+	} else {
+		/* buffer 0 */
+		len = MIN(USB_GET_EP_RX_COUNT_0(addr) & 0x3ff, len);
+		st_usbfs_copy_from_pm(buf, USB_GET_EP_RX_BUFF_0(addr), len);
+	}
+
+	/* There's no need for flow control because the hardware will
+	   automatically NAK while HW_BUF == SW_BUF */
+
+	USB_TGL_EP_RX_SW_BUF(addr);
+
+	USB_CLR_EP_RX_CTR(addr);
+	return len;
+}
+
+static void st_usbfs_double_ep_setup(usbd_device *usb_dev, uint8_t addr,
+		uint8_t type,
+		uint16_t max_size,
+		void (*callback) (usbd_device *usbd_dev,
+		uint8_t ep))
+{
+	/* only bulk endpoints can be double buffered. Otherwise fall back to
+	   the single buffered implementation */
+	if (type != USB_ENDPOINT_ATTR_BULK) {
+		return st_usbfs_ep_setup(usb_dev, addr, type, max_size, callback);
+	}
+
+	uint8_t dir = addr & 0x80;
+	addr &= 0x7f;
+
+	/* Assign address. */
+	USB_SET_EP_ADDR(addr, addr);
+	USB_SET_EP_TYPE(addr, USB_EP_TYPE_BULK);
+	USB_SET_EP_KIND(addr); /* double buffered mode */
+
+	first_double_run |= (1 << addr);
+
+	if (dir || (addr == 0)) {
+		USB_SET_EP_TX_ADDR_0(addr, usb_dev->pm_top);
+		if (callback) {
+			usb_dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
+				(void *)callback;
+		}
+		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
+		usb_dev->pm_top += max_size;
+
+		/* second buffer */
+		USB_SET_EP_TX_ADDR_1(addr, usb_dev->pm_top);
+		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_DISABLED);
+		usb_dev->pm_top += max_size;
+	}
+
+	if (!dir) {
+		uint16_t realsize;
+		uint32_t reg_size;
+		realsize = st_usbfs_calc_ep_rx_bufsize(usb_dev, max_size,
+				&reg_size);
+
+		USB_SET_EP_RX_ADDR_0(addr, usb_dev->pm_top);
+		USB_SET_EP_RX_COUNT_0(addr, reg_size);
+		if (callback) {
+			usb_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
+				(void *)callback;
+		}
+		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);
+		usb_dev->pm_top += realsize;
+
+		/* second buffer */
+		USB_SET_EP_RX_ADDR_1(addr, usb_dev->pm_top);
+		USB_SET_EP_RX_COUNT_1(addr, reg_size);
+		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_DISABLED);
+		usb_dev->pm_top += realsize;
+	}
+}
+
+const struct _usbd_driver st_usbfs_double_usb_driver = {
+	.init = st_usbfs_v2_usbd_init,
+	.set_address = st_usbfs_set_address,
+	.ep_setup = st_usbfs_double_ep_setup,
+	.ep_reset = st_usbfs_endpoints_reset,
+	.ep_stall_set = st_usbfs_ep_stall_set,
+	.ep_stall_get = st_usbfs_ep_stall_get,
+	.ep_nak_set = st_usbfs_ep_nak_set,
+	.ep_write_packet = st_usbfs_double_ep_write_packet,
+	.ep_read_packet = st_usbfs_double_ep_read_packet,
+	.disconnect = st_usbfs_v2_disconnect,
+	.poll = st_usbfs_poll,
+};

--- a/lib/stm32/st_usbfs_v2.c
+++ b/lib/stm32/st_usbfs_v2.c
@@ -25,9 +25,10 @@
 #include <libopencm3/usb/usbd.h>
 #include "../usb/usb_private.h"
 #include "common/st_usbfs_core.h"
+#include "common/st_usbfs_v2.h"
 
 /** Initialize the USB device controller hardware of the STM32. */
-static usbd_device *st_usbfs_v2_usbd_init(void)
+usbd_device *st_usbfs_v2_usbd_init(void)
 {
 	rcc_periph_clock_enable(RCC_USB);
 	SET_REG(USB_CNTR_REG, 0);
@@ -85,7 +86,7 @@ void st_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 	}
 }
 
-static void st_usbfs_v2_disconnect(usbd_device *usbd_dev, bool disconnected)
+void st_usbfs_v2_disconnect(usbd_device *usbd_dev, bool disconnected)
 {
 	(void)usbd_dev;
 	uint16_t reg = GET_REG(USB_BCDR_REG);

--- a/lib/stm32/st_usbfs_v2_double.c
+++ b/lib/stm32/st_usbfs_v2_double.c
@@ -178,7 +178,7 @@ static void st_usbfs_double_ep_setup(usbd_device *usb_dev, uint8_t addr,
 	}
 }
 
-const struct _usbd_driver st_usbfs_double_usb_driver = {
+const struct _usbd_driver st_usbfs_v2_double_usb_driver = {
 	.init = st_usbfs_v2_usbd_init,
 	.set_address = st_usbfs_set_address,
 	.ep_setup = st_usbfs_double_ep_setup,

--- a/tests/gadget-zero/Makefile.stm32f072disco-double
+++ b/tests/gadget-zero/Makefile.stm32f072disco-double
@@ -1,0 +1,45 @@
+##
+## This file is part of the libopencm3 project.
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BOARD = stm32f072disco
+VARIANT = double
+PROJECT = usb-gadget0-$(BOARD)-$(VARIANT)
+BUILD_DIR = bin-$(BOARD)-$(VARIANT)
+
+SHARED_DIR = ../shared
+
+CFILES = main-$(BOARD)-$(VARIANT).c
+CFILES += usb-gadget0.c
+CFILES += delay.c
+
+VPATH += $(SHARED_DIR)
+
+INCLUDES += $(patsubst %,-I%, . $(SHARED_DIR))
+
+OPENCM3_DIR=../..
+
+### This section can go to an arch shared rules eventually...
+LDSCRIPT = ../../lib/stm32/f0/stm32f07xzb.ld
+OPENCM3_LIB = opencm3_stm32f0
+OPENCM3_DEFS = -DSTM32F0
+#FP_FLAGS ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+ARCH_FLAGS = -mthumb -mcpu=cortex-m0 $(FP_FLAGS)
+#OOCD_INTERFACE = stlink-v2
+#OOCD_TARGET = stm32f4x
+OOCD_FILE = openocd.stm32f072disco.cfg
+
+include ../rules.mk

--- a/tests/gadget-zero/main-efm32hg309-generic.c
+++ b/tests/gadget-zero/main-efm32hg309-generic.c
@@ -47,7 +47,7 @@ void trace_send_blocking8(int stimulus_port, char c)
 int main(void)
 {
 	usbd_device *usbd_dev = gadget0_init(&efm32hg_usb_driver,
-			"efm32hg309-generic");
+			"efm32hg309-generic", true);
 
 	ER_DPRINTF("bootup complete\n");
 

--- a/tests/gadget-zero/main-stm32f072disco-double.c
+++ b/tests/gadget-zero/main-stm32f072disco-double.c
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/stm32/crs.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+
+#include <stdio.h>
+#include "usb-gadget0.h"
+
+/* no trace on cm0 #define ER_DEBUG */
+#ifdef ER_DEBUG
+#define ER_DPRINTF(fmt, ...) \
+	do { printf(fmt, ## __VA_ARGS__); } while (0)
+#else
+#define ER_DPRINTF(fmt, ...) \
+	do { } while (0)
+#endif
+
+#include "trace.h"
+void trace_send_blocking8(int stimulus_port, char c)
+{
+	(void)stimulus_port;
+	(void)c;
+}
+
+
+int main(void)
+{
+	rcc_clock_setup_in_hsi48_out_48mhz();
+	crs_autotrim_usb_enable();
+	rcc_set_usbclk_source(RCC_HSI48);
+
+	/* LED on for boot progress */
+	rcc_periph_clock_enable(RCC_GPIOC);
+	gpio_mode_setup(GPIOC, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO7);
+	gpio_set(GPIOC, GPIO7);
+
+	usbd_device *usbd_dev = gadget0_init(&st_usbfs_v2_double_usb_driver,
+					     "stm32f072disco", false);
+
+	ER_DPRINTF("bootup complete\n");
+	gpio_clear(GPIOC, GPIO7);
+	while (1) {
+		gadget0_run(usbd_dev);
+	}
+
+}
+

--- a/tests/gadget-zero/main-stm32f072disco.c
+++ b/tests/gadget-zero/main-stm32f072disco.c
@@ -54,7 +54,7 @@ int main(void)
 	gpio_set(GPIOC, GPIO7);
 
 	usbd_device *usbd_dev = gadget0_init(&st_usbfs_v2_usb_driver,
-					     "stm32f072disco");
+					     "stm32f072disco", true);
 
 	ER_DPRINTF("bootup complete\n");
 	gpio_clear(GPIOC, GPIO7);

--- a/tests/gadget-zero/main-stm32f103-generic.c
+++ b/tests/gadget-zero/main-stm32f103-generic.c
@@ -59,7 +59,7 @@ int main(void)
 
 
 	usbd_device *usbd_dev = gadget0_init(&st_usbfs_v1_usb_driver,
-					     "stm32f103-generic");
+					     "stm32f103-generic", true);
 
 	ER_DPRINTF("bootup complete\n");
 	gpio_clear(GPIOC, GPIO13);

--- a/tests/gadget-zero/main-stm32f3-disco.c
+++ b/tests/gadget-zero/main-stm32f3-disco.c
@@ -62,7 +62,7 @@ int main(void)
 	gpio_set_af(GPIOA, GPIO_AF14, GPIO11|GPIO12);
 
 	usbd_device *usbd_dev = gadget0_init(&st_usbfs_v1_usb_driver,
-					     "stm32f3-disco");
+					     "stm32f3-disco", true);
 
 	ER_DPRINTF("bootup complete\n");
 	gpio_clear(GPIOE, GPIO12);

--- a/tests/gadget-zero/main-stm32f429i-disco.c
+++ b/tests/gadget-zero/main-stm32f429i-disco.c
@@ -48,7 +48,8 @@ int main(void)
 	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT,
 			GPIO_PUPD_NONE, GPIO12 | GPIO13 | GPIO14 | GPIO15);
 
-	usbd_device *usbd_dev = gadget0_init(&otghs_usb_driver, "stm32f429i-disco");
+	usbd_device *usbd_dev = gadget0_init(&otghs_usb_driver, "stm32f429i-disco",
+			true);
 
 	ER_DPRINTF("bootup complete\n");
 	while (1) {

--- a/tests/gadget-zero/main-stm32f4disco.c
+++ b/tests/gadget-zero/main-stm32f4disco.c
@@ -47,7 +47,8 @@ int main(void)
 	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT,
 			GPIO_PUPD_NONE, GPIO12 | GPIO13 | GPIO14 | GPIO15);
 
-	usbd_device *usbd_dev = gadget0_init(&otgfs_usb_driver, "stm32f4disco");
+	usbd_device *usbd_dev = gadget0_init(&otgfs_usb_driver, "stm32f4disco",
+			true);
 
 	ER_DPRINTF("bootup complete\n");
 	while (1) {

--- a/tests/gadget-zero/main-stm32l053disco.c
+++ b/tests/gadget-zero/main-stm32l053disco.c
@@ -78,7 +78,7 @@ int main(void)
 	rcc_wait_for_osc_ready(RCC_HSI48);
 
 	usbd_device *usbd_dev = gadget0_init(&st_usbfs_v2_usb_driver,
-					     "stm32l053disco");
+					     "stm32l053disco", true);
 
 	ER_DPRINTF("bootup complete\n");
 	gpio_clear(GPIOA, GPIO5);

--- a/tests/gadget-zero/main-stm32l1-generic.c
+++ b/tests/gadget-zero/main-stm32l1-generic.c
@@ -67,7 +67,7 @@ int main(void)
 	SYSCFG_PMC |= SYSCFG_PMC_USB_PU;
 
 	usbd_device *usbd_dev = gadget0_init(&st_usbfs_v1_usb_driver,
-					     "stm32l1-generic");
+					     "stm32l1-generic", true);
 
 	ER_DPRINTF("bootup complete\n");
 	gpio_clear(GPIOB, GPIO8);

--- a/tests/gadget-zero/main-tilm4f120xl.c
+++ b/tests/gadget-zero/main-tilm4f120xl.c
@@ -57,7 +57,8 @@ int main(void)
 	gpio_mode_setup(GPIOF, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO2);
 	gpio_set_output_config(GPIOF, GPIO_OTYPE_PP, GPIO_DRIVE_2MA, GPIO2);
 
-	usbd_device *usbd_dev = gadget0_init(&lm4f_usb_driver, "tilm4f120xl");
+	usbd_device *usbd_dev = gadget0_init(&lm4f_usb_driver, "tilm4f120xl",
+			true);
 
 	ER_DPRINTF("bootup complete\n");
 	while (1) {

--- a/tests/gadget-zero/usb-gadget0.h
+++ b/tests/gadget-zero/usb-gadget0.h
@@ -28,9 +28,12 @@
  * @param userserial if non-null, will become the serial number.
  *	You should provide this to help the test code find something particular
  *	to the hardware.
+ * @param bidirectional_endpoints controls whether bidirectional endpoints are
+ *        used
  * @return the usbd_device created.
 */
-usbd_device *gadget0_init(const usbd_driver *driver, const char *userserial);
+usbd_device *gadget0_init(const usbd_driver *driver, const char *userserial,
+		bool bidirectional_endpoints);
 
 /**
  * Call this forever.


### PR DESCRIPTION
Adds double buffered bulk endpoint support for stm32f0.

The fix in  d3bfb68  is kept separate because it isn't obvious that it is needed from the datasheet (which is ambiguous about which bits of double buffered flow control are done on the first transaction). I arrived at that fix experimentally.