### PR TITLE
C11 usability improvements

### DIFF
--- a/include/libopencm3/cm3/scb.h
+++ b/include/libopencm3/cm3/scb.h
@@ -549,7 +549,7 @@ struct scb_exception_stack_frame {
 
 #define SCB_GET_EXCEPTION_STACK_FRAME(f)				\
 	do {								\
-		asm volatile ("mov %[frameptr], sp"			\
+		__asm__ __volatile__("mov %[frameptr], sp"			\
 			      : [frameptr]"=r" (f));			\
 	} while (0)
 


### PR DESCRIPTION
Made use of `__asm__` in the scb code which automatically implies volatile and allows use with C11

This has been done in prep to allow the Black Magic Debug project to switch to C11 ahead of some changes that make use of C11 atomics.

As noted in the GCC manual page, `asm` is a vendor extension, which became an illegal word in C11 (all vendor extensions being required to be decorated with `__`). Technically the use of `volatile` with the standards conforming version of `asm` is extra verbiage for nothing, however after a conversation with @esden we agreed that keeping it in this change would be good for readers not familiar with the difference in semantics.

For further reading please refer to the [GCC page on Basic Asm](https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html#Basic-Asm), the [C reference on identifiers](https://en.cppreference.com/w/c/language/identifier#Reserved_identifiers) and [GCC page on Alternate Keywords](https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html#Alternate-Keywords) for more on extension naming.

It should be noted that `asm` can cause problems on non-GCC compilers which is a further reason to avoid using it, while `__asm__` is fairly consistently supported.