### PR TITLE
fix an occasional hangup with PR #409, and include PR #1294

### DIFF
--- a/include/libopencm3/usb/msc.h
+++ b/include/libopencm3/usb/msc.h
@@ -78,6 +78,23 @@ typedef struct _usbd_mass_storage usbd_mass_storage;
 #define USB_MSC_REQ_BULK_ONLY_RESET	0xFF
 #define USB_MSC_REQ_GET_MAX_LUN		0xFE
 
+/* SBC-2, 5.1.22 START STOP UNIT, Table 52 */
+#define USB_MSC_SBC_2_POWER_CONDITION_START		0x10	// Additional code.
+#define USB_MSC_SBC_2_POWER_CONDITION_STOP		0x20	// Additional code.
+#define USB_MSC_SBC_2_POWER_CONDITION_ACTIVE		0x01
+#define USB_MSC_SBC_2_POWER_CONDITION_IDLE		0x02
+#define USB_MSC_SBC_2_POWER_CONDITION_STANDBY		0x03
+#define USB_MSC_SBC_2_POWER_CONDITION_SLEEP		0x05
+#define USB_MSC_SBC_2_POWER_CONDITION_DEVICE		0x07
+#define USB_MSC_SBC_2_POWER_CONDITION_DEVICE_IDLE	0x0A
+#define USB_MSC_SBC_2_POWER_CONDITION_DEVICE_STANDBY	0x0B
+
+/* SPC-2, 7.12 PREVENT ALLOW MEDIUM REMOVAL, Table 77 */
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_NONE		0x00
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_REMOTE	0x01
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_DEVICE	0x02
+#define USB_MSC_SPC_2_MEDIUM_EJECT_LOCKED_BOTH		0x03
+
 usbd_mass_storage *usb_msc_init(usbd_device *usbd_dev,
 				 uint8_t ep_in, uint8_t ep_in_size,
 				 uint8_t ep_out, uint8_t ep_out_size,
@@ -87,6 +104,16 @@ usbd_mass_storage *usb_msc_init(usbd_device *usbd_dev,
 				 const uint32_t block_count,
 				 int (*read_block)(uint32_t lba, uint8_t *copy_to),
 				 int (*write_block)(uint32_t lba, const uint8_t *copy_from));
+
+uint8_t usb_msc_get_medium_eject_locked(usbd_mass_storage *msc_dev);
+
+void usb_msc_set_medium_loaded(usbd_mass_storage *msc_dev,
+                               uint8_t is_loaded);
+uint8_t usb_msc_get_medium_loaded(usbd_mass_storage *msc_dev);
+
+void usb_msc_register_power_condition_callback(usbd_mass_storage *msc_dev,
+					       void (*power_condition_changed)(uint8_t power_condition,
+									       uint8_t load_eject));
 
 #endif
 


### PR DESCRIPTION
Hi,
I had occasional hangups with the mass storage class code, related to the changes made in PR #409. I'm using the usb_msc example, slightly modified to run on stm32f103. The hangup occurs occasionally after a write_10 by the host (can be triggered by mounting/unmounting several times, or adding a file to the storage device). After the write_10 the host is initiating an IN transaction to receive the CSW, but target hasn't prepared any data. 
I have noticed that just before the hangup, the code in https://github.com/libopencm3/libopencm3/compare/master...stefaandesmet2003:MSC_bugfix_PR409?expand=1#diff-dae3753d1fc8542f037be2cf8456abd0c8418f8b307f132c9f66db8ef679fcadL636-L651
 is trying to write to LBA=1, although the ongoing transaction was for a 1-sector write to LBA=0 (happens on other LBA too). This code is wrong and should be removed entirely. It is placed in an if-block that is supposed to handle transactions which don't require additional read/write, and only require a CSW response from the msc device. Furthermore lba + trans->block_count is the block too far to write, and thus corrupting the storage device.
the code from PR #409 copies the CSW 'all-good' response to packet memory on the first msc_data_rx_cb (ie. after the first 64 bytes of data to write have been read from the ep-out; it is expecting at least 512). My code postpones this action till all bytes from the transaction have been received and written to the storage device, and solves the occasional hangup entirely.
https://github.com/stefaandesmet2003/libopencm3/blob/MSC_bugfix_PR409/lib/usb/usb_msc.c#L790-L805

The other diffs are related to PR #1294 merged here, because this PR is useful and works correctly.
Thanks for considering this PR,
Cheers,
Stefaan