### PR TITLE
MSC enhancements

### DIFF
--- a/include/libopencm3/usb/msc.h
+++ b/include/libopencm3/usb/msc.h
@@ -78,6 +78,12 @@ typedef struct _usbd_mass_storage usbd_mass_storage;
 #define USB_MSC_REQ_BULK_ONLY_RESET	0xFF
 #define USB_MSC_REQ_GET_MAX_LUN		0xFE
 
+/* SPC-2, 7.12 PREVENT ALLOW MEDIUM REMOVAL, Table 77 */
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_NONE		0x00
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_REMOTE	0x01
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_DEVICE	0x02
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_BOTH		0x03
+
 usbd_mass_storage *usb_msc_init(usbd_device *usbd_dev,
 				 uint8_t ep_in, uint8_t ep_in_size,
 				 uint8_t ep_out, uint8_t ep_out_size,
@@ -87,6 +93,8 @@ usbd_mass_storage *usb_msc_init(usbd_device *usbd_dev,
 				 const uint32_t block_count,
 				 int (*read_block)(uint32_t lba, uint8_t *copy_to),
 				 int (*write_block)(uint32_t lba, const uint8_t *copy_from));
+
+uint8_t usb_msc_get_medium_eject_locked(usbd_mass_storage *msc_dev);
 
 #endif
 

--- a/include/libopencm3/usb/msc.h
+++ b/include/libopencm3/usb/msc.h
@@ -78,6 +78,17 @@ typedef struct _usbd_mass_storage usbd_mass_storage;
 #define USB_MSC_REQ_BULK_ONLY_RESET	0xFF
 #define USB_MSC_REQ_GET_MAX_LUN		0xFE
 
+/* SBC-2, 5.1.22 START STOP UNIT, Table 52 */
+#define USB_MSC_SBC_2_POWER_CONDITION_START		0x10	// Additional code.
+#define USB_MSC_SBC_2_POWER_CONDITION_STOP		0x20	// Additional code.
+#define USB_MSC_SBC_2_POWER_CONDITION_ACTIVE		0x01
+#define USB_MSC_SBC_2_POWER_CONDITION_IDLE		0x02
+#define USB_MSC_SBC_2_POWER_CONDITION_STANDBY		0x03
+#define USB_MSC_SBC_2_POWER_CONDITION_SLEEP		0x05
+#define USB_MSC_SBC_2_POWER_CONDITION_DEVICE		0x07
+#define USB_MSC_SBC_2_POWER_CONDITION_DEVICE_IDLE	0x0A
+#define USB_MSC_SBC_2_POWER_CONDITION_DEVICE_STANDBY	0x0B
+
 /* SPC-2, 7.12 PREVENT ALLOW MEDIUM REMOVAL, Table 77 */
 #define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_NONE		0x00
 #define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_REMOTE	0x01
@@ -95,6 +106,14 @@ usbd_mass_storage *usb_msc_init(usbd_device *usbd_dev,
 				 int (*write_block)(uint32_t lba, const uint8_t *copy_from));
 
 uint8_t usb_msc_get_medium_eject_locked(usbd_mass_storage *msc_dev);
+
+void usb_msc_set_medium_loaded(usbd_mass_storage *msc_dev,
+                               uint8_t is_loaded);
+uint8_t usb_msc_get_medium_loaded(usbd_mass_storage *msc_dev);
+
+void usb_msc_register_power_condition_callback(usbd_mass_storage *msc_dev,
+					       void (*power_condition_changed)(uint8_t power_condition,
+									       uint8_t load_eject));
 
 #endif
 


### PR DESCRIPTION
I implemented some enhancements to the MSC (mass storage class) implementation. Some changes are inspired by [this article](https://medium.com/@ly.lee/stm32-blue-pill-usb-bootloader-how-i-fixed-the-usb-storage-serial-dfu-and-webusb-interfaces-36d7fe245b5c). I hope it is okay to have several changes in one pull request but since later commits depend on earlier ones, I decided to got with it. The changes I made are:

 * d6ac26b: Adds handling for vital product data pages. This omission was already marked as TODO. VPD-pages are mandatory according to SCSI and not supporting them caused long timeouts on Windows 7 when mounting my device. The commit also includes a dummy implementation of the unit serial number VPD-page. While not mandatory by the SCSI standard, not having it, too, caused delays when mounting the device.
 * 4430735: Adds support for the READ FORMAT CAPACITIES scsi command. Again, Windows wants this call to work, so I implemented a minimal version.
 * 89d0841: Not strictly mandatory but if you want to build a MSC device that is removable, you need to support the PREVENT ALLOW MEDIUM REMOVAL command. The implementation accepts all medium lock calls (and exposes the current state to the device firmware). There is no callback support though.
 * 0affe8f: Implements handling of START STOP UNIT, that is the second part of removable MSC support. This call includes a callback that can be used to set the medium loaded state. Setting the medium to not loaded also changes the device status to reflect this state.

Combining all of these changes enables you to write a MSC device that mounts (quickly) on all OSes I could test and that also correctly ejects itself when you eject it in the OS.