### PR TITLE
usart: use rcc helpers for peripheral clock frequency

### DIFF
--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -52,17 +52,7 @@ usart_reg_base
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud)
 {
-	uint32_t clock = rcc_apb1_frequency;
-
-#if defined USART1
-	if ((usart == USART1)
-#if defined USART6
-		|| (usart == USART6)
-#endif
-		) {
-		clock = rcc_apb2_frequency;
-	}
-#endif
+	uint32_t clock = rcc_get_usart_clk_freq(usart);
 
 	/*
 	 * Yes it is as simple as that. The reference manual is

--- a/lib/stm32/h7/Makefile
+++ b/lib/stm32/h7/Makefile
@@ -48,7 +48,7 @@ OBJS += rcc_common_all.o
 OBJS += rng_common_v1.o
 OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o
-OBJS += usart_common_v2.o usart_common_fifos.o
+OBJS += usart_common_all.o usart_common_v2.o usart_common_fifos.o
 OBJS += quadspi_common_v1.o
 
 VPATH += ../../usb:../:../../cm3:../common


### PR DESCRIPTION
These rcc clock helpers seem to be implemented for the whole family, and H7 specifically has only its static clock structure and not the rcc_apb*_frequency variables, so this seemed like a sane switch to allow the H7 USART to work.

Tested with USART1 on an stm32h743.