### PR TITLE
cm3: systick: Add "uint8_t systick_get_clocksource(void)" function

### DIFF
--- a/include/libopencm3/cm3/systick.h
+++ b/include/libopencm3/cm3/systick.h
@@ -182,6 +182,7 @@ bool systick_set_frequency(uint32_t freq, uint32_t ahb);
 uint32_t systick_get_reload(void);
 uint32_t systick_get_value(void);
 void systick_set_clocksource(uint8_t clocksource);
+uint8_t systick_get_clocksource(void);
 void systick_interrupt_enable(void);
 void systick_interrupt_disable(void);
 void systick_counter_enable(void);

--- a/lib/cm3/systick.c
+++ b/lib/cm3/systick.c
@@ -126,6 +126,19 @@ void systick_set_clocksource(uint8_t clocksource)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief Get the SysTick Clock Source.
+ *
+ * The clock source can be either the AHB clock or the same clock divided by 8.
+ *
+ * @returns clocksource uint8_t. Clock source from @ref systick_clksource.
+ */
+
+uint8_t systick_get_clocksource(void)
+{
+	return STK_CSR & STK_CSR_CLKSOURCE;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief Enable SysTick Interrupt.
  *
  */


### PR DESCRIPTION
Add function to read the systick clocksource register value. The return value is an uint8_t in the same format as STK_CSR_CLKSOURCE_AHB or STK_CSR_CLKSOURCE_AHB_DIV8 used for the systick_set_clocksource()-function.