### PR TITLE
stm32: Support CRC, SYSCFG and USART on G4

### DIFF
--- a/include/libopencm3/stm32/crc.h
+++ b/include/libopencm3/stm32/crc.h
@@ -40,6 +40,8 @@
 #       include <libopencm3/stm32/l4/crc.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/crc.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/crc.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/g4/crc.h
+++ b/include/libopencm3/stm32/g4/crc.h
@@ -1,0 +1,33 @@
+/** @defgroup crc_defines CRC Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G4xx CRC Generator </b>
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_CRC_H
+#define LIBOPENCM3_CRC_H
+
+#include <libopencm3/stm32/common/crc_v2.h>
+
+#endif

--- a/include/libopencm3/stm32/g4/syscfg.h
+++ b/include/libopencm3/stm32/g4/syscfg.h
@@ -1,0 +1,50 @@
+/** @defgroup syscfg_defines SYSCFG Defines
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @brief Defined Constants and Types for the STM32G4xx Sysconfig
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_SYSCFG_H
+#define LIBOPENCM3_SYSCFG_H
+
+#define SYSCFG_MEMRM			MMIO32(SYSCFG_BASE + 0x00)
+
+#define SYSCFG_PMC			MMIO32(SYSCFG_BASE + 0x04)
+
+/* External interrupt configuration registers [0..3] (SYSCFG_EXTICR[1..4]) */
+#define SYSCFG_EXTICR(i)		MMIO32(SYSCFG_BASE + 0x08 + (i)*4)
+#define SYSCFG_EXTICR1			SYSCFG_EXTICR(0)
+#define SYSCFG_EXTICR2			SYSCFG_EXTICR(1)
+#define SYSCFG_EXTICR3			SYSCFG_EXTICR(2)
+#define SYSCFG_EXTICR4			SYSCFG_EXTICR(3)
+
+#define SYSCFG_SWPR			MMIO32(SYSCFG_BASE + 0x20)
+
+/* --- SYSCFG_EXTICR Values -------------------------------------------------*/
+
+#define SYSCFG_EXTICR_FIELDSIZE		4
+
+#endif

--- a/include/libopencm3/stm32/g4/usart.h
+++ b/include/libopencm3/stm32/g4/usart.h
@@ -1,0 +1,55 @@
+/** @defgroup usart_defines USART Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G4xx USART</b>
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_USART_H
+#define LIBOPENCM3_USART_H
+
+#include <libopencm3/stm32/common/usart_common_all.h>
+#include <libopencm3/stm32/common/usart_common_v2.h>
+
+/**@{*/
+
+/** @defgroup usart_reg_base USART register base addresses
+ * Holds all the U(S)ART peripherals supported.
+ * @{
+ */
+#define USART1				USART1_BASE
+#define USART2				USART2_BASE
+#define USART3				USART3_BASE
+#define UART4				UART4_BASE
+#define UART5				UART5_BASE
+/**@}*/
+
+BEGIN_DECLS
+
+END_DECLS
+
+/**@}*/
+
+#endif
+

--- a/include/libopencm3/stm32/syscfg.h
+++ b/include/libopencm3/stm32/syscfg.h
@@ -38,6 +38,8 @@
 #       include <libopencm3/stm32/l4/syscfg.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/syscfg.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/syscfg.h>
 #elif defined(STM32H7)
 #       include <libopencm3/stm32/h7/syscfg.h>
 #else

--- a/include/libopencm3/stm32/usart.h
+++ b/include/libopencm3/stm32/usart.h
@@ -40,6 +40,8 @@
 #       include <libopencm3/stm32/l4/usart.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/usart.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/usart.h>
 #elif defined(STM32H7)
 #       include <libopencm3/stm32/h7/usart.h>
 #else

--- a/lib/stm32/g4/Makefile
+++ b/lib/stm32/g4/Makefile
@@ -37,6 +37,7 @@ ARFLAGS		= rcs
 
 OBJS += adc.o adc_common_v2.o adc_common_v2_multi.o
 OBJS += crs_common_all.o
+OBJS += crc_common_all.o crc_v2.o
 OBJS += dac_common_all.o dac_common_v2.o
 OBJS += dma_common_l1f013.o
 OBJS += dmamux.o
@@ -51,6 +52,7 @@ OBJS += rng_common_v1.o
 OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o timer_common_f0234.o
 OBJS += quadspi_common_v1.o
+OBJS += usart_common_v2.o usart_common_all.o
 
 OBJS += usb.o usb_control.o usb_standard.o
 OBJS += usb_audio.o


### PR DESCRIPTION
CRC and USART are just copied from F3, as they should be fully compatible according to this [application note](https://www.st.com/content/ccc/resource/technical/document/application_note/group1/87/f0/7b/96/37/cf/49/b8/DM00442720/files/DM00442720.pdf/jcr:content/translations/en.DM00442720.pdf). LPUART support is not implemented.

I've tested this PR by running [BMP](https://github.com/blackmagic-debug/blackmagic) code on STM32G431 and USART bridge works.