### PR TITLE
usb-dwc: clear STUP interrupt flag

### DIFF
--- a/lib/usb/usb_dwc_common.c
+++ b/lib/usb/usb_dwc_common.c
@@ -350,6 +350,14 @@ void dwc_poll(usbd_device *usbd_dev)
 
 			REBASE(OTG_DIEPINT(i)) = OTG_DIEPINTX_XFRC;
 		}
+
+		/*
+		 * On some controllers the STUP interrupt flag seems to inhibit
+		 * the internal state machine from entering the setup completed
+		 * state again. Thus it must be cleared.
+		 */
+		REBASE(OTG_DOEPINT(i)) = OTG_DOEPINTX_STUP;
+
 	}
 
 	/* Note: RX and TX handled differently in this device. */


### PR DESCRIPTION
Previously the STUP interrupt flag was never cleared.
On the STM32F722 the STUP interrupt flag seems to stops the internal
statemachine of the USB core from reaching the setup finished state.
This renders the USB controller unusable.

This commit ensures the STUP interrupt flag is cleared whenever the
driver is polled.

I do not have a whole lot of experience with DWC usb controllers, thus I'm unable to gauge whether this change breaks exisiting device support. Thus I'd love to see this change tested on as many devices as possible before it is merged,

I've tested this change on a STM32F722RET6 with cdcacm and it works great.