### PR TITLE
this pull request is a demonstration showing how to avoid initialized data in libopencm3

### DIFF
--- a/include/libopencm3/stm32/h7/rcc.h
+++ b/include/libopencm3/stm32/h7/rcc.h
@@ -708,6 +708,8 @@ enum rcc_periph_rst {
 
 BEGIN_DECLS
 
+void rcc_init(void);
+
 /**
  * Setup the base PLLs and clock domains for the STM32H7. This function will
  * utilize the users input parameters to configure all 3 PLLs, as well as the

--- a/lib/stm32/h7/rcc.c
+++ b/lib/stm32/h7/rcc.c
@@ -32,14 +32,16 @@ static struct {
 		uint16_t r_mhz;
 	} pll1, pll2, pll3;
 	uint16_t hse_khz;			/* This can't exceed 50MHz */
-} rcc_clock_tree = {
-	.sysclk_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ,
-	.cpu_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ,
-	.hclk_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ,
-	.per.pclk1_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ,
-	.per.pclk2_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ,
-	.per.pclk3_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ,
-	.per.pclk4_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ
+} rcc_clock_tree;
+
+void rcc_init(void) {
+	rcc_clock_tree.sysclk_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ;
+	rcc_clock_tree.cpu_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ;
+	rcc_clock_tree.hclk_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ;
+	rcc_clock_tree.per.pclk1_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ;
+	rcc_clock_tree.per.pclk2_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ;
+	rcc_clock_tree.per.pclk3_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ;
+	rcc_clock_tree.per.pclk4_mhz = RCC_HSI_BASE_FREQUENCY / HZ_PER_MHZ;
 };
 
 static void rcc_configure_pll(uint32_t clkin, const struct pll_config *config, int pll_num) {

--- a/lib/stm32/h7/vector_chipset.c
+++ b/lib/stm32/h7/vector_chipset.c
@@ -19,9 +19,13 @@
  */
 
 #include <libopencm3/cm3/scb.h>
+#include <libopencm3/stm32/rcc.h>
 
 static void pre_main(void)
 {
 	/* Enable access to Floating-Point coprocessor. */
 	SCB_CPACR |= SCB_CPACR_FULL * (SCB_CPACR_CP10 | SCB_CPACR_CP11);
+
+    /* Initialize the default clock tree */
+    rcc_init();
 }


### PR DESCRIPTION
here is my attempt at avoiding the only initialized data in the libopencm3 project for stm32
I just initialized the required fields from a boot hook.

This PR is not ready for inclusion yet. it's a demo for the issue discussed at https://github.com/libopencm3/libopencm3/issues/1453