### PR TITLE
added additional configuration bits for STM32G4 series timer 1,8 and 20

### DIFF
--- a/include/libopencm3/stm32/g4/timer.h
+++ b/include/libopencm3/stm32/g4/timer.h
@@ -29,3 +29,51 @@
 
 #pragma once
 #include <libopencm3/stm32/common/timer_common_f24.h>
+
+/* --- TIMx_CR2 values ----------------------------------------------------- */
+
+/****************************************************************************/
+/** @defgroup tim_x_cr2_ois TIMx_CR2_OIS: Force Output Idle State Control Values
+@{*/
+/* OIS4N:*//** Output idle state 4 (OC4N output) */
+#define TIM_CR2_OIS4N			(1 << 15)
+
+/* OIS5:*//** Output idle state 5 (OC5 output) */
+#define TIM_CR2_OIS4N			(1 << 16)
+
+/* OIS6:*//** Output idle state 6 (OC6 output) */
+#define TIM_CR2_OIS4N			(1 << 18)
+#define TIM_CR2_OIS_MASK		(0xfff << 8)
+/**@}*/
+
+/* MMS[3:0]: Master mode selection */
+/****************************************************************************/
+/** @defgroup tim_mastermode TIMx_CR2 MMS[25:4]: Master Mode Selection
+@{*/
+#define TIM_CR2_MMS_RESET		(0x0 << 4)
+#define TIM_CR2_MMS_ENABLE		(0x1 << 4)
+#define TIM_CR2_MMS_UPDATE		(0x2 << 4)
+#define TIM_CR2_MMS_COMPARE_PULSE	(0x3 << 4)
+#define TIM_CR2_MMS_COMPARE_OC1REF	(0x4 << 4)
+#define TIM_CR2_MMS_COMPARE_OC2REF	(0x5 << 4)
+#define TIM_CR2_MMS_COMPARE_OC3REF	(0x6 << 4)
+#define TIM_CR2_MMS_COMPARE_OC4REF	(0x7 << 4)
+#define TIM_CR2_MMS_ENCODER_OUTPUT	(0x200000 << 4)
+#define TIM_CR2_MMS_MASK		(0x200007 << 4)
+/**@}*/
+
+/* MMS2[3:0]: Master mode selection 2 */
+/****************************************************************************/
+/** @defgroup tim_mastermode TIMx_CR2 MMS2[23:20]: Master Mode Selection 2
+@{*/
+#define TIM_CR2_MMS2_RESET		(0x0 << 20)
+#define TIM_CR2_MMS2_ENABLE		(0x1 << 20)
+#define TIM_CR2_MMS2_UPDATE		(0x2 << 20)
+#define TIM_CR2_MMS2_COMPARE_PULSE	(0x3 << 20)
+#define TIM_CR2_MMS2_COMPARE_OC1REF	(0x4 << 20)
+#define TIM_CR2_MMS2_COMPARE_OC2REF	(0x5 << 20)
+#define TIM_CR2_MMS2_COMPARE_OC3REF	(0x6 << 20)
+#define TIM_CR2_MMS2_COMPARE_OC4REF	(0x7 << 20)
+#define TIM_CR2_MMS_ENCODER_OUTPUT	(0x8 << 20)
+#define TIM_CR2_MMS2_MASK		(0xf << 20)
+/**@}*/


### PR DESCRIPTION
Trying to configure the TRGO2 signal present in the advanced timers of the STM32G4 series I could not find the corresponding register, the MMS2 register (neither in timer_common_all.h nor in timer_common_f24.h). This pull request adds it, along all other changes of this register compared to STM32F2 and STM32F4. (see STM32G4 reference manual p. 1170)
The MMS register has a 4th bit added that is separated from the other 3 bits. I am not sure I handled this the way it should be (see line 61 and 62), feel free to suggest a better solution.
I have also no idea whether doxygen will get along with what I did.

Open for any suggestions!