### PR TITLE
Feature: u(s)art configuration retrieval

### DIFF
--- a/include/libopencm3/lm4f/uart.h
+++ b/include/libopencm3/lm4f/uart.h
@@ -444,6 +444,7 @@ BEGIN_DECLS
 
 void uart_set_baudrate(uint32_t uart, uint32_t baud);
 void uart_set_databits(uint32_t uart, uint8_t databits);
+uint8_t uart_get_databits(uint32_t uart);
 void uart_set_stopbits(uint32_t uart, uint8_t stopbits);
 void uart_set_parity(uint32_t uart, enum uart_parity parity);
 void uart_set_mode(uint32_t uart, uint32_t mode);

--- a/include/libopencm3/lm4f/uart.h
+++ b/include/libopencm3/lm4f/uart.h
@@ -448,6 +448,7 @@ uint8_t uart_get_databits(uint32_t uart);
 void uart_set_stopbits(uint32_t uart, uint8_t stopbits);
 uint8_t uart_get_stopbits(uint32_t uart);
 void uart_set_parity(uint32_t uart, enum uart_parity parity);
+enum uart_parity uart_get_parity(uint32_t uart);
 void uart_set_mode(uint32_t uart, uint32_t mode);
 void uart_set_flow_control(uint32_t uart, enum uart_flowctl flow);
 void uart_enable(uint32_t uart);

--- a/include/libopencm3/lm4f/uart.h
+++ b/include/libopencm3/lm4f/uart.h
@@ -446,6 +446,7 @@ void uart_set_baudrate(uint32_t uart, uint32_t baud);
 void uart_set_databits(uint32_t uart, uint8_t databits);
 uint8_t uart_get_databits(uint32_t uart);
 void uart_set_stopbits(uint32_t uart, uint8_t stopbits);
+uint8_t uart_get_stopbits(uint32_t uart);
 void uart_set_parity(uint32_t uart, enum uart_parity parity);
 void uart_set_mode(uint32_t uart, uint32_t mode);
 void uart_set_flow_control(uint32_t uart, enum uart_flowctl flow);

--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -102,6 +102,7 @@ void usart_set_baudrate(uint32_t usart, uint32_t baud);
 void usart_set_databits(uint32_t usart, uint32_t bits);
 uint32_t usart_get_databits(uint32_t usart);
 void usart_set_stopbits(uint32_t usart, uint32_t stopbits);
+uint32_t usart_get_stopbits(uint32_t usart);
 void usart_set_parity(uint32_t usart, uint32_t parity);
 void usart_set_mode(uint32_t usart, uint32_t mode);
 void usart_set_flow_control(uint32_t usart, uint32_t flowcontrol);

--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -100,6 +100,7 @@ BEGIN_DECLS
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud);
 void usart_set_databits(uint32_t usart, uint32_t bits);
+uint32_t usart_get_databits(uint32_t usart);
 void usart_set_stopbits(uint32_t usart, uint32_t stopbits);
 void usart_set_parity(uint32_t usart, uint32_t parity);
 void usart_set_mode(uint32_t usart, uint32_t mode);

--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -104,6 +104,7 @@ uint32_t usart_get_databits(uint32_t usart);
 void usart_set_stopbits(uint32_t usart, uint32_t stopbits);
 uint32_t usart_get_stopbits(uint32_t usart);
 void usart_set_parity(uint32_t usart, uint32_t parity);
+uint32_t usart_get_parity(uint32_t usart);
 void usart_set_mode(uint32_t usart, uint32_t mode);
 void usart_set_flow_control(uint32_t usart, uint32_t flowcontrol);
 void usart_enable(uint32_t usart);

--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -140,4 +140,3 @@ END_DECLS
 #endif
 /** @endcond */
 /**@}*/
-

--- a/include/libopencm3/usb/cdc.h
+++ b/include/libopencm3/usb/cdc.h
@@ -118,7 +118,7 @@ struct usb_cdc_acm_descriptor {
 /* Table 13: Class-Specific Request Codes for PSTN subclasses */
 /* ... */
 #define USB_CDC_REQ_SET_LINE_CODING		0x20
-/* ... */
+#define USB_CDC_REQ_GET_LINE_CODING		0x21
 #define USB_CDC_REQ_SET_CONTROL_LINE_STATE	0x22
 /* ... */
 
@@ -161,4 +161,3 @@ struct usb_cdc_notification {
 #endif
 
 /**@}*/
-

--- a/lib/lm4f/uart.c
+++ b/lib/lm4f/uart.c
@@ -151,6 +151,12 @@ void uart_set_databits(uint32_t uart, uint8_t databits)
 	UART_LCRH(uart) = reg32;
 }
 
+uint8_t uart_get_databits(uint32_t uart)
+{
+	const uint8_t bits = (UART_LCRH(uart) & UART_LCRH_WLEN_MASK) >> 5;
+	return bits + 5;
+}
+
 /**
  * \brief Set UART stopbits
  *

--- a/lib/lm4f/uart.c
+++ b/lib/lm4f/uart.c
@@ -214,6 +214,26 @@ void uart_set_parity(uint32_t uart, enum uart_parity parity)
 	UART_LCRH(uart) = reg32;
 }
 
+enum uart_parity uart_get_parity(uint32_t uart)
+{
+	const uint32_t reg32 = UART_LCRH(uart);
+	/* Check if parity is even enabled */
+	if (!(reg32 & UART_LCRH_PEN))
+		return UART_PARITY_NONE;
+	/* Check for sticky modes */
+	if (reg32 & UART_LCRH_SPS) {
+		if (reg32 & UART_LCRH_EPS) {
+			return UART_PARITY_STICK_0;
+		}
+		return UART_PARITY_STICK_1;
+	} else {
+		if (reg32 & UART_LCRH_EPS) {
+			return UART_PARITY_EVEN;
+		}
+		return UART_PARITY_ODD;
+	}
+}
+
 /**
  * \brief Set the flow control scheme
  *

--- a/lib/lm4f/uart.c
+++ b/lib/lm4f/uart.c
@@ -172,6 +172,13 @@ void uart_set_stopbits(uint32_t uart, uint8_t stopbits)
 	}
 }
 
+uint8_t uart_get_stopbits(uint32_t uart)
+{
+	if (UART_LCRH(uart) & UART_LCRH_STP2)
+		return 2;
+	return 1;
+}
+
 /**
  * \brief Set UART parity
  *

--- a/lib/lm4f/uart.c
+++ b/lib/lm4f/uart.c
@@ -138,16 +138,16 @@ void uart_set_baudrate(uint32_t uart, uint32_t baud)
  */
 void uart_set_databits(uint32_t uart, uint8_t databits)
 {
-	uint32_t reg32, bitint32_t;
+	uint32_t reg32, bits32;
 
 	/* This has the same effect as using UART_LCRH_WLEN_5/6/7/8 directly */
-	bitint32_t = (databits - 5) << 5;
+	bits32 = (databits - 5) << 5;
 
 	/* TODO: What about 9 data bits? */
 
 	reg32 = UART_LCRH(uart);
 	reg32 &= ~UART_LCRH_WLEN_MASK;
-	reg32 |= bitint32_t;
+	reg32 |= bits32;
 	UART_LCRH(uart) = reg32;
 }
 

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -106,6 +106,27 @@ void usart_set_databits(uint32_t usart, uint32_t bits)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Get Word Length.
+
+The word length is set to 8 or 9 bits. Note that the last bit will be a parity
+bit if parity is enabled, in which case the data length will be 7 or 8 bits
+respectively.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@returns unsigned 32 bit Word length in bits 8 or 9.
+*/
+
+uint32_t usart_get_databits(uint32_t usart)
+{
+	const uint32_t reg32 = USART_CR1(usart) & USART_CR1_M;
+	if (reg32)
+		return 9;
+	else
+		return 8;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Set Stop Bit(s).
 
 The stop bits are specified as 0.5, 1, 1.5 or 2.

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -146,6 +146,22 @@ void usart_set_stopbits(uint32_t usart, uint32_t stopbits)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Get Stop Bit(s).
+
+The stop bits are specified as 0.5, 1, 1.5 or 2.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@returns unsigned 32 bit Stop bits @ref usart_cr2_stopbits.
+*/
+
+uint32_t usart_get_stopbits(uint32_t usart)
+{
+	const uint32_t reg32 = USART_CR2(usart);
+	return reg32 & USART_CR2_STOPBITS_MASK;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Set Parity.
 
 The parity bit can be selected as none, even or odd.

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -406,7 +406,7 @@ void usart_disable_tx_interrupt(uint32_t usart)
 /*---------------------------------------------------------------------------*/
 /**
  * @brief USART Transmission Complete Interrupt Enable
- * 
+ *
  * @param[in] usart unsigned 32 bit. USART block register address base @ref
 usart_reg_base
  */
@@ -419,7 +419,7 @@ void usart_enable_tx_complete_interrupt(uint32_t usart)
 /*---------------------------------------------------------------------------*/
 /**
  * @brief USART Transmission Complete Interrupt Disable
- * 
+ *
  * @param[in] usart unsigned 32 bit. USART block register address base @ref
 usart_reg_base
  */
@@ -477,4 +477,3 @@ void usart_disable_error_interrupt(uint32_t usart)
 }
 
 /**@}*/
-

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -181,6 +181,22 @@ void usart_set_parity(uint32_t usart, uint32_t parity)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Get Parity.
+
+The stop bits are specified as 0.5, 1, 1.5 or 2.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref
+usart_reg_base
+@returns unsigned 32 bit Parity @ref usart_cr2_stopbits.
+*/
+
+uint32_t usart_get_parity(uint32_t usart)
+{
+	const uint32_t reg32 = USART_CR1(usart);
+	return reg32 & USART_PARITY_MASK;
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Set Rx/Tx Mode.
 
 The mode can be selected as Rx only, Tx only or Rx+Tx.


### PR DESCRIPTION
As part of addressing some defects in BMP, we found that the USB CDC support in locm3 didn't support the class specific request `GET_LINE_CODING`.

This PR addresses that by adding the missing define and then providing support for STM32 and LM4F (TM4C) for retrieving the current UART configuration to answer this USB request.