### PR TITLE
Avoid warning message about cast pointer from smaller integer type

### DIFF
--- a/include/libopencm3/cm3/common.h
+++ b/include/libopencm3/cm3/common.h
@@ -64,10 +64,10 @@
 #include <stdbool.h>
 
 /* Generic memory-mapped I/O accessor functions */
-#define MMIO8(addr)		(*(volatile uint8_t *)(addr))
-#define MMIO16(addr)		(*(volatile uint16_t *)(addr))
-#define MMIO32(addr)		(*(volatile uint32_t *)(addr))
-#define MMIO64(addr)		(*(volatile uint64_t *)(addr))
+#define MMIO8(addr)		(*(volatile uint8_t *)((uintptr_t)addr))
+#define MMIO16(addr)		(*(volatile uint16_t *)((uintptr_t)addr))
+#define MMIO32(addr)		(*(volatile uint32_t *)((uintptr_t)addr))
+#define MMIO64(addr)		(*(volatile uint64_t *)((uintptr_t)addr))
 
 /* Generic bit-band I/O accessor functions */
 #define BBIO_SRAM(addr, bit) \


### PR DESCRIPTION
This is avoid warning messages about cast pointers to integer, including analyzers.

![Screenshot_20220323_124246](https://user-images.githubusercontent.com/15130560/159683403-49c4cbc0-befa-498b-ae9b-bb58bbe5d9c7.png)
