### PR TITLE
STM32 RTC: added better RTC periph API functions

### DIFF
--- a/include/libopencm3/stm32/common/rtc_common_l1f024.h
+++ b/include/libopencm3/stm32/common/rtc_common_l1f024.h
@@ -426,6 +426,20 @@ specific memorymap.h header before including this header file.*/
 #define RTC_ALRMXSSR_SS_SHIFT     (0)
 #define RTC_ALARXSSR_SS_MASK      (0x7fff)
 
+enum rtc_fmt {
+	RTC_CR_FMT_24H = 0x0,
+	RTC_CR_FMT_12H,
+};
+
+enum rtc_wdu {
+	RTC_DR_WDU_MON = 0x01,
+	RTC_DR_WDU_TUE,
+	RTC_DR_WDU_WED,
+	RTC_DR_WDU_THU,
+	RTC_DR_WDU_FRI,
+	RTC_DR_WDU_SAT,
+	RTC_DR_WDU_SUN,
+};
 
 BEGIN_DECLS
 
@@ -435,6 +449,23 @@ void rtc_lock(void);
 void rtc_unlock(void);
 void rtc_set_wakeup_time(uint16_t wkup_time, uint8_t rtc_cr_wucksel);
 void rtc_clear_wakeup_flag(void);
+void rtc_set_init_flag(void);
+void rtc_clear_init_flag(void);
+bool rtc_init_flag_is_ready(void);
+void rtc_wait_for_init_ready(void);
+void rtc_set_bypass_shadow_register(void);
+void rtc_enable_bypass_shadow_register(void);
+void rtc_disable_bypass_shadow_register(void);
+void rtc_set_hour_format(enum rtc_fmt fmt);
+void rtc_calendar_set_year(uint8_t year_tens, uint8_t year_units);
+void rtc_calendar_set_weekday(enum rtc_wdu weekday);
+void rtc_calendar_set_month(uint8_t month_tens, uint8_t month_units);
+void rtc_calendar_set_day(uint8_t day_tens, uint8_t day_units);
+void rtc_time_set_am_notation(void);
+void rtc_time_set_pm_notation(void);
+void rtc_time_set_hour(uint8_t hour_tens, uint8_t hour_units);
+void rtc_time_set_minute(uint8_t min_tens, uint8_t min_units);
+void rtc_time_set_second(uint8_t sec_tens, uint8_t sec_units);
 
 END_DECLS
 /**@}*/

--- a/include/libopencm3/stm32/common/rtc_common_l1f024.h
+++ b/include/libopencm3/stm32/common/rtc_common_l1f024.h
@@ -426,12 +426,7 @@ specific memorymap.h header before including this header file.*/
 #define RTC_ALRMXSSR_SS_SHIFT     (0)
 #define RTC_ALARXSSR_SS_MASK      (0x7fff)
 
-enum rtc_fmt {
-	RTC_CR_FMT_24H = 0x0,
-	RTC_CR_FMT_12H,
-};
-
-enum rtc_wdu {
+enum rtc_weekday {
 	RTC_DR_WDU_MON = 0x01,
 	RTC_DR_WDU_TUE,
 	RTC_DR_WDU_WED,
@@ -456,16 +451,15 @@ void rtc_wait_for_init_ready(void);
 void rtc_set_bypass_shadow_register(void);
 void rtc_enable_bypass_shadow_register(void);
 void rtc_disable_bypass_shadow_register(void);
-void rtc_set_hour_format(enum rtc_fmt fmt);
-void rtc_calendar_set_year(uint8_t year_tens, uint8_t year_units);
-void rtc_calendar_set_weekday(enum rtc_wdu weekday);
-void rtc_calendar_set_month(uint8_t month_tens, uint8_t month_units);
-void rtc_calendar_set_day(uint8_t day_tens, uint8_t day_units);
-void rtc_time_set_am_notation(void);
-void rtc_time_set_pm_notation(void);
-void rtc_time_set_hour(uint8_t hour_tens, uint8_t hour_units);
-void rtc_time_set_minute(uint8_t min_tens, uint8_t min_units);
-void rtc_time_set_second(uint8_t sec_tens, uint8_t sec_units);
+void rtc_set_am_format(void);
+void rtc_set_pm_format(void);
+void rtc_calendar_set_year(uint8_t year);
+void rtc_calendar_set_weekday(enum rtc_weekday rtc_dr_wdu);
+void rtc_calendar_set_month(uint8_t month);
+void rtc_calendar_set_day(uint8_t day);
+void rtc_time_set_hour(uint8_t hour, bool am_notation);
+void rtc_time_set_minute(uint8_t minute);
+void rtc_time_set_second(uint8_t second);
 
 END_DECLS
 /**@}*/

--- a/include/libopencm3/stm32/common/rtc_common_l1f024.h
+++ b/include/libopencm3/stm32/common/rtc_common_l1f024.h
@@ -457,7 +457,7 @@ void rtc_calendar_set_year(uint8_t year);
 void rtc_calendar_set_weekday(enum rtc_weekday rtc_dr_wdu);
 void rtc_calendar_set_month(uint8_t month);
 void rtc_calendar_set_day(uint8_t day);
-void rtc_time_set_hour(uint8_t hour, bool am_notation);
+void rtc_time_set_hour(uint8_t hour, bool use_am_notation);
 void rtc_time_set_minute(uint8_t minute);
 void rtc_time_set_second(uint8_t second);
 

--- a/include/libopencm3/stm32/common/rtc_common_l1f024.h
+++ b/include/libopencm3/stm32/common/rtc_common_l1f024.h
@@ -457,9 +457,11 @@ void rtc_calendar_set_year(uint8_t year);
 void rtc_calendar_set_weekday(enum rtc_weekday rtc_dr_wdu);
 void rtc_calendar_set_month(uint8_t month);
 void rtc_calendar_set_day(uint8_t day);
+void rtc_calendar_set_date(uint8_t year, uint8_t month, uint8_t day, enum rtc_weekday rtc_dr_wdu);
 void rtc_time_set_hour(uint8_t hour, bool use_am_notation);
 void rtc_time_set_minute(uint8_t minute);
 void rtc_time_set_second(uint8_t second);
+void rtc_time_set_time(uint8_t hour, uint8_t minute, uint8_t second, bool use_am_notation);
 
 END_DECLS
 /**@}*/

--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -539,7 +539,7 @@ enum rcc_periph_rst {
 	RST_CEC		= _REG_BIT(0x10, 30),
 
 	/* Advanced peripherals */
-	RST_BACKUPDOMAIN = _REG_BIT(0x20, 16),/* BDCR[16] */
+	RST_BDCR = _REG_BIT(0x20, 16),/* BDCR[16] */
 
 	/* AHB peripherals */
 	RST_GPIOA	= _REG_BIT(0x28, 17),

--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -538,7 +538,7 @@ enum rcc_periph_rst {
 	RST_DAC1	= _REG_BIT(0x10, 29), /* Compatibility alias */
 	RST_CEC		= _REG_BIT(0x10, 30),
 
-	/* RTC domain control */
+	/* Backup domain control */
 	RST_BDCR	= _REG_BIT(0x20, 16),/* BDCR[16] */
 
 	/* AHB peripherals */

--- a/include/libopencm3/stm32/f0/rcc.h
+++ b/include/libopencm3/stm32/f0/rcc.h
@@ -538,8 +538,8 @@ enum rcc_periph_rst {
 	RST_DAC1	= _REG_BIT(0x10, 29), /* Compatibility alias */
 	RST_CEC		= _REG_BIT(0x10, 30),
 
-	/* Advanced peripherals */
-	RST_BDCR = _REG_BIT(0x20, 16),/* BDCR[16] */
+	/* RTC domain control */
+	RST_BDCR	= _REG_BIT(0x20, 16),/* BDCR[16] */
 
 	/* AHB peripherals */
 	RST_GPIOA	= _REG_BIT(0x28, 17),

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -1092,6 +1092,9 @@ enum rcc_periph_rst {
 	RST_SAI1RST	= _REG_BIT(0x24, 22),/* F42x, F43x */
 	RST_LTDC	= _REG_BIT(0x24, 26),/* F42x, F43x */
 	RST_DSI		= _REG_BIT(0x24, 27),/* F42x, F43x */
+
+	/* Advanced peripherals */
+	RST_BDCR	= _REG_BIT(0x70, 16),/* BDCR[16] */
 };
 
 #undef _REG_BIT

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -1093,7 +1093,7 @@ enum rcc_periph_rst {
 	RST_LTDC	= _REG_BIT(0x24, 26),/* F42x, F43x */
 	RST_DSI		= _REG_BIT(0x24, 27),/* F42x, F43x */
 
-	/* Advanced peripherals */
+	/* RTC domain control */
 	RST_BDCR	= _REG_BIT(0x70, 16),/* BDCR[16] */
 };
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -1093,7 +1093,7 @@ enum rcc_periph_rst {
 	RST_LTDC	= _REG_BIT(0x24, 26),/* F42x, F43x */
 	RST_DSI		= _REG_BIT(0x24, 27),/* F42x, F43x */
 
-	/* RTC domain control */
+	/* Backup domain control */
 	RST_BDCR	= _REG_BIT(0x70, 16),/* BDCR[16] */
 };
 

--- a/lib/stm32/common/rtc_common_l1f024.c
+++ b/lib/stm32/common/rtc_common_l1f024.c
@@ -265,12 +265,12 @@ void rtc_calendar_set_day(uint8_t day)
 
 @details Requires unlocking the RTC write-protection (RTC_WPR)
 
-Pass true to am_notation to use 24-hour input time; pass false to am_notation
-to use 12-hour (AM/PM) input time
+Pass true to use_am_notation to use 24-hour input time; pass false to
+use_am_notation to use 12-hour (AM/PM) input time
 */
-void rtc_time_set_hour(uint8_t hour, bool am_notation)
+void rtc_time_set_hour(uint8_t hour, bool use_am_notation)
 {
-	if (am_notation)
+	if (use_am_notation)
 		RTC_TR &= ~(RTC_TR_PM);
 	else
 		RTC_TR |= RTC_TR_PM;

--- a/lib/stm32/common/rtc_common_l1f024.c
+++ b/lib/stm32/common/rtc_common_l1f024.c
@@ -211,6 +211,9 @@ void rtc_set_pm_format(void)
 /** @brief Sets the RTC BCD calendar year value
 
 @details Requires unlocking the RTC write-protection (RTC_WPR)
+
+The year value should only be the abbreviated year tens, meaning if 2021 is
+desired pass in only 21.
 */
 void rtc_calendar_set_year(uint8_t year)
 {

--- a/lib/stm32/common/rtc_common_l1f024.c
+++ b/lib/stm32/common/rtc_common_l1f024.c
@@ -264,6 +264,9 @@ void rtc_calendar_set_day(uint8_t day)
 /** @brief Sets the RTC BCD calendar value
 
 @details Requires unlocking the RTC write-protection (RTC_WPR)
+
+The year value should only be the abbreviated year tens, meaning if 2021 is
+desired pass in only 21.
 */
 void rtc_calendar_set_date(uint8_t year, uint8_t month, uint8_t day, enum rtc_weekday rtc_dr_wdu)
 {

--- a/lib/stm32/common/rtc_common_l1f024.c
+++ b/lib/stm32/common/rtc_common_l1f024.c
@@ -122,4 +122,189 @@ void rtc_clear_wakeup_flag(void)
 	RTC_ISR &= ~RTC_ISR_WUTF;
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the initialization flag
+
+@details Requires unlocking backup domain write protection (PWR_CR_DBP)
+*/
+void rtc_set_init_flag(void)
+{
+	RTC_ISR |= RTC_ISR_INIT;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clears (resets) the initialization flag
+
+@details Requires unlocking backup domain write protection (PWR_CR_DBP)
+*/
+void rtc_clear_init_flag(void)
+{
+	RTC_ISR &= ~RTC_ISR_INIT;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Returns if the RTC_ISR init flag RTC_ISR_INITF is set
+
+@details Requires unlocking backup domain write protection (PWR_CR_DBP)
+*/
+bool rtc_init_flag_is_ready(void)
+{
+	return (RTC_ISR & RTC_ISR_INITF);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Waits infinitely for initialization flag to be set in RTC_ISR
+
+@details Requires unlocking backup domain write protection (PWR_CR_DBP)
+*/
+void rtc_wait_for_init_ready(void)
+{
+	while (!rtc_init_flag_is_ready());
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the bypass shadow bit in RTC_CR
+
+@details Requires unlocking backup domain write protection (PWR_CR_DBP)
+*/
+void rtc_enable_bypass_shadow_register(void)
+{
+	RTC_CR |= RTC_CR_BYPSHAD;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Clears the bypass shadow bit in RTC_CR
+
+@details Requires unlocking backup domain write protection (PWR_CR_DBP)
+*/
+void rtc_disable_bypass_shadow_register(void)
+{
+	RTC_CR &= ~RTC_CR_BYPSHAD;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC hour format (24h or 12h)
+
+@details Requires unlocking backup domain write protection (PWR_CR_DBP)
+*/
+void rtc_set_hour_format(enum rtc_fmt fmt)
+{
+	switch (fmt) {
+	case RTC_CR_FMT_24H:
+		RTC_CR &= ~RTC_CR_FMT;
+		break;
+	case RTC_CR_FMT_12H:
+		RTC_CR |= RTC_CR_FMT;
+		break;
+	}
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD calendar year value (tens and ones)
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_calendar_set_year(uint8_t year_tens, uint8_t year_units)
+{
+	RTC_DR = ((year_tens & RTC_DR_YT_MASK) << RTC_DR_YT_SHIFT) |
+		(RTC_DR & ~(RTC_DR_YT_MASK << RTC_DR_YT_SHIFT));
+	RTC_DR = ((year_units & RTC_DR_YU_MASK) << RTC_DR_YU_SHIFT) |
+		(RTC_DR & ~(RTC_DR_YU_MASK << RTC_DR_YU_SHIFT));
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD calendar weekday
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_calendar_set_weekday(enum rtc_wdu weekday)
+{
+	RTC_DR = ((weekday & RTC_DR_WDU_MASK) << RTC_DR_WDU_SHIFT) |
+		(RTC_DR & ~(RTC_DR_WDU_MASK << RTC_DR_WDU_SHIFT));
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD calendar month value (tens and ones)
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_calendar_set_month(uint8_t month_tens, uint8_t month_units)
+{
+	RTC_DR = ((month_tens & RTC_DR_MT_MASK) << RTC_DR_MT_SHIFT) |
+		(RTC_DR & ~(RTC_DR_MT_MASK << RTC_DR_MT_SHIFT));
+	RTC_DR = ((month_units & RTC_DR_MU_MASK) << RTC_DR_MU_SHIFT) |
+		(RTC_DR & ~(RTC_DR_MU_MASK << RTC_DR_MU_SHIFT));
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD calendar day value (tens and ones)
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_calendar_set_day(uint8_t day_tens, uint8_t day_units)
+{
+	RTC_DR = ((day_tens & RTC_DR_DT_MASK) << RTC_DR_DT_SHIFT) |
+		(RTC_DR & ~(RTC_DR_DT_MASK << RTC_DR_DT_SHIFT));
+	RTC_DR = ((day_units & RTC_DR_DU_MASK) << RTC_DR_DU_SHIFT) |
+		(RTC_DR & ~(RTC_DR_DU_MASK << RTC_DR_DU_SHIFT));
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets RTC time to use AM or 24-hour format
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_time_set_am_notation(void)
+{
+	RTC_TR &= ~RTC_TR_PM;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC time to use AM/PM or 12-hour format
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_time_set_pm_notation(void)
+{
+	RTC_TR |= RTC_TR_PM;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD time hour value (tens and ones)
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_time_set_hour(uint8_t hour_tens, uint8_t hour_units)
+{
+	RTC_TR = ((hour_tens & RTC_TR_HT_MASK) << RTC_TR_HT_SHIFT) |
+		(RTC_TR & ~(RTC_TR_HT_MASK << RTC_TR_HT_SHIFT));
+	RTC_TR = ((hour_units & RTC_TR_HU_MASK) << RTC_TR_HU_SHIFT) |
+		(RTC_TR & ~(RTC_TR_HU_MASK << RTC_TR_HU_SHIFT));
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD time minute value (tens and ones)
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_time_set_minute(uint8_t min_tens, uint8_t min_units)
+{
+	RTC_TR = ((min_tens & RTC_TR_MNT_MASK) << RTC_TR_MNT_SHIFT) |
+		(RTC_TR & ~(RTC_TR_MNT_MASK << RTC_TR_MNT_SHIFT));
+	RTC_TR = ((min_units & RTC_TR_MNU_MASK) << RTC_TR_MNU_SHIFT) |
+		(RTC_TR & ~(RTC_TR_MNU_MASK << RTC_TR_MNU_SHIFT));
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD time second value (tens and ones)
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_time_set_second(uint8_t sec_tens, uint8_t sec_units)
+{
+	RTC_TR = ((sec_tens & RTC_TR_ST_MASK) << RTC_TR_ST_SHIFT) |
+		(RTC_TR & ~(RTC_TR_ST_MASK << RTC_TR_ST_SHIFT));
+	RTC_TR = ((sec_units & RTC_TR_SU_MASK) << RTC_TR_SU_SHIFT) |
+		(RTC_TR & ~(RTC_TR_SU_MASK << RTC_TR_SU_SHIFT));
+}
 /**@}*/

--- a/lib/stm32/common/rtc_common_l1f024.c
+++ b/lib/stm32/common/rtc_common_l1f024.c
@@ -261,6 +261,19 @@ void rtc_calendar_set_day(uint8_t day)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD calendar value
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_calendar_set_date(uint8_t year, uint8_t month, uint8_t day, enum rtc_weekday rtc_dr_wdu)
+{
+	rtc_calendar_set_year(year);
+	rtc_calendar_set_month(month);
+	rtc_calendar_set_weekday(rtc_dr_wdu);
+	rtc_calendar_set_day(day);
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief Sets the RTC BCD time hour value
 
 @details Requires unlocking the RTC write-protection (RTC_WPR)
@@ -305,5 +318,17 @@ void rtc_time_set_second(uint8_t second)
 	RTC_TR &= ~(RTC_TR_ST_MASK << RTC_TR_ST_SHIFT | RTC_TR_SU_MASK << RTC_TR_SU_SHIFT);
 	RTC_TR |= (((bcd_second >> 4) & RTC_TR_ST_MASK) << RTC_TR_ST_SHIFT) |
 		((bcd_second & RTC_TR_SU_MASK) << RTC_TR_SU_SHIFT);
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Sets the RTC BCD time
+
+@details Requires unlocking the RTC write-protection (RTC_WPR)
+*/
+void rtc_time_set_time(uint8_t hour, uint8_t minute, uint8_t second, bool use_am_notation)
+{
+	rtc_time_set_hour(hour, use_am_notation);
+	rtc_time_set_minute(minute);
+	rtc_time_set_second(second);
 }
 /**@}*/

--- a/lib/stm32/common/rtc_common_l1f024.c
+++ b/lib/stm32/common/rtc_common_l1f024.c
@@ -286,10 +286,11 @@ use_am_notation to use 12-hour (AM/PM) input time
 */
 void rtc_time_set_hour(uint8_t hour, bool use_am_notation)
 {
-	if (use_am_notation)
+	if (use_am_notation) {
 		RTC_TR &= ~(RTC_TR_PM);
-	else
+	} else {
 		RTC_TR |= RTC_TR_PM;
+	}
 
 	uint8_t bcd_hour = _rtc_dec_to_bcd(hour);
 	RTC_TR &= ~(RTC_TR_HT_MASK << RTC_TR_HT_SHIFT | RTC_TR_HU_MASK << RTC_TR_HU_SHIFT);


### PR DESCRIPTION
# Summary
- Adds missing functionality to RTC library shared for L1, F0, F2, and F4 STM32s
- Adds two new `enum`s to RTC:
   - `rtc_fmt`
   - `rtc_wdu`
- Revises `RST_BDCR` naming in `rcc.h` for consistency (_no other variables are named by full name like such_)
- Adds private non-user facing function `_rtc_dec_to_bcd(uint8_t dec)` in `rcc_common.c` for ease of conversion of time units

# Notes
- Unsure about doxygen commenting style, feedback appreciated
- Tested on STM32F0 and STM32F4, do not have L0, or F2 to test, but reference manuals check out
- Intentionally avoided adding BCD helpers as this is up to the user.