### PR TITLE
stm32: Define FLASH_BASE and PERIPH_BASE for all families

### DIFF
--- a/include/libopencm3/stm32/f2/memorymap.h
+++ b/include/libopencm3/stm32/f2/memorymap.h
@@ -25,6 +25,7 @@
 /* --- STM32F20x specific peripheral definitions --------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)
 #define PERIPH_BASE_APB2		(PERIPH_BASE + 0x10000)

--- a/include/libopencm3/stm32/f3/memorymap.h
+++ b/include/libopencm3/stm32/f3/memorymap.h
@@ -27,6 +27,7 @@
 /* --- STM32F3 specific peripheral definitions ----------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)
 #define PERIPH_BASE_APB2		(PERIPH_BASE + 0x10000)

--- a/include/libopencm3/stm32/f4/memorymap.h
+++ b/include/libopencm3/stm32/f4/memorymap.h
@@ -25,6 +25,7 @@
 /* --- STM32F4 specific peripheral definitions ----------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)
 #define PERIPH_BASE_APB2		(PERIPH_BASE + 0x10000)

--- a/include/libopencm3/stm32/f7/memorymap.h
+++ b/include/libopencm3/stm32/f7/memorymap.h
@@ -23,6 +23,7 @@
 /* --- STM32F7 specific peripheral definitions ----------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)
 #define PERIPH_BASE_APB2		(PERIPH_BASE + 0x10000)

--- a/include/libopencm3/stm32/g0/memorymap.h
+++ b/include/libopencm3/stm32/g0/memorymap.h
@@ -20,6 +20,7 @@
 
 #include <libopencm3/cm3/memorymap.h>
 
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define IOPORT_BASE			(0x50000000U)
 #define INFO_BASE			(0x1fff7500U)

--- a/include/libopencm3/stm32/g4/memorymap.h
+++ b/include/libopencm3/stm32/g4/memorymap.h
@@ -20,6 +20,8 @@
 
 #include <libopencm3/cm3/memorymap.h>
 
+#define FLASH_BASE			(0x08000000U)
+#define PERIPH_BASE			(0x40000000U)
 #define INFO_BASE			(0x1fff0000U)
 #define PERIPH_BASE_APB1		(0x40000000U)
 #define PERIPH_BASE_APB2		(0x40010000U)

--- a/include/libopencm3/stm32/h7/memorymap.h
+++ b/include/libopencm3/stm32/h7/memorymap.h
@@ -23,6 +23,7 @@
 /* --- STM32H7 specific peripheral definitions ----------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE          0x08000000U
 #define PERIPH_BASE         0x40000000U
 #define PERIPH_BASE_APB1    0x40000000U
 #define PERIPH_BASE_APB2    0x40010000U

--- a/include/libopencm3/stm32/l0/memorymap.h
+++ b/include/libopencm3/stm32/l0/memorymap.h
@@ -23,6 +23,7 @@
 /* --- STM32 specific peripheral definitions ------------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define IOPORT_BASE			(0x50000000U)
 #define INFO_BASE			(0x1ff80000U)

--- a/include/libopencm3/stm32/l1/memorymap.h
+++ b/include/libopencm3/stm32/l1/memorymap.h
@@ -26,6 +26,7 @@
 /* --- STM32 specific peripheral definitions ------------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define INFO_BASE			(0x1ff00000U)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)

--- a/include/libopencm3/stm32/l4/memorymap.h
+++ b/include/libopencm3/stm32/l4/memorymap.h
@@ -23,6 +23,7 @@
 /* --- STM32 specific peripheral definitions ------------------------------- */
 
 /* Memory map for all busses */
+#define FLASH_BASE			(0x08000000U)
 #define PERIPH_BASE			(0x40000000U)
 #define FMC1_BANK_BASE			(0x60000000U)
 #define FMC3_BANK_BASE			(0x80000000U)


### PR DESCRIPTION
FLASH_BASE was already defined for some and PERIPH_BASE for all but one,
but this makes these available for all families. Note that the value is
identical for all familes (I doublechecked the more exotic ones such
STM32H7), but it is still useful to have these defines to make code more
readable and so that libopencm3 users can write portable code without
having to check that these are identical on all STM32 families.

This fixes https://github.com/libopencm3/libopencm3-examples/issues/224 (which I accidentally reported in the wrong repository).