### PR TITLE
genlink: Provide LIBNAME even if library isn't built yet

### DIFF
--- a/ld/devices.data
+++ b/ld/devices.data
@@ -509,7 +509,7 @@ lpc13u lpc13xx USBRAM_OFF=0x20004000
 lpc17[56]x lpc17xx RAM1_OFF=0x2007C000 RAM2_OFF=0x20080000
 lpc17[78]x lpc17xx RAM1_OFF=0x20000000 RAM2_OFF=0x20004000
 
-lpc43xx_m0 lpc43xx CPU=cortex-m0 FPU=soft
+lpc43xx_m0 lpc43xx CPU=cortex-m0 FPU=soft LIBNAME=lpc43xx_m0
 lpc43xx_m4 lpc43xx CPU=cortex-m4 FPU=hard-fp4-sp-d16
 
 ################################################################################

--- a/mk/genlink-config.mk
+++ b/mk/genlink-config.mk
@@ -25,6 +25,7 @@ LDSCRIPT	= generated.$(DEVICE).ld
 DEVICES_DATA = $(OPENCM3_DIR)/ld/devices.data
 
 genlink_family		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) FAMILY)
+genlink_libname		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) LIBNAME)
 genlink_subfamily	:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) SUBFAMILY)
 genlink_cpu		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) CPU)
 genlink_fpu		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) FPU)
@@ -52,18 +53,7 @@ ifeq ($(genlink_family),)
 $(warning $(DEVICE) not found in $(DEVICES_DATA))
 endif
 
-# only append to LDFLAGS if the library file exists to not break builds
-# where those are provided by different means
-ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(genlink_family).a))
-LIBNAME = opencm3_$(genlink_family)
-else
-ifneq (,$(wildcard $(OPENCM3_DIR)/lib/libopencm3_$(genlink_subfamily).a))
-LIBNAME = opencm3_$(genlink_subfamily)
-else
-$(warning $(OPENCM3_DIR)/lib/libopencm3_$(genlink_family).a library variant for the selected device does not exist.)
-endif
-endif
-
+LIBNAME ?= opencm3_$(genlink_libname)
 LDLIBS += -l$(LIBNAME)
 LIBDEPS += $(OPENCM3_DIR)/lib/lib$(LIBNAME).a
 

--- a/scripts/genlink.py
+++ b/scripts/genlink.py
@@ -116,6 +116,11 @@ elif mode == 'SUBFAMILY':
     if len(device['family']) > 1:
         sys.stdout.write(device['family'][1])
 
+# library name suffix for device
+elif mode == 'LIBNAME':
+    libname = dict(device['defs']).get('LIBNAME', device['family'][0])
+    sys.stdout.write(libname)
+
 # device info
 else:
     info = mode.lower()


### PR DESCRIPTION
Currently genlink-config.mk tries to look for the device library by first
looking for the family and then subfamily suffix. This has two problems:

1) If the library wasn't built yet we get a warning and LIBNAME isn't
set. This makes building libopencm3 automatically as part of another
project's makefile uneccesarily difficult as LIBNAME has to be hardcoded as a
workaround.

2) In the special case of the lpc43xx_m0 "device" the correct LIBNAME is
actually the one with subfamily suffix, but currently we prefere the family
one.

Both of these issues are fixed by makeing the canonical LIBNAME part of the
genlink's database. When asking genlink for a LIBNAME we default to the
family suffix so as to not require annotating evey device manually but
allow overriding this by specifying a LIBNAME as a definition in
devices.data.

Currently lpc43xx_m0 is the only odd one out that requires this though.

---
This was submitted as part of #1137 previously. Commit d60d7802 seems to have fixed some of the GENHDR problems since I submitted my fix for that.

Tested by building libopencm3-template and libopencm3-examples with this. Still seems to work fine apart from a small LDSCRIPT fix due to e15071dbf8 I assume.