### PR TITLE
stm32g4: add SPI

### DIFF
--- a/include/libopencm3/stm32/g4/spi.h
+++ b/include/libopencm3/stm32/g4/spi.h
@@ -1,0 +1,36 @@
+/** @defgroup spi_defines SPI Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G4xx SPI</b>
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @version 1.0.0
+ *
+ * @date 5 December 2012
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_SPI_H
+#define LIBOPENCM3_SPI_H
+
+#include <libopencm3/stm32/common/spi_common_v2.h>
+
+#endif

--- a/include/libopencm3/stm32/spi.h
+++ b/include/libopencm3/stm32/spi.h
@@ -40,6 +40,8 @@
 #       include <libopencm3/stm32/l4/spi.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/spi.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/spi.h>
 #elif defined(STM32H7)
 #       include <libopencm3/stm32/h7/spi.h>
 #else

--- a/lib/stm32/g4/Makefile
+++ b/lib/stm32/g4/Makefile
@@ -44,6 +44,7 @@ OBJS += gpio_common_all.o gpio_common_f0234.o
 OBJS += opamp_common_all.o opamp_common_v2.o
 OBJS += pwr.o
 OBJS += rcc.o rcc_common_all.o
+OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o timer_common_f0234.o
 
 OBJS += usb.o usb_control.o usb_standard.o


### PR DESCRIPTION
The SPI peripheral on G4 is identical to F3, this patch copies the
header files directly from F3