### PR TITLE
Fix FDCAN incorrect FIFO acknowledgment

### DIFF
--- a/lib/stm32/common/fdcan_common.c
+++ b/lib/stm32/common/fdcan_common.c
@@ -609,7 +609,7 @@ int fdcan_receive(uint32_t canport, uint8_t fifo_id, bool release, uint32_t *id,
 	}
 
 	if (release) {
-		FDCAN_RXFIA(canport, fifo_id) |= get_index << FDCAN_RXFIFO_AI_SHIFT;
+		FDCAN_RXFIA(canport, fifo_id) = get_index << FDCAN_RXFIFO_AI_SHIFT;
 	}
 
 	return FDCAN_E_OK;


### PR DESCRIPTION
Fix incorrect way of acknowledging FIFO processing. Old code ORed old
value in register with index of FIFO buffer just processed, which
generated invalid value for acknowledge. This caused FIFO to repeatedly
return same content. Both fdcan_receive() and fdcan_release_fifo() were
affected.