### PR TITLE
usb: avoid modulo operation

### DIFF
--- a/lib/usb/usb_private.h
+++ b/lib/usb/usb_private.h
@@ -74,7 +74,7 @@ struct _usbd_device {
 		uint8_t *ctrl_buf;
 		uint16_t ctrl_len;
 		usbd_control_complete_callback complete;
-		bool needs_zlp;
+		bool may_need_zlp;
 	} control_state;
 
 	struct user_control_callback {


### PR DESCRIPTION
The current code uses modulo using a divisor which is not necessarily
a power of two. This pulls in __aeabi_idivmod and other libgcc provided
functions dealing with division.

The code can be rewritten to determine if a zero-length packet is
actually required once we are transfering the last packet. This improves
runtime as well as code size.