### PR TITLE
STM32: Use const qualifier in i2c_transfer7

### DIFF
--- a/include/libopencm3/stm32/common/i2c_common_v1.h
+++ b/include/libopencm3/stm32/common/i2c_common_v1.h
@@ -415,7 +415,7 @@ void i2c_enable_dma(uint32_t i2c);
 void i2c_disable_dma(uint32_t i2c);
 void i2c_set_dma_last_transfer(uint32_t i2c);
 void i2c_clear_dma_last_transfer(uint32_t i2c);
-void i2c_transfer7(uint32_t i2c, uint8_t addr, uint8_t *w, size_t wn, uint8_t *r, size_t rn);
+void i2c_transfer7(uint32_t i2c, uint8_t addr, const uint8_t *w, size_t wn, uint8_t *r, size_t rn);
 void i2c_set_speed(uint32_t i2c, enum i2c_speeds speed, uint32_t clock_megahz);
 
 END_DECLS

--- a/include/libopencm3/stm32/common/i2c_common_v2.h
+++ b/include/libopencm3/stm32/common/i2c_common_v2.h
@@ -444,7 +444,7 @@ void i2c_enable_rxdma(uint32_t i2c);
 void i2c_disable_rxdma(uint32_t i2c);
 void i2c_enable_txdma(uint32_t i2c);
 void i2c_disable_txdma(uint32_t i2c);
-void i2c_transfer7(uint32_t i2c, uint8_t addr, uint8_t *w, size_t wn, uint8_t *r, size_t rn);
+void i2c_transfer7(uint32_t i2c, uint8_t addr, const uint8_t *w, size_t wn, uint8_t *r, size_t rn);
 void i2c_set_speed(uint32_t i2c, enum i2c_speeds speed, uint32_t clock_megahz);
 
 END_DECLS

--- a/lib/stm32/common/i2c_common_v1.c
+++ b/lib/stm32/common/i2c_common_v1.c
@@ -464,7 +464,7 @@ void i2c_clear_dma_last_transfer(uint32_t i2c)
 	I2C_CR2(i2c) &= ~I2C_CR2_LAST;
 }
 
-static void i2c_write7_v1(uint32_t i2c, int addr, uint8_t *data, size_t n)
+static void i2c_write7_v1(uint32_t i2c, int addr, const uint8_t *data, size_t n)
 {
 	while ((I2C_SR2(i2c) & I2C_SR2_BUSY)) {
 	}
@@ -531,7 +531,7 @@ static void i2c_read7_v1(uint32_t i2c, int addr, uint8_t *res, size_t n)
  * @param r destination buffer to read into
  * @param rn number of bytes to read (r should be at least this long)
  */
-void i2c_transfer7(uint32_t i2c, uint8_t addr, uint8_t *w, size_t wn, uint8_t *r, size_t rn) {
+void i2c_transfer7(uint32_t i2c, uint8_t addr, const uint8_t *w, size_t wn, uint8_t *r, size_t rn) {
 	if (wn) {
 		i2c_write7_v1(i2c, addr, w, wn);
 	}

--- a/lib/stm32/common/i2c_common_v2.c
+++ b/lib/stm32/common/i2c_common_v2.c
@@ -395,7 +395,7 @@ void i2c_disable_txdma(uint32_t i2c)
  * @param r destination buffer to read into
  * @param rn number of bytes to read (r should be at least this long)
  */
-void i2c_transfer7(uint32_t i2c, uint8_t addr, uint8_t *w, size_t wn, uint8_t *r, size_t rn)
+void i2c_transfer7(uint32_t i2c, uint8_t addr, const uint8_t *w, size_t wn, uint8_t *r, size_t rn)
 {
 	/*  waiting for busy is unnecessary. read the RM */
 	if (wn) {


### PR DESCRIPTION
The write buffer (data being sent from the I2C controller to the I2C peripheral) is read-only, so I thought it would be nicer if we made it const.