### PR TITLE
Fix built-in USB SCSI implementation slow to initialize in Windows

### DIFF
--- a/lib/usb/usb_msc.c
+++ b/lib/usb/usb_msc.c
@@ -214,6 +214,17 @@ static const uint8_t _spc3_inquiry_response[36] = {
 	0x20, 0x20, 0x20, 0x20
 };
 
+static const uint8_t _spc3_inqury_vpd_serial[23] = {
+	0x00,	/* Byte 0: Peripheral Qualifier = 0, Peripheral Device Type = 0 */
+	0x80,	/* Byte 1: Page code (fixed) */
+		/* Byte 2 - Byte 3: Page length (fixed) */
+	0x00, 0x14,
+		/* Byte 4 - Byte 11: Product Serial Number */
+	' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+		/* Byte 12 - Byte 23: Print Circuit Board Serial Number */
+	' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '
+};
+
 static const uint8_t _spc3_request_sense[18] = {
 	0x70,	/* Byte 0: VALID = 0, Response Code = 112 */
 	0x00,	/* Byte 1: Obsolete = 0 */
@@ -360,6 +371,28 @@ static void scsi_read_capacity(usbd_mass_storage *ms,
 	}
 }
 
+static void scsi_read_format_capacities(usbd_mass_storage *ms,
+					struct usb_msc_trans *trans,
+					enum trans_event event)
+{
+	/* This is documented as an optional command, but Windows slows
+   	   to a crawl initializing the device if it's not implemented */
+
+	if (EVENT_CBW_VALID == event) {
+		/* Reserved bytes */
+		trans->msd_buf[0] = 0;
+		trans->msd_buf[1] = 0;
+		trans->msd_buf[2] = 0;
+
+		/* Capacity list length */
+		trans->msd_buf[3] = 0;
+
+		trans->bytes_to_write = 4;
+
+		set_sbc_status_good(ms);
+	}
+}
+
 static void scsi_format_unit(usbd_mass_storage *ms,
 			     struct usb_msc_trans *trans,
 			     enum trans_event event)
@@ -435,6 +468,41 @@ static void scsi_mode_sense_6(usbd_mass_storage *ms,
 	}
 }
 
+/* Vital Product Data page request */
+static void _vpd_page_inquiry(uint8_t vpdPage,
+			      usbd_mass_storage *ms,
+		 	      struct usb_msc_trans *trans,
+		 	      enum trans_event event)
+{
+	(void) event;
+
+	switch (vpdPage) {
+	case 0x80: /* Unit Serial Number */
+		memcpy(trans->msd_buf, _spc3_inqury_vpd_serial,
+			sizeof(_spc3_inqury_vpd_serial));
+
+		trans->bytes_to_write = sizeof(_spc3_inqury_vpd_serial);
+		trans->csw.csw.dCSWDataResidue = sizeof(_spc3_inqury_vpd_serial);
+
+		set_sbc_status_good(ms);
+		break;
+
+	default: /* Unimplemented field */
+		set_sbc_status(ms,
+			       SBC_SENSE_KEY_ILLEGAL_REQUEST,
+			       SBC_ASC_INVALID_FIELD_IN_CDB,
+			       SBC_ASCQ_NA);
+
+		trans->bytes_to_write = 0;
+		trans->bytes_to_read = 0;
+		trans->csw.csw.bCSWStatus = CSW_STATUS_FAILED;
+		break;
+	}
+
+	/* TODO: Add VPD 0x83 support */
+	/* TODO: Add VPD 0x00 support */
+}
+
 static void scsi_inquiry(usbd_mass_storage *ms,
 			 struct usb_msc_trans *trans,
 			 enum trans_event event)
@@ -470,8 +538,8 @@ static void scsi_inquiry(usbd_mass_storage *ms,
 
 			set_sbc_status_good(ms);
 		} else {
-			/* TODO: Add VPD 0x83 support */
-			/* TODO: Add VPD 0x00 support */
+			/* Host requested a specific Vital Product Data page */
+			_vpd_page_inquiry(buf[2], ms, trans, event);
 		}
 	}
 }
@@ -516,6 +584,9 @@ static void scsi_command(usbd_mass_storage *ms,
 		break;
 	case SCSI_READ_CAPACITY:
 		scsi_read_capacity(ms, trans, event);
+		break;
+	case SCSI_READ_FORMAT_CAPACITIES:
+		scsi_read_format_capacities(ms, trans, event);
 		break;
 	case SCSI_READ_10:
 		scsi_read_10(ms, trans, event);


### PR DESCRIPTION
Using `usb_msc_init` works fine under Linux and my BIOS, but I had issues with Windows 10 taking two minutes to show the device. This was particularly noticeable during boot as Windows 10 stays on its boot screen until all storage devices are ready.

Inspecting with usbpcap and Wireshark, Windows appears to get tripped up
by two separate commands. It retries each command 3 times with a 20 second
delay between attempts:

 - `READ FORMAT CAPACITIES` is an optional SCSI command, but Windows
   doesn't seem to like getting an ILLEGAL_COMMAND response to it. This
   is fixed here by returning a valid response with zero format capacities.

 - An inquiry for the "Unit Serial Number" Vital Product Data page wasn't
   being handled. Segate's SCSI reference docs state that INVALID_FIELD
   can be returned where a VPD field isn't implemented, but Windows still
   hung when getting that response. Returning a the VPD response with a
   blank serial number (spaces per the docs) resolves this issue.

I haven't worked with SCSI before, so it's possible this old implementation is doing something incorrect, but with these two changes Windows initializes my MSC device without delay.

Here's the USB capture on Windows 10 before this fix (note the time column):

![windows_usb_msc_slowness](https://user-images.githubusercontent.com/2230769/116773245-7f2fd180-aaa8-11eb-8564-05c69baf9a69.png)
