### PR TITLE
I2c v2 enable ack

### DIFF
--- a/include/libopencm3/stm32/common/i2c_common_v2.h
+++ b/include/libopencm3/stm32/common/i2c_common_v2.h
@@ -440,6 +440,8 @@ bool i2c_transfer_complete(uint32_t i2c);
 bool i2c_received_data(uint32_t i2c);
 void i2c_enable_interrupt(uint32_t i2c, uint32_t interrupt);
 void i2c_disable_interrupt(uint32_t i2c, uint32_t interrupt);
+void i2c_enable_ack(uint32_t i2c);
+void i2c_disable_ack(uint32_t i2c);
 void i2c_enable_rxdma(uint32_t i2c);
 void i2c_disable_rxdma(uint32_t i2c);
 void i2c_enable_txdma(uint32_t i2c);

--- a/lib/stm32/common/i2c_common_v2.c
+++ b/lib/stm32/common/i2c_common_v2.c
@@ -345,6 +345,29 @@ void i2c_disable_interrupt(uint32_t i2c, uint32_t interrupt)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief I2C Enable ACK
+
+Enables acking of own 7/10 bit address
+@param[in] i2c Unsigned int32. I2C register base address @ref i2c_reg_base.
+*/
+void i2c_enable_ack(uint32_t i2c)
+{
+	I2C_OAR1(i2c) |= I2C_OAR1_OA1EN_ENABLE;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief I2C Disable ACK
+
+Disables acking of own 7/10 bit address
+@param[in] i2c Unsigned int32. I2C register base address @ref i2c_reg_base.
+*/
+void i2c_disable_ack(uint32_t i2c)
+{
+	I2C_OAR1(i2c) &= ~I2C_OAR1_OA1EN_ENABLE;
+}
+
+
+/*---------------------------------------------------------------------------*/
 /** @brief I2C Enable reception DMA
  *
  * @param[in] i2c Unsigned int32. I2C register base address @ref i2c_reg_base.


### PR DESCRIPTION
Judging from their reference manual, stm32 i2c-v1 peripherals immediately start receiving as soon as their OAR1 address is matched; however, they may refrain from sending an ACK if the i2C_CR1 "ACK" bit is not set. Hence, a "i2c_enable_ack()" function starts slave reception and i2c_disable_ack() stops it.

The i2c-v2 peripherals have an "OA1EN: Own Address 1 enable" bit to enable or disable ACKing the slave address. This bit does have a definition in i2c_common_v2.h (I2C_OAR1_OA1EN_DISABLE and ..._ENABLE), but there is no "I2C_OAR1(I2C1) |= I2C_OAR1_OA1EN_ENABLE" in the v2 code. This effectively makes the slave in v2 inoperable.

A proper way to set this up may be to just add the "i2c_enable_ack()" and "i2c_disable_ack()" calls to the v2 code, changing these calls to implement I2C_OAR1(I2C1) |= I2C_OAR1_OA1EN_ENABLE, which is what I did. Tested on a stm32f030f4p6. Without enabling OA1EN, there is no slave reception; using i2c_enable_ack, receiving works as intended.