### PR TITLE
README: added info about partial build, take 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,5 +124,7 @@ genlinktests.clean:
 		printf "  TEST FAIL : $*\n";		\
 	fi;
 
+list-targets:
+	@echo $(TARGETS)
 
-.PHONY: build lib $(LIB_DIRS) doc clean generatedheaders cleanheaders stylecheck genlinktests genlinktests.clean
+.PHONY: build lib $(LIB_DIRS) doc clean generatedheaders cleanheaders stylecheck genlinktests genlinktests.clean list-targets

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ For a more verbose build you can use
 
     $ make V=1
 
+You can reduce the build time by specifying a particular MCU series
+
+    $ make TARGETS='stm32/f1 stm32/f4'
+
+Supported targets can be listed using:
+
+    $ make list-targets
+
 Fine-tuning the build
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ them as environment variables, for example:
    If the Cortex-M core supports a hard float ABI, it will be compiled with
    the best floating-point support by default. In cases where this is not desired, the
    behavior can be specified by setting `FP_FLAGS`.
-   
+
    Currently, M4F cores default to `-mfloat-abi=hard -mfpu=fpv4-sp-d16`, and
    M7 cores defaults to double precision `-mfloat-abi=hard -mfpu=fpv5-d16` if available,
    and single precision `-mfloat-abi=hard -mfpu=fpv5-sp-d16` otherwise.
    Other architectures use no FP flags, in otherwords, traditional softfp.
-   
-   You may find which FP_FLAGS you can use in a particular architecture in the readme.txt 
+
+   You may find which FP_FLAGS you can use in a particular architecture in the readme.txt
    file shipped with the gcc-arm-embedded package.
 
    Examples:


### PR DESCRIPTION
See https://github.com/libopencm3/libopencm3/pull/1287

- split white space change in another commit,
- remove list of targets from README to avoid duplicated work and add a list-targets in Makefile,
- replace “footprint of the library” by “build time”, as someone could wrongly understand that the compiled size of the lib depends on the list of built targets.
