### PR TITLE
Fix #1328: Make error return codes negative values

### DIFF
--- a/include/libopencm3/stm32/fdcan.h
+++ b/include/libopencm3/stm32/fdcan.h
@@ -723,28 +723,30 @@ struct fdcan_tx_buffer_element {
 #define FDCAN_FIFO_RXTS_MASK			0xFFFF
 
 
-/** FDCAN error return values
+/** @defgroup fdcan_error FDCAN error return values
+ * @{
  */
-enum fdcan_error {
-	/** No error. Operation finished successfully */
-	FDCAN_E_OK,
 
-	/** Value provided was out of range */
-	FDCAN_E_OUTOFRANGE,
+/** No error. Operation finished successfully */
+#define FDCAN_E_OK						0
 
-	/** Timeout waiting for FDCAN block to accept INIT bit change */
-	FDCAN_E_TIMEOUT,
+/** Value provided was out of range */
+#define FDCAN_E_OUTOFRANGE				-1
 
-	/** Value provided was invalid (FIFO index, FDCAN block base address, length, etc.) */
-	FDCAN_E_INVALID,
+/** Timeout waiting for FDCAN block to accept INIT bit change */
+#define FDCAN_E_TIMEOUT					-2
 
-	/** Device is busy: Transmit buffer is full, unable to queue additional message or device
-	 * is outside of INIT mode and cannot perform desired operation. */
-	FDCAN_E_BUSY,
+/** Value provided was invalid (FIFO index, FDCAN block base address, length, etc.) */
+#define FDCAN_E_INVALID					-3
 
-	/** Receive buffer is empty, unable to read any new message */
-	FDCAN_E_NOTAVAIL
-};
+/** Device is busy: Transmit buffer is full, unable to queue additional message or device
+ * is outside of INIT mode and cannot perform desired operation. */
+#define FDCAN_E_BUSY					-4
+
+/** Receive buffer is empty, unable to read any new message */
+#define FDCAN_E_NOTAVAIL				-5
+
+/**@}*/
 
 /**@}*/
 


### PR DESCRIPTION
Fix the bug where certain functions were returning meaningful return
and/or error code, where positive values of error codes were interfering
with meaningful return value. Error codes now have negative values as it
was originally intended but never implemented.