### PR TITLE
add I2C for STM32G4

### DIFF
--- a/include/libopencm3/stm32/g4/i2c.h
+++ b/include/libopencm3/stm32/g4/i2c.h
@@ -2,7 +2,7 @@
  *
  * @ingroup STM32G4xx_defines
  *
- * @brief <b>Defined Constants and Types for the STM32G0xx I2C</b>
+ * @brief <b>Defined Constants and Types for the STM32G4xx I2C</b>
  *
  * @version 1.0.0
  *

--- a/include/libopencm3/stm32/g4/i2c.h
+++ b/include/libopencm3/stm32/g4/i2c.h
@@ -1,0 +1,34 @@
+/** @defgroup i2c_defines I2C Defines
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G0xx I2C</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_I2C_H
+#define LIBOPENCM3_I2C_H
+
+#include <libopencm3/stm32/common/i2c_common_v2.h>
+
+#endif
+

--- a/include/libopencm3/stm32/i2c.h
+++ b/include/libopencm3/stm32/i2c.h
@@ -40,7 +40,8 @@
 #       include <libopencm3/stm32/l4/i2c.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/i2c.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/i2c.h>
 #else
 #       error "stm32 family not defined."
 #endif
-

--- a/lib/stm32/g4/Makefile
+++ b/lib/stm32/g4/Makefile
@@ -43,6 +43,7 @@ OBJS += dmamux.o
 OBJS += fdcan.o fdcan_common.o
 OBJS += flash.o flash_common_all.o flash_common_f.o flash_common_idcache.o
 OBJS += gpio_common_all.o gpio_common_f0234.o
+OBJS += i2c_common_v2.o
 OBJS += opamp_common_all.o opamp_common_v2.o
 OBJS += pwr.o
 OBJS += rcc.o rcc_common_all.o


### PR DESCRIPTION
The STM32G4 series has the exact same I2C peripheral as STM32G0 (that is already supported). This PR makes it possible to use I2C on the STM32G4 series as well.
(used to be #1410)