### PR TITLE
USB Core 0x2000 Fix

### DIFF
--- a/include/libopencm3/usb/dwc/otg_common.h
+++ b/include/libopencm3/usb/dwc/otg_common.h
@@ -233,6 +233,7 @@
 
 /* OTG FS Product ID register (OTG_CID) */
 #define OTG_CID_HAS_VBDEN	0x00002000
+#define OTG_CID_CNAK_EARLY	0x00002000
 
 /* Device-mode CSRs */
 /* OTG device control register (OTG_DCTL) */

--- a/lib/stm32/common/st_usbfs_core.c
+++ b/lib/stm32/common/st_usbfs_core.c
@@ -252,7 +252,6 @@ void st_usbfs_poll(usbd_device *dev)
 			/* OUT or SETUP? */
 			if (*USB_EP_REG(ep) & USB_EP_SETUP) {
 				type = USB_TRANSACTION_SETUP;
-				st_usbfs_ep_read_packet(dev, ep, &dev->control_state.req, 8);
 			} else {
 				type = USB_TRANSACTION_OUT;
 			}

--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -212,8 +212,6 @@ static void usb_control_setup_write(usbd_device *usbd_dev,
 	} else {
 		usbd_dev->control_state.state = LAST_DATA_OUT;
 	}
-
-	usbd_ep_nak_set(usbd_dev, 0, 0);
 }
 
 /* Do not appear to belong to the API, so are omitted from docs */
@@ -225,8 +223,6 @@ void _usbd_control_setup(usbd_device *usbd_dev, uint8_t ea)
 	(void)ea;
 
 	usbd_dev->control_state.complete = NULL;
-
-	usbd_ep_nak_set(usbd_dev, 0, 1);
 
 	if (usbd_ep_read_packet(usbd_dev, 0, req, 8) != 8) {
 		stall_transaction(usbd_dev);
@@ -299,7 +295,6 @@ void _usbd_control_in(usbd_device *usbd_dev, uint8_t ea)
 		break;
 	case LAST_DATA_IN:
 		usbd_dev->control_state.state = STATUS_OUT;
-		usbd_ep_nak_set(usbd_dev, 0, 0);
 		break;
 	case STATUS_IN:
 		if (usbd_dev->control_state.complete) {

--- a/lib/usb/usb_control.c
+++ b/lib/usb/usb_control.c
@@ -228,6 +228,11 @@ void _usbd_control_setup(usbd_device *usbd_dev, uint8_t ea)
 
 	usbd_ep_nak_set(usbd_dev, 0, 1);
 
+	if (usbd_ep_read_packet(usbd_dev, 0, req, 8) != 8) {
+		stall_transaction(usbd_dev);
+		return;
+	}
+
 	if (req->wLength == 0) {
 		usb_control_setup_read(usbd_dev, req);
 	} else if (req->bmRequestType & 0x80) {

--- a/lib/usb/usb_dwc_common.c
+++ b/lib/usb/usb_dwc_common.c
@@ -358,11 +358,6 @@ void dwc_poll(usbd_device *usbd_dev)
 		uint32_t rxstsp = REBASE(OTG_GRXSTSP);
 		uint32_t pktsts = rxstsp & OTG_GRXSTSP_PKTSTS_MASK;
 		uint8_t ep = rxstsp & OTG_GRXSTSP_EPNUM_MASK;
-
-		if (pktsts == OTG_GRXSTSP_PKTSTS_SETUP_COMP) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_SETUP] (usbd_dev, ep);
-		}
-
 		if (pktsts == OTG_GRXSTSP_PKTSTS_OUT_COMP
 			|| pktsts == OTG_GRXSTSP_PKTSTS_SETUP_COMP)  {
 			REBASE(OTG_DOEPTSIZ(ep)) = usbd_dev->doeptsiz[ep];
@@ -395,9 +390,7 @@ void dwc_poll(usbd_device *usbd_dev)
 		/* Save packet size for dwc_ep_read_packet(). */
 		usbd_dev->rxbcnt = (rxstsp & OTG_GRXSTSP_BCNT_MASK) >> 4;
 
-		if (type == USB_TRANSACTION_SETUP) {
-			dwc_ep_read_packet(usbd_dev, ep, &usbd_dev->control_state.req, 8);
-		} else if (usbd_dev->user_callback_ctr[ep][type]) {
+		if (usbd_dev->user_callback_ctr[ep][type]) {
 			usbd_dev->user_callback_ctr[ep][type] (usbd_dev, ep);
 		}
 

--- a/lib/usb/usb_lm4f.c
+++ b/lib/usb/usb_lm4f.c
@@ -503,9 +503,6 @@ static void lm4f_poll(usbd_device *usbd_dev)
 				usbd_dev->control_state.state != LAST_DATA_OUT)
 				? USB_TRANSACTION_SETUP :
 				  USB_TRANSACTION_OUT;
-			if (type == USB_TRANSACTION_SETUP) {
-				lm4f_ep_read_packet(usbd_dev, 0, &usbd_dev->control_state.req, 8);
-			}
 			if (usbd_dev->user_callback_ctr[0][type]) {
 				usbd_dev->
 					user_callback_ctr[0][type](usbd_dev, 0);


### PR DESCRIPTION
Commit 26ab78a introduced a fix for issue #873 (*regression of the FIFO word loss issue*) but broke USB completely for all STM32s chips using the DWC USB core with ID 0x2000. This PR is a solution for both the word loss issue in 0x1200 cores as well as the broken USB for 0x2000 cores.

## Analysis

An analysis showed that the cores with ID 0x1200 and 0x200 behave slightly differently when it comes to OUT endpoints. Both are supposed to trigger two consecutive interrupts with two different packet status (see description of OTG_GRXSTSP register):

1. OUT data packet received
2. OUT transfer completed

Since the endpoints are configured for a single packet only, the core will set the NAK flag on the endpoint when a packet is received. On cores with ID 0x1200 the flag *MUST NOT* be cleared after the first interrupt. Otherwise four bytes are lost. On cores with ID 0x2000, the flag *MUST* be cleared after the first interrupt. Otherwise the second interrupt never occurs.

So on chips with core 0x2000, OUT endpoint 0 remained in NAK as the second interrupt, which reset the NAK flag, never occurred.

## Tests

This change has been successfully tested both with *gadget0* and source/sink/loopback test for bulk endpoints that makes heavy use of flow control (`usbd_ep_nak_set`) on different hardware:

- NUCLEO-F042K6
- Chinese BlackPill with STM32F103CB
- Chinese board with STM32F401CC
- NUCELO-F411RE
- NUCELO-F412ZG
- NUCELO-F446RE
- NUCELO-L476RG

The test has been executed with 4 additional PRs installed:
- PR #1259 Fix usb_dwc_common.c late IN usb interrupt flag clearing, #1241
- PR #1258 Fix usb_dwc_common.c endpoint initialization
- PR #1257 USB OTG driver for STM32L4 
- PR #1256 Disable VBUS sensing 

The tests use both USB polling in the main loop (gadget0) and USB processing in the USB interrupt handler (loopback).

## Additional Notes

This PR basically reverts two commits:

- 26ab78a as it broke the USB for cores with ID 0x2000 in the first place
- PR #785 (*Ensure control events are handled in order*) / commit 9b60f303b36d7fb97d0250582755751ddd680a99

If the latter one is still a problem even with this fix applied, it must be solved differently, e.g. by first fetching the RX FIFO and then the TX FIFO (instead of the other way round). Forcing NAK (as done by 9b60f303b36d7fb97d0250582755751ddd680a99) will at best solve part of the problem as the core ignores the NAK flag for SETUP data packets (see description of flag NAKSTS of register OTG_DIEPCTL0).

Most likely, the current implementation of `usbd_ep_nak_set` is not sufficiently robust. If the NAK flag is set between the *OUT data packet received* event and the *OUT transfer completed* event, data might be lost. But that is work for a future PR...
