### PR TITLE
Update python references to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Building requires Python (some code is generated).
  Download and install:
 
  - msys - http://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.11/MSYS-1.0.11.exe
- - Python - http://www.python.org/ftp/python/2.7/python-2.7.msi (any 2.7 release)
+ - Python - https://www.python.org/downloads/windows/ (any release)
  - arm-none-eabi/arm-elf toolchain (for example this one https://launchpad.net/gcc-arm-embedded)
 
-Run msys shell and set the path without standard Windows paths, so Windows programs such as 'find' won't interfere:
+Run msys shell and set the path without standard Windows paths (adjusting to your version of Python), so Windows programs such as 'find' won't interfere:
 
-    export PATH="/c//Python27:/c/ARMToolchain/bin:/usr/local/bin:/usr/bin:/bin"
+    export PATH="/c//Program Files/Python 3.9:/c/ARMToolchain/bin:/usr/local/bin:/usr/bin:/bin"
 
 After that you can navigate to the folder where you've extracted libopencm3 and build it.
 

--- a/scripts/data/lpc43xx/csv2yaml.py
+++ b/scripts/data/lpc43xx/csv2yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import yaml
@@ -18,8 +18,8 @@ def convert_file(fname):
         register = registers[register_name]
         fields = register['fields']
         if field_name in fields:
-            raise RuntimeError('Duplicate field name "%s" in register "%s"' %
-                    field_name, register_name)
+            raise RuntimeError('Duplicate field name "%s" in register "%s"'
+                               % (field_name, register_name))
         else:
             fields[field_name] = {
                 'lsb': int(lsb),

--- a/scripts/data/lpc43xx/gen.py
+++ b/scripts/data/lpc43xx/gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import yaml
@@ -7,7 +7,7 @@ registers = yaml.load(open(sys.argv[1], 'r'))
 
 for register_name, register in registers.iteritems():
     print('/* --- %s values %s */' % (register_name, '-' * (50 - len(register_name))))
-    print
+    print()
     fields = register['fields']
     #for field_name, field in sorted(fields.items(), lambda x, y: cmp(x[1]['lsb'], y[1]['lsb'])):
     for field_name, field in fields.items():
@@ -22,4 +22,4 @@ for register_name, register in registers.iteritems():
         print('#define %s_%s(x) ((x) << %s_%s_SHIFT)' % (
             register_name, field_name, register_name, field_name,
         ))
-        print
+        print()

--- a/scripts/gendoxylayout.py
+++ b/scripts/gendoxylayout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This python program generates parameters for the linker script generator feature.
 
 # This file is part of the libopencm3 project.

--- a/scripts/genlink.py
+++ b/scripts/genlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This python program generates parameters for the linker script generator feature.
 
 # This file is part of the libopencm3 project.
@@ -17,7 +17,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import print_function
 import fnmatch
 import sys
 import re

--- a/scripts/irq2nvic_h
+++ b/scripts/irq2nvic_h
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of the libopencm3 project.
 # 

--- a/scripts/lpcvtcksum
+++ b/scripts/lpcvtcksum
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Compute and insert the vector table checksum required for booting the
 # LPC43xx and some other NXP ARM microcontrollers.
@@ -29,12 +29,10 @@ rawvectors = binfile.read(32)
 vectors = list(struct.unpack('<IIIIIIII', rawvectors))
 
 # compute vector table checksum
-sum = 0
-for i in range(7):
-	sum += vectors[i]
-vectors[7] = 1 + (0xffffffff ^ (0xffffffff & sum))
+vectors_sum = sum(vectors[:7])
+vectors[7] = 1 + (0xffffffff ^ (0xffffffff & vectors_sum))
 
-print "computed vector table checksum: 0x%08x" % vectors[7]
+print("computed vector table checksum: 0x%08x" % vectors[7])
 
 rawremainder = binfile.read()
 remainder = list(struct.unpack('B' * len(rawremainder), rawremainder))

--- a/tests/gadget-zero/Jenkinsfile
+++ b/tests/gadget-zero/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
         		. .env3/bin/activate
         		cd tests/gadget-zero
         		rm -rf tests
-        		python test_gadget0.py -X
+        		python3 test_gadget0.py -X
         		for x in tests/*; do TT=$(basename \$x); sed -i "s/testcase\\ classname=\\"/testcase\\ classname=\\"\${TT}./g" \$x/TEST-*; done
         		'''
             }


### PR DESCRIPTION
Python2 is end-of-life [1] since the 1st of January 2020.

Some distributions (most notably: Debian and its derivatives) will stop
providing a `python` executable in order to encourage users to specify
the interpreter language of local scripts explicitly.  Users of such
environments will be forced to work around this in one of these ways:

* create a virtual environment or
* manipulate the shebangs of the scripts or
* install the python2 package (as long as it is provided by distributions)

All currently maintained distribution releases provide python3.
In the near future distributions will need to remove python2, since it
is not maintained anymore.

PEP-394 [2] recommends to reference a specific python version
(python2 or python3), if the script is not expected to run in a virtual
environment.

Closes: #1265

[1] https://www.python.org/dev/peps/pep-0373/#update-april-2014
[2] https://www.python.org/dev/peps/pep-0394/#for-python-script-publishers