### PR TITLE
stm32: dac: new api for waveform characteristics

### DIFF
--- a/include/libopencm3/stm32/common/dac_common_all.h
+++ b/include/libopencm3/stm32/common/dac_common_all.h
@@ -103,9 +103,11 @@ specific memorymap.h header before including this header file.*/
 /** MAMP2[3:0]: DAC channel2 mask/amplitude selector */
 #define DAC_CR_MAMP2_SHIFT		24
 
-/** WAVE2[1:0]: DAC channel2 noise/triangle wave generation enable */
+/** Wave generation mode mask size */
+#define DAC_CR_WAVEx_MASK		0x3
+
+/** WAVE2[1:0]: DAC channel2 wave generation mode*/
 #define DAC_CR_WAVE2_SHIFT		22
-#define DAC_CR_WAVE2_MASK		0x3
 
 /** EN2: DAC channel2 enable */
 #define DAC_CR_EN2			(1 << 16)
@@ -122,9 +124,8 @@ specific memorymap.h header before including this header file.*/
 #define DAC_CR_MAMP1_SHIFT		8
 #define DAC_CR_MAMPx_MASK		0xf
 
-/** WAVEn[1:0]: DAC channel1 noise/triangle wave generation enable */
+/** WAVE1[1:0]: DAC channel1 wave generation mode */
 #define DAC_CR_WAVE1_SHIFT		6
-#define DAC_CR_WAVE1_MASK		0x3
 
 /** EN1: DAC channel1 enable */
 #define DAC_CR_EN1			(1 << 0)
@@ -237,7 +238,9 @@ enum dac_align {
 	DAC_ALIGN_LEFT12,
 };
 
-/** DAC waveform generation options. */
+/** DAC waveform generation options.
+ * Not all wave shapes are available on all parts.
+ */
 enum dac_wave {
 	DAC_WAVE_DISABLE  = 0,
 	DAC_WAVE_NOISE    = 1,
@@ -256,7 +259,7 @@ void dac_dma_disable(uint32_t dac, int channel);
 void dac_trigger_enable(uint32_t dac, int channel);
 void dac_trigger_disable(uint32_t dac, int channel);
 void dac_set_trigger_source(uint32_t dac, uint32_t source);
-void dac_set_waveform_generation(uint32_t dac, enum dac_wave wave);
+void dac_set_waveform_generation(uint32_t dac, int channel, enum dac_wave wave);
 void dac_disable_waveform_generation(uint32_t dac, int channel);
 void dac_set_waveform_characteristics(uint32_t dac, uint8_t mamp1, uint8_t mamp2);
 void dac_load_data_buffer_single(uint32_t dac, uint16_t data,

--- a/include/libopencm3/stm32/common/dac_common_all.h
+++ b/include/libopencm3/stm32/common/dac_common_all.h
@@ -120,6 +120,7 @@ specific memorymap.h header before including this header file.*/
 
 /** MAMP1[3:0]: DAC channel1 mask/amplitude selector */
 #define DAC_CR_MAMP1_SHIFT		8
+#define DAC_CR_MAMPx_MASK		0xf
 
 /** WAVEn[1:0]: DAC channel1 noise/triangle wave generation enable */
 #define DAC_CR_WAVE1_SHIFT		6
@@ -257,7 +258,7 @@ void dac_trigger_disable(uint32_t dac, int channel);
 void dac_set_trigger_source(uint32_t dac, uint32_t source);
 void dac_set_waveform_generation(uint32_t dac, enum dac_wave wave);
 void dac_disable_waveform_generation(uint32_t dac, int channel);
-void dac_set_waveform_characteristics(uint32_t dac, uint8_t mamp);
+void dac_set_waveform_characteristics(uint32_t dac, uint8_t mamp1, uint8_t mamp2);
 void dac_load_data_buffer_single(uint32_t dac, uint16_t data,
                                  enum dac_align align, int channel);
 void dac_load_data_buffer_dual(uint32_t dac, uint16_t data1, uint16_t data2,

--- a/lib/stm32/common/dac_common_all.c
+++ b/lib/stm32/common/dac_common_all.c
@@ -347,12 +347,16 @@ become read-only.
 @note The DAC trigger must be enabled for this to work.
 
 @param[in] dac the base address of the DAC. @ref dac_reg_base
-@param[in] mamp uint8_t. Taken from @ref dac_mamp2 or @ref dac_mamp1 or a
-logical OR of one of each of these to set both channels simultaneously.
+@param[in] mamp1 mask of bits to use for channel 1
+@param[in] mamp2 mask of bits to use for channel 2
 */
-void dac_set_waveform_characteristics(uint32_t dac, uint8_t mamp)
+void dac_set_waveform_characteristics(uint32_t dac, uint8_t mamp1, uint8_t mamp2)
 {
-	DAC_CR(dac) |= mamp;
+	uint32_t reg = DAC_CR(dac);
+	reg &= ~(DAC_CR_MAMPx_MASK << DAC_CR_MAMP1_SHIFT |
+		DAC_CR_MAMPx_MASK << DAC_CR_MAMP2_SHIFT);
+	reg |= mamp1 << DAC_CR_MAMP1_SHIFT | mamp2 << DAC_CR_MAMP2_SHIFT;
+	DAC_CR(dac) = reg;
 }
 
 /** @brief Load DAC Data Register.


### PR DESCRIPTION
Old API required users to manually construct bit maps frm opaquely named
defines, with little help.  It also was a pure OR operation, with no way
to ever clear bits.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>