### PR TITLE
fix(lib/stm32/common/iwdg_common_all.c): Fix stm32-iwdg period set function bug

### DIFF
--- a/lib/stm32/common/iwdg_common_all.c
+++ b/lib/stm32/common/iwdg_common_all.c
@@ -108,6 +108,9 @@ void iwdg_set_period_ms(uint32_t period)
 	while (iwdg_reload_busy());
 	IWDG_KR = IWDG_KR_UNLOCK;
 	IWDG_RLR = count & COUNT_MASK;
+	
+	/* Refresh counter after configuration is complete */
+	iwdg_reset();
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Fix the bug that the iwdg counter is not refreshed after the configurationis complete, if this counter is not refreshed after the configuration is completed, the first iwdg counting period will be as long as 26 seconds.
We want the watchdog to take effect immediately after the period configuration is completed, so we need to refresh this counter immediately.