### PR TITLE
Add nrf51822 device in devices.data

### DIFF
--- a/ld/devices.data
+++ b/ld/devices.data
@@ -522,6 +522,13 @@ pac5532 pac55xx ROM=128K RAM=32K
 pac5556 pac55xx ROM=128K RAM=32K
 
 ################################################################################
+# nRF51xx Cortex-M0 based chips
+
+nrf51822aa nrf51sf ROM=256K RAM=16K
+nrf51822ab nrf51sf ROM=128K RAM=16K
+nrf51822ac nrf51sf ROM=256K RAM=32K
+
+################################################################################
 # nRF52xx Cortex-M4 based chips
 nrf52805* nrf52sf ROM=192k RAM=24K
 nrf52810* nrf52sf ROM=192k RAM=24K
@@ -651,11 +658,16 @@ vf6xx END CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 pac55xx END ROM_OFF=0x00000000 RAM_OFF=0x20000000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16
 
 ################################################################################
+# nRF51xx families
+#
+nrf51sf nrf51 FPU=soft
+
+nrf51 END ROM_OFF=0x00000000 RAM_OFF=0x20000000 CPU=cortex-m0
+
+################################################################################
 # nRF52xx families
 #
 nrf52sf nrf52 FPU=soft
 nrf52fp nrf52 FPU=hard-fpv4-sp-d16
 
 nrf52 END ROM_OFF=0x00000000 RAM_OFF=0x20000000 CPU=cortex-m4
-
-


### PR DESCRIPTION
Add support to generate ld script for nrf51822 devices. In this pull request 3 devices are added: nrf51822aa,nrf51822ab and nrf51822ac. Rom and ram supported by those devices are listed [here](https://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.4.pdf)  P.76 section 10.6 table 75 . 
Thanks


 

 