### PR TITLE
stm32: fix typo for auto baud rate request bit in USART_RQR

### DIFF
--- a/include/libopencm3/stm32/common/usart_common_v2.h
+++ b/include/libopencm3/stm32/common/usart_common_v2.h
@@ -478,7 +478,7 @@
 #define USART_RQR_SBKRQ		            (1 << 1)
 
 /** ABRRQ: Auto baud rate request */
-#define USART_RQR_ABKRQ		            (1 << 0)
+#define USART_RQR_ABRRQ		            (1 << 0)
 
 /**@}*/
 


### PR DESCRIPTION
Just a small change to fix a wrong character