### PR TITLE
stm32g4: Add support for selecting peripheral clock source

### DIFF
--- a/include/libopencm3/stm32/g4/rcc.h
+++ b/include/libopencm3/stm32/g4/rcc.h
@@ -1031,6 +1031,7 @@ uint32_t rcc_system_clock_source(void);
 void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
 void __attribute__((deprecated("Use rcc_clock_setup_pll as direct replacement"))) rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
 void rcc_set_clock48_source(uint32_t clksel);
+void rcc_set_peripheral_clk_sel(uint32_t periph, uint32_t sel);
 
 END_DECLS
 

--- a/lib/stm32/g4/rcc.c
+++ b/lib/stm32/g4/rcc.c
@@ -10,8 +10,9 @@
  * @author @htmlonly &copy; @endhtmlonly 2013 Frantisek Burian <BuFran at seznam.cz>
  * @author @htmlonly &copy; @endhtmlonly 2020 Sam Kirkham <sam.kirkham@codethink.co.uk>
  * @author @htmlonly &copy; @endhtmlonly 2020 Ben Brewer <ben.brewer@codethink.co.uk>
+ * @author @htmlonly &copy; @endhtmlonly 2021 Eduard Drusa <ventyl86 at netkosice dot sk>
  *
- * @date 30 July 2020
+ * @date 17 Feb 2021
  *
  * This library supports the Reset and Clock Control System in the STM32 series
  * of ARM Cortex Microcontrollers by ST Microelectronics.
@@ -28,6 +29,7 @@
  * Copyright (C) 2013 Frantisek Burian <BuFran at seznam.cz>
  * Copyright (C) 2020 Sam Kirkham <sam.kirkham@codethink.co.uk>
  * Copyright (C) 2020 Ben Brewer <ben.brewer@codethink.co.uk>
+ * Copyright (C) 2021 Eduard Drusa <ventyl86 at netkosice dot sk>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -761,6 +763,111 @@ void rcc_set_clock48_source(uint32_t clksel)
 {
 	RCC_CCIPR &= ~(RCC_CCIPR_SEL_MASK << RCC_CCIPR_CLK48_SHIFT);
 	RCC_CCIPR |= (clksel << RCC_CCIPR_CLK48_SHIFT);
+}
+
+/** @brief Select clock fed into specific peripheral.
+ *
+ * This allows to select, which clock will drive certain peripherals
+ * if those can be driven by more than on possible clock source.
+ * @param periph identification of peripheral by the means of its base address (use xxx_BASE defines)
+ * @param sel clock source selected to drive given peripheral (use RCC_CCIPR_<device>_<source> defines)
+ * @note Mind the fact that clock domains for certain devices are bound
+ * together. This means that e.g. ADC1_BASE and ADC2_BASE will both work
+ * as an input to rcc_set_peripheral_clk_sel, but both will configure the
+ * same clock input effectively affecting each other.
+ */
+void rcc_set_peripheral_clk_sel(uint32_t periph, uint32_t sel)
+{
+	uint8_t shift;
+	uint32_t mask = RCC_CCIPR_SEL_MASK;
+
+	switch(periph)
+	{
+		case USART1_BASE:
+			shift = RCC_CCIPR_USART1_SHIFT;
+			break;
+
+		case USART2_BASE:
+			shift = RCC_CCIPR_USART2_SHIFT;
+			break;
+
+		case USART3_BASE:
+			shift = RCC_CCIPR_USART3_SHIFT;
+			break;
+
+		case UART4_BASE:
+			shift = RCC_CCIPR_UART4_SHIFT;
+			break;
+
+		case UART5_BASE:
+			shift = RCC_CCIPR_UART5_SHIFT;
+			break;
+
+		case LPUART1_BASE:
+			shift = RCC_CCIPR_LPUART1SEL_SHIFT;
+			break;
+
+		case I2C1_BASE:
+			shift = RCC_CCIPR_I2C1_SHIFT;
+			break;
+
+		case I2C2_BASE:
+			shift = RCC_CCIPR_I2C2_SHIFT;
+			break;
+
+		case I2C3_BASE:
+			shift = RCC_CCIPR_I2C3_SHIFT;
+			break;
+
+		case LPTIM1_BASE:
+			shift = RCC_CCIPR_LPTIM1SEL_SHIFT;
+			break;
+
+		case SAI1_BASE:
+			shift = RCC_CCIPR_SAI1_SHIFT;
+			break;
+
+		case SPI2_BASE:
+			// fall through
+		case SPI3_BASE:
+			shift = RCC_CCIPR_I2S23_SHIFT;
+			break;
+
+		case FDCAN1_BASE:
+			// fall through
+		case FDCAN2_BASE:
+			// fall through
+		case FDCAN3_BASE:
+			shift = RCC_CCIPR_FDCAN_SHIFT;
+			break;
+
+		case USB_DEV_FS_BASE:
+			// fall through
+		case RNG_BASE:
+			shift = RCC_CCIPR_CLK48_SHIFT;
+			break;
+
+		case ADC1_BASE:
+			// fall through
+		case ADC2_BASE:
+			shift = RCC_CCIPR_ADC12_SHIFT;
+			break;
+
+		case ADC3_BASE:
+			// fall through
+		case ADC4_BASE:
+			// fall through
+		case ADC5_BASE:
+			shift = RCC_CCIPR_ADC345_SHIFT;
+			break;
+
+		default:
+			cm3_assert_not_reached();
+			return;
+	}
+
+	uint32_t reg32 = RCC_CCIPR & ~(mask << shift);
+	RCC_CCIPR = reg32 | ((sel & mask) << shift);
 }
 
 /**@}*/


### PR DESCRIPTION
Implemented rcc_set_peripheral_clk_sel function for STM32G4. Again.