### PR TITLE
USB OTG support for STM32F7 series

### DIFF
--- a/include/libopencm3/usb/dwc/otg_fs.h
+++ b/include/libopencm3/usb/dwc/otg_fs.h
@@ -28,7 +28,7 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_FS_BASE address */
-#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4)
+#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4) || defined(STM32F7) || defined(STM32L4)
 #	include <libopencm3/stm32/memorymap.h>
 #elif defined(EFM32HG)
 #	include <libopencm3/efm32/memorymap.h>

--- a/include/libopencm3/usb/dwc/otg_hs.h
+++ b/include/libopencm3/usb/dwc/otg_hs.h
@@ -28,7 +28,7 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_HS_BASE address */
-#if defined(STM32F2) || defined(STM32F4)
+#if defined(STM32F2) || defined(STM32F4) || defined(STM32F7)
 #	include <libopencm3/stm32/memorymap.h>
 #else
 #	error "device family not supported by dwc/otg_hs."

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -63,6 +63,10 @@ OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o
 OBJS += usart_common_all.o usart_common_v2.o
 
+OBJS += usb.o usb_standard.o usb_control.o usb_msc.o
+OBJS += usb_hid.o
+OBJS += usb_dwc_common.o usb_f107.o usb_f207.o
+
 # Ethernet
 OBJS += mac.o phy.o mac_stm32fxx7.o phy_ksz80x1.o
 


### PR DESCRIPTION
This PR adds the changes required to add USB OTG support for the STM32F7 series. It consists of minor changes (additional files in Makefile, extended #ifdef).

The changes has been successfully tested with gadget0 and a loopback test on:

- Nucleo F722ZE
- Discovery F723E

The changes have been tested with several PRs applied:
- #1256 Disable VBUS sensing
- #1258 Fix usb_dwc_common.c endpoint initialization
- #1259 Fix usb_dwc_common.c late IN usb interrupt flag clearing
- #1261 USB Core 0x2000 fix

The PR is likely in conflict with #1257 *USB OTG driver for STM32L4* as it extends the same lines. Merging it will however be easy.