### PR TITLE
make sure dev->pm_top is even

### DIFF
--- a/lib/stm32/common/st_usbfs_core.c
+++ b/lib/stm32/common/st_usbfs_core.c
@@ -104,7 +104,13 @@ void st_usbfs_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 		}
 		USB_CLR_EP_TX_DTOG(addr);
 		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
-		dev->pm_top += max_size;
+		/* Packet memory is 16-bit aligned, so an address needs to be even.
+		 * See the comment for Bit 0 of ADDRn_RX and ADDRn_TX in RM0091, RM0008.
+		 * USB_SET_EP_TX_ADDR and USB_SET_EP_RX_ADDR rely on dev->pm_top being even,
+		 * when st_usbfs_ep_setup() is called once more after this instance.
+		 * So if max_size is odd, increase dev->pm_top by (max_size + 1).
+		 */
+		dev->pm_top += ((max_size + 1) >> 1) << 1;
 	}
 
 	if (!dir) {


### PR DESCRIPTION
Working on a hid device with rx and tx size 17 bytes, setting up tx first did not work, while rx first did.
Setting up rx first increases dev->pm_top by 18, so tx address starts at even, works.
Setting up tx first increases dev->pm_top by 17, so rx address starts at odd, doesn't work.
Packet memory is 16-bit aligned, so an address needs to be even. See the comment for Bit 0 of ADDRn_RX and ADDRn_TX in RM0091 and RM0008.
USB_SET_EP_TX_ADDR and USB_SET_EP_RX_ADDR rely on dev->pm_top being even, when st_usbfs_ep_setup() is called again.
So if the increment size is odd, increase dev->pm_top by the next even (18 instead of 17 in this example).
Double of https://github.com/libopencm3/libopencm3/issues/537 and part of https://github.com/libopencm3/libopencm3/pull/628/commits/7224576eeb20eed4f6811dd679c2ee591eedc96b
This bug and the fix are known but not accepted since 6 years, so if you need more information to accept this, I am willing to clarify.