### PR TITLE
add package.json so this repository can directly be used in PlatformIO

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "framework-libopencm3",
+  "version": "1.10000.220601",
+  "description": "Open source ARM Cortex-M microcontroller library",
+  "keywords": [
+    "framework",
+    "arm"
+  ],
+  "homepage": "http://www.libopencm3.org/",
+  "license": "GPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/libopencm3/libopencm3"
+  }
+}


### PR DESCRIPTION
with this file present this repository can be used in PlatformIO using the command

`platform_packages = framework-libopencm3@https://github.com/libopencm3/libopencm3.git`

in the platformio.ini file of any project. 
This is helpful for anyone using this platform because the default package of libopencm3 that is provided by PlatformIO is 2 years old.