### PR TITLE
Fix for injected ADC conversion configuration - STM32F3

### DIFF
--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -265,7 +265,7 @@
 #define ADC_JSQR_JSQ2_LSB		14
 #define ADC_JSQR_JSQ1_LSB		8
 
-#define ADC_JSQR_JSQ_VAL(n, val)	((val) << (((n) - 1) * 6 + 8))
+#define ADC_JSQR_JSQ_VAL(n, val)	((val) << (((n)) * 6 + 8))
 #define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
 
 /* Bits 30:26 JSQ4[4:0]: 4th conversion in the injected sequence */

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -582,7 +582,8 @@ void adc_disable_external_trigger_regular(uint32_t adc);
 void adc_disable_external_trigger_injected(uint32_t adc);
 void adc_set_watchdog_high_threshold(uint32_t adc, uint16_t threshold);
 void adc_set_watchdog_low_threshold(uint32_t adc, uint16_t threshold);
-void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[]);
+void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[],
+					uint32_t trigger, uint32_t polarity);
 bool adc_eoc_injected(uint32_t adc);
 bool adc_eos_injected(uint32_t adc);
 uint32_t adc_read_injected(uint32_t adc, uint8_t reg);

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -456,9 +456,14 @@ void adc_set_watchdog_low_threshold(uint32_t adc, uint16_t threshold)
  * @param[in] length Unsigned int8. Number of channels in the group.
  * @param[in] channel Unsigned int8[]. Set of channels in sequence, integers
  * 0..18
+ * @param[in] trigger Unsigned int8. Trigger identifier
+ * @ref adc_trigger_injected
+ * @param[in] polarity Unsigned int32. Trigger polarity
+ * @ref adc_trigger_polarity_injected
  */
 
-void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
+void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[],
+	uint32_t trigger, uint32_t polarity)
 {
 	uint32_t reg32 = 0;
 	uint8_t i = 0;
@@ -473,6 +478,10 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 	}
 
 	reg32 |= ADC_JSQR_JL_VAL(length);
+
+	/* Setup external trigger & polarity. */
+	reg32 &= ~(ADC_JSQR_JEXTSEL_MASK | ADC_JSQR_JEXTEN_MASK);
+	reg32 |= (trigger | polarity);
 
 	ADC_JSQR(adc) = reg32;
 }

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -469,7 +469,7 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 	}
 
 	for (i = 0; i < length; i++) {
-		reg32 |= ADC_JSQR_JSQ_VAL(4 - i, channel[length - i - 1]);
+		reg32 |= ADC_JSQR_JSQ_VAL(i, channel[length - i - 1]);
 	}
 
 	reg32 |= ADC_JSQR_JL_VAL(length);

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -474,7 +474,7 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[],
 	}
 
 	for (i = 0; i < length; i++) {
-		reg32 |= ADC_JSQR_JSQ_VAL(i, channel[length - i - 1]);
+		reg32 |= ADC_JSQR_JSQ_VAL(i, channel[i]);
 	}
 
 	reg32 |= ADC_JSQR_JL_VAL(length);


### PR DESCRIPTION
# Injected Sequence Channels Configuration:

Currently, the software loads the ADCx_JSQR in descending order.
The ADCx_JSQ4 is loaded first down to ADCx_JSQ1 when calling the
adc_set_injected_sequence function.

This causes problems if ALL the sequences are not used, because
the ones left unused will contain an invalid configuration 0x00
value.

This changes reverses the loading order such that if, for example,
three sequences are used, the JSQ1..JSQR3 registers will be loaded
with the correct channels.

# Function `adc_set_injected_sequence` to update whole `ADCx_JSQR` register:

Currently the adc_set_injected_sequence function only updates
the JSQ & JL bits of the ADCx_JSQR register. This has the
following unintended effect: when the
adc_enable_external_trigger_injected function is called, this
new bit values are queded in the "Queue of Context" for injected
conversions. Please see section 15.3.2.1 of RM0316. Which means
that these new bit values will not be updated until a new
conversion takes place (either triggered by hw or sw).

When the new conversion takes place, now the ADCx_JSQR register
will contain the desired value, but the adc injected conversion
must be started again by calling adc_start_conversion_injected.
(Does not mater if HW triggers are still being generated).

This change combines the current functionality of
adc_enable_external_trigger_injected into function
adc_set_injected_sequence such that the ADCx_JSQR register is
updated in one go and this side effect of queueing does not happen.