### PR TITLE
stm32: Extend the timer api 

### DIFF
--- a/include/libopencm3/stm32/common/timer_common_all.h
+++ b/include/libopencm3/stm32/common/timer_common_all.h
@@ -415,6 +415,7 @@ specific memorymap.h header before including this header file.*/
 @{*/
 #define TIM_CR1_DIR_UP			(0 << 4)
 #define TIM_CR1_DIR_DOWN		(1 << 4)
+#define TIM_CR1_DIR_MASK		(1 << 4)
 /**@}*/
 
 /* OPM: One pulse mode */
@@ -1160,6 +1161,7 @@ void timer_disable_preload(uint32_t timer_peripheral);
 void timer_set_alignment(uint32_t timer_peripheral, uint32_t alignment);
 void timer_direction_up(uint32_t timer_peripheral);
 void timer_direction_down(uint32_t timer_peripheral);
+uint32_t timer_get_direction(uint32_t timer_peripheral);
 void timer_one_shot_mode(uint32_t timer_peripheral);
 void timer_continuous_mode(uint32_t timer_peripheral);
 void timer_update_on_any(uint32_t timer_peripheral);

--- a/lib/stm32/common/timer_common_all.c
+++ b/lib/stm32/common/timer_common_all.c
@@ -344,6 +344,21 @@ void timer_direction_down(uint32_t timer_peripheral)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief Get the Timer count direction.
+
+Useful when the timer is in encoder interface mode and the DIR bit is modified
+by hardware.
+
+@param[in] timer_peripheral Unsigned int32. Timer register address base @ref
+tim_reg_base
+*/
+
+uint32_t timer_get_direction(uint32_t timer_peripheral)
+{
+	return TIM_CR1(timer_peripheral) & TIM_CR1_DIR_MASK;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief Enable the Timer for One Cycle and Stop.
 
 @param[in] timer_peripheral Unsigned int32. Timer register address base @ref


### PR DESCRIPTION
Add function to get the count direction bit. This is useful when the timer is in encoder interface mode and the DIR bit is modified by hardware.