### PR TITLE
Sending of CAN extended frames fails, fix the header

### DIFF
--- a/include/libopencm3/stm32/fdcan.h
+++ b/include/libopencm3/stm32/fdcan.h
@@ -698,7 +698,7 @@ struct fdcan_tx_buffer_element {
  * @{
  */
 #define FDCAN_FIFO_ESI					(1 << 31)
-#define FDCAN_FIFO_XTD					(1 << 20)
+#define FDCAN_FIFO_XTD					(1 << 30)
 #define FDCAN_FIFO_RTR					(1 << 29)
 #define FDCAN_FIFO_EFC					(1 << 23)
 #define FDCAN_FIFO_FDF					(1 << 21)


### PR DESCRIPTION
The FDCAN_FIFO_XTD bit is at position 30 according to RM0440 (rev. 7), table 404. Probably just a typo.