### PR TITLE
Enable required files to ensure successful build of a "stm32h7" only lib

### DIFF
--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -52,17 +52,7 @@ usart_reg_base
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud)
 {
-	uint32_t clock = rcc_apb1_frequency;
-
-#if defined USART1
-	if ((usart == USART1)
-#if defined USART6
-		|| (usart == USART6)
-#endif
-		) {
-		clock = rcc_apb2_frequency;
-	}
-#endif
+	uint32_t clock = rcc_get_usart_clk_freq(usart);
 
 	/*
 	 * Yes it is as simple as that. The reference manual is

--- a/lib/stm32/h7/Makefile
+++ b/lib/stm32/h7/Makefile
@@ -48,7 +48,7 @@ OBJS += rcc_common_all.o
 OBJS += rng_common_v1.o
 OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o
-OBJS += usart_common_v2.o usart_common_fifos.o
+OBJS += usart_common_all.o usart_common_v2.o usart_common_fifos.o
 OBJS += quadspi_common_v1.o
 
 VPATH += ../../usb:../:../../cm3:../common


### PR DESCRIPTION
Hi, to accelerate lib build time, I enabled just stm32h7 and noticed the final link failed some files were missing in the stm32h7 makefile.

Here is a patch to fix that.

Also, the uart source needs an update to use get_uart_clk instead of directly accessing the global vars.

Thanks!