### PR TITLE
Fix STM32H7 FDCAN FIFO acknowledgment process

### DIFF
--- a/include/libopencm3/stm32/fdcan.h
+++ b/include/libopencm3/stm32/fdcan.h
@@ -78,7 +78,9 @@
  * @param can_base FDCAN block base address @ref fdcan_block
  * @param fifo_id ID of FIFO, 0 or 1
  */
-#define FDCAN_RXFIA(can_base, fifo_id)	MMIO32(can_base + 0x0094 + (FDCAN_RXFI_OFFSET * fifo_id))
+#define FDCAN_RXFIA(can_base, fifo_id)	\
+	MMIO32(can_base + FDCAN_RXFIA_BASE + (FDCAN_RXFI_OFFSET * fifo_id))
+
 #define FDCAN_RXF0A(can_base)			FDCAN_RXFIA(can_base, 0)
 #define FDCAN_RXF1A(can_base)			FDCAN_RXFIA(can_base, 1)
 
@@ -725,26 +727,24 @@ struct fdcan_tx_buffer_element {
 
 /** FDCAN error return values
  */
-enum fdcan_error {
 	/** No error. Operation finished successfully */
-	FDCAN_E_OK,
+#define FDCAN_E_OK 						0
 
 	/** Value provided was out of range */
-	FDCAN_E_OUTOFRANGE,
+#define FDCAN_E_OUTOFRANGE				-1
 
 	/** Timeout waiting for FDCAN block to accept INIT bit change */
-	FDCAN_E_TIMEOUT,
+#define FDCAN_E_TIMEOUT					-2
 
 	/** Value provided was invalid (FIFO index, FDCAN block base address, length, etc.) */
-	FDCAN_E_INVALID,
+#define FDCAN_E_INVALID					-3
 
 	/** Device is busy: Transmit buffer is full, unable to queue additional message or device
 	 * is outside of INIT mode and cannot perform desired operation. */
-	FDCAN_E_BUSY,
+#define FDCAN_E_BUSY					-4
 
 	/** Receive buffer is empty, unable to read any new message */
-	FDCAN_E_NOTAVAIL
-};
+#define FDCAN_E_NOTAVAIL				-5
 
 /**@}*/
 

--- a/lib/stm32/h7/fdcan.c
+++ b/lib/stm32/h7/fdcan.c
@@ -79,7 +79,7 @@ unsigned fdcan_get_fifo_element_size(uint32_t canport, unsigned fifo_id)
 	}
 
 	/* Mask is unshifted and at this point, element_size is unshifted too */
-	return 8 + fdcan_dlc_to_length((element_size & FDCAN_RXESC_F0DS_MASK) | 0x7);
+	return 8 + fdcan_dlc_to_length((element_size & FDCAN_RXESC_F0DS_MASK) | 0x8);
 }
 
 /** Returns actual size of transmit entry in transmit queue/FIFO for given CAN port.
@@ -95,7 +95,7 @@ unsigned fdcan_get_txbuf_element_size(uint32_t canport)
 {
 	unsigned element_size;
 	element_size = (FDCAN_TXESC(canport) >> FDCAN_TXESC_TBDS_SHIFT) & FDCAN_TXESC_TBDS_MASK;
-	return 8 + fdcan_dlc_to_length((element_size & FDCAN_TXESC_TBDS_MASK) | 0x7);
+	return 8 + fdcan_dlc_to_length((element_size & FDCAN_TXESC_TBDS_MASK) | 0x8);
 }
 
 /** Initialize allocation of standard filter block in CAN message RAM.


### PR DESCRIPTION
Fix FDCAN FIFO acknowledge register definition to make it correct for H7
MCUs. Previous definition contained hardcoded offset instead of using
MCU-specific macro.

Fix incorrect decoding of buffer element size. During decoding, value
returned was erratically set to 7 instead of setting 4th LSB. Buffer
element size was then always reported as 15 bytes.