### PR TITLE
STM32F0/G0/G4/L0: ADC: add missing macros, fix mask/shift style

### DIFF
--- a/include/libopencm3/stm32/f0/adc.h
+++ b/include/libopencm3/stm32/f0/adc.h
@@ -52,17 +52,16 @@
 /* Register definitions                                                      */
 /*****************************************************************************/
 
+#define ADC_SMPR(adc)			ADC_SMPR1(adc)
+#define ADC_TR(adc)			ADC_TR1(adc)
+
 #define ADC1_ISR			ADC_ISR(ADC)
 #define ADC1_IER			ADC_IER(ADC)
 #define ADC1_CR				ADC_CR(ADC)
 #define ADC1_CFGR1			ADC_CFGR1(ADC)
 #define ADC1_CFGR2			ADC_CFGR2(ADC)
-#define ADC1_SMPR1			ADC_SMPR1(ADC)
-#define ADC_SMPR(adc)			ADC_SMPR1(adc)  /* Compatibility */
-#define ADC1_SMPR			ADC_SMPR1(ADC) /* Compatibility */
-#define ADC1_TR1			ADC_TR1(ADC)
-#define ADC_TR(adc)			ADC_TR1(adc) /* Compatibility */
-#define ADC1_TR				ADC1_TR(ADC) /* Compatibility */
+#define ADC1_SMPR			ADC_SMPR(ADC)
+#define ADC1_TR				ADC_TR(ADC)
 #define ADC1_CHSELR			ADC_CHSELR(ADC)
 #define ADC1_DR				ADC_DR(ADC)
 #define ADC1_CCR			ADC_CCR(ADC)
@@ -91,23 +90,25 @@
 /* ADC_CFGR2 Values ---------------------------------------------------------*/
 
 #define ADC_CFGR2_CKMODE_SHIFT		30
-#define ADC_CFGR2_CKMODE		(3 << ADC_CFGR2_CKMODE_SHIFT)
-#define ADC_CFGR2_CKMODE_CK_ADC		(0 << ADC_CFGR2_CKMODE_SHIFT)
-#define ADC_CFGR2_CKMODE_PCLK_DIV2	(1 << ADC_CFGR2_CKMODE_SHIFT)
-#define ADC_CFGR2_CKMODE_PCLK_DIV4	(2 << ADC_CFGR2_CKMODE_SHIFT)
+#define ADC_CFGR2_CKMODE_MASK		0x3
+
+#define ADC_CFGR2_CKMODE_CK_ADC		0x0
+#define ADC_CFGR2_CKMODE_PCLK_DIV2	0x1
+#define ADC_CFGR2_CKMODE_PCLK_DIV4	0x2
 
 /* ADC_SMPR Values ----------------------------------------------------------*/
 
 #define ADC_SMPR_SMP_SHIFT		0
-#define ADC_SMPR_SMP			(7 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_001DOT5		(0 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_007DOT5		(1 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_013DOT5		(2 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_028DOT5		(3 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_041DOT5		(4 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_055DOT5		(5 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_071DOT5		(6 << ADC_SMPR_SMP_SHIFT)
-#define ADC_SMPR_SMP_239DOT5		(7 << ADC_SMPR_SMP_SHIFT)
+#define ADC_SMPR_SMP_MASK		0x7
+
+#define ADC_SMPR_SMP_001DOT5		0x0
+#define ADC_SMPR_SMP_007DOT5		0x1
+#define ADC_SMPR_SMP_013DOT5		0x2
+#define ADC_SMPR_SMP_028DOT5		0x3
+#define ADC_SMPR_SMP_041DOT5		0x4
+#define ADC_SMPR_SMP_055DOT5		0x5
+#define ADC_SMPR_SMP_071DOT5		0x6
+#define ADC_SMPR_SMP_239DOT5		0x7
 
 
 /*****************************************************************************/

--- a/include/libopencm3/stm32/g0/adc.h
+++ b/include/libopencm3/stm32/g0/adc.h
@@ -66,6 +66,29 @@
 #define ADC_CALFACT(adc)	MMIO32((adc) + 0xB4)
 /**@}*/
 
+/* --- Register definitions -------------------------------------------------------*/
+
+#define ADC_SMPR(adc)		ADC_SMPR1(adc)
+#define ADC_TR(adc)		ADC_TR1(adc)
+
+#define ADC1_ISR		ADC_ISR(ADC1)
+#define ADC1_IER		ADC_IER(ADC1)
+#define ADC1_CR			ADC_CR(ADC1)
+#define ADC1_CFGR1		ADC_CFGR1(ADC1)
+#define ADC1_CFGR2		ADC_CFGR2(ADC1)
+#define ADC1_SMPR		ADC_SMPR(ADC1)
+#define ADC1_TR			ADC_TR(ADC1)
+#define ADC1_CHSELR		ADC_CHSELR(ADC1)
+#define ADC1_DR			ADC_DR(ADC1)
+#define ADC1_CCR		ADC_CCR(ADC1)
+
+#define ADC1_AWD1TR		ADC_AWD1TR(ADC1)
+#define ADC1_AWD2TR		ADC_AWD2TR(ADC1)
+#define ADC1_AWD3TR		ADC_AWD3TR(ADC1)
+#define ADC1_AWD2CR		ADC_AWD2CR(ADC1)
+#define ADC1_AWD3CR		ADC_AWD3CR(ADC1)
+#define ADC1_CALFACT		ADC_CALFACT(ADC1)
+
 /* --- Register values -------------------------------------------------------*/
 
 /** @addtogroup adc_isr
@@ -123,8 +146,7 @@
 
 /* EXTSEL[2:0]: External trigger selection for regular group */
 #define ADC_CFGR1_EXTSEL_SHIFT			6
-#define ADC_CFGR1_EXTSEL			(0x7 << ADC_CFGR1_EXTSEL_SHIFT)
-#define ADC_CFGR1_EXTSEL_VAL(x)			((x) << ADC_CFGR1_EXTSEL_SHIFT)
+#define ADC_CFGR1_EXTSEL_MASK			0x7
 /** @defgroup adc_cfgr1_extsel ADC external trigger selection values
  *@{*/
 #define ADC_CFGR1_EXTSEL_TIM1_TRGO2	0x0
@@ -163,10 +185,6 @@
 
 #define ADC_CFGR2_OVSS_SHIFT		(5)
 #define ADC_CFGR2_OVSS_MASK			(0xf)
-/** @defgroup adc_cfgr2_ovss ADC Oversampling shift
- *@{*/
-#define ADC_CFGR2_OVSS_BITS(bits)	(bits)
-/**@}*/
 
 #define ADC_CFGR2_OVSR_SHIFT		(2)
 #define ADC_CFGR2_OVSR_MASK			(0x7)
@@ -193,8 +211,7 @@
 /* SMP1 ADC Channel Sample Time selection */
 #define ADC_SMPR_SMPSEL_SHIFT			0x8
 #define ADC_SMPR_SMPSEL_MASK			0x7ffff
-#define ADC_SMPR_SMPSEL_CHANNEL_SHIFT(channel)	((channel) + ADC_SMPR_SMPSEL_SHIFT)
-#define ADC_SMPR_SMPSEL_CHANNEL_MASK			(1)
+#define ADC_SMPR_SMPSEL(x)			(1 << ((x) + ADC_SMPR_SMPSEL_SHIFT))
 /** @defgroup adc_smpr_smpsel ADC Sample Time selection
 @{*/
 #define ADC_SMPR_SMPSEL_SMP1	0x0
@@ -228,12 +245,10 @@
 @{*/
 
 #define ADC_AWDTR1_LT_SHIFT		0
-#define ADC_AWDTR1_LT			(0xFFF << ADC_TR1_LT_SHIFT)
-#define ADC_AWDTR1_LT_VAL(x)		((x) << ADC_TR1_LT_SHIFT)
+#define ADC_AWDTR1_LT_MASK		0xfff
 
 #define ADC_AWDTR1_HT_SHIFT		16
-#define ADC_AWDTR1_HT			(0xFFF << ADC_TR1_HT_SHIFT)
-#define ADC_AWDTR1_HT_VAL(x)		((x) << ADC_TR1_HT_SHIFT)
+#define ADC_AWDTR1_HT_MASK		0xfff
 
 /**@}*/
 
@@ -241,12 +256,10 @@
 @{*/
 
 #define ADC_AWDTR2_LT_SHIFT		0
-#define ADC_AWDTR2_LT			(0xFFF << ADC_TR2_LT_SHIFT)
-#define ADC_AWDTR2_LT_VAL(x)		((x) << ADC_TR2_LT_SHIFT)
+#define ADC_AWDTR2_LT_MASK		0xfff
 
 #define ADC_AWDTR2_HT_SHIFT		16
-#define ADC_AWDTR2_HT			(0xFFF << ADC_TR2_HT_SHIFT)
-#define ADC_AWDTR2_HT_VAL(x)		((x) << ADC_TR2_HT_SHIFT)
+#define ADC_AWDTR2_HT_MASK		0xfff
 
 /**@}*/
 
@@ -258,8 +271,8 @@
 
 /** ADC_CHSELR_MAX_SQ_CHANNELS Maximum number of sequences in fully configurable mode */
 #define ADC_CHSELR_MAX_SQS		8
-/** ADC_CHSELR_SQS_MAX_CHANNEL Maximum channel number in a fully configuralbe sequence */
-#define ADC_CHSELR_SQS_MAX_CHANNEL		14
+/** ADC_CHSELR_SQS_MAX_CHANNELS Maximum channel number in a fully configuralbe sequence */
+#define ADC_CHSELR_SQS_MAX_CHANNELS	14
 
 #define ADC_CHSELR_SQx_MASK		0xf
 #define ADC_CHSELR_SQx_SHIFT(seqnum)  (4 * ((seqnum)-1))
@@ -268,20 +281,18 @@
 #define ADC_CHSELR_SQx(seqnum, value)	((value) << ADC_CHSELR_SQx_SHIFT(seqnum))
 
 /** ADC_CHSELR_SQx_EOS End of Sequence */
-#define ADC_CHSELR_SQx_EOS		0xf
+#define ADC_CHSELR_SQx_EOS(seqnum)	ADC_CHSELR_SQx(seqnum, 0xf)
 
 /**@}*/
 
-/** @defgroup adc_awdtr2 AWDTR2 ADC watchdog threshold register 2
+/** @defgroup adc_awdtr3 AWDTR3 ADC watchdog threshold register 3
 @{*/
 
 #define ADC_AWDTR3_LT_SHIFT		0
-#define ADC_AWDTR3_LT			(0xFFF << ADC_TR3_LT_SHIFT)
-#define ADC_AWDTR3_LT_VAL(x)		((x) << ADC_TR3_LT_SHIFT)
+#define ADC_AWDTR3_LT_MASK		0xfff
 
 #define ADC_AWDTR3_HT_SHIFT		16
-#define ADC_AWDTR3_HT			(0xFFF << ADC_TR3_HT_SHIFT)
-#define ADC_AWDTR3_HT_VAL(x)		((x) << ADC_TR3_HT_SHIFT)
+#define ADC_AWDTR3_HT_MASK		0xfff
 
 /**@}*/
 

--- a/include/libopencm3/stm32/l0/adc.h
+++ b/include/libopencm3/stm32/l0/adc.h
@@ -56,6 +56,24 @@
 /* Calibration Factors */
 #define ADC_CALFACT(adc)	MMIO32((adc) + 0xB4)
 
+/* Register definitions */
+
+#define ADC_SMPR(adc)		ADC_SMPR1(adc)
+#define ADC_TR(adc)		ADC_TR1(adc)
+
+#define ADC1_ISR		ADC_ISR(ADC1)
+#define ADC1_IER		ADC_IER(ADC1)
+#define ADC1_CR			ADC_CR(ADC1)
+#define ADC1_CFGR1		ADC_CFGR1(ADC1)
+#define ADC1_CFGR2		ADC_CFGR2(ADC1)
+#define ADC1_SMPR		ADC_SMPR(ADC1)
+#define ADC1_TR			ADC_TR(ADC1)
+#define ADC1_CHSELR		ADC_CHSELR(ADC1)
+#define ADC1_DR			ADC_DR(ADC1)
+#define ADC1_CCR		ADC_CCR(ADC1)
+
+#define ADC1_CALFACT		ADC_CALFACT(ADC1)
+
 /* Register values */
 /* ADC_CFGR1 Values ---------------------------------------------------------*/
 
@@ -64,9 +82,7 @@
 
 /* EXTSEL[2:0]: External trigger selection for regular group */
 #define ADC_CFGR1_EXTSEL_SHIFT		6
-#define ADC_CFGR1_EXTSEL		(0x7 << ADC_CFGR1_EXTSEL_SHIFT)
-#define ADC_CFGR1_EXTSEL_VAL(x)		((x) << ADC_CFGR1_EXTSEL_SHIFT)
-
+#define ADC_CFGR1_EXTSEL_MASK		0x7
 /** @defgroup adc_cfgr1_extsel ADC external trigger selection values
  *@{*/
 #define ADC_CFGR1_EXTSEL_TIM6_TRGO	0x0
@@ -83,11 +99,14 @@
 /* ADC_CFGR2 Values ---------------------------------------------------------*/
 
 #define ADC_CFGR2_CKMODE_SHIFT		30
-#define ADC_CFGR2_CKMODE		(3 << ADC_CFGR2_CKMODE_SHIFT)
-#define ADC_CFGR2_CKMODE_CK_ADC		(0 << ADC_CFGR2_CKMODE_SHIFT)
-#define ADC_CFGR2_CKMODE_PCLK_DIV2	(1 << ADC_CFGR2_CKMODE_SHIFT)
-#define ADC_CFGR2_CKMODE_PCLK_DIV4	(2 << ADC_CFGR2_CKMODE_SHIFT)
-#define ADC_CFGR2_CKMODE_PCLK		(3 << ADC_CFGR2_CKMODE_SHIFT)
+#define ADC_CFGR2_CKMODE_MASK		0x3
+
+#define ADC_CFGR2_CKMODE_CK_ADC		0x0
+#define ADC_CFGR2_CKMODE_PCLK_DIV2	0x1
+#define ADC_CFGR2_CKMODE_PCLK_DIV4	0x2
+#define ADC_CFGR2_CKMODE_PCLK		0x3
+
+/* ADC_SMPR Values ----------------------------------------------------------*/
 
 /** @defgroup adc_sample_rg ADC Sample Time Selection for All Channels
 @ingroup adc_defines

--- a/lib/stm32/f0/adc.c
+++ b/lib/stm32/f0/adc.c
@@ -162,11 +162,10 @@ void adc_set_operation_mode(uint32_t adc, enum adc_opmode opmode)
 void adc_enable_external_trigger_regular(uint32_t adc, uint32_t trigger,
 				 uint32_t polarity)
 {
-	uint32_t reg = ADC_CFGR1(adc);
-	reg &= ~(ADC_CFGR1_EXTSEL_MASK << ADC_CFGR1_EXTSEL_SHIFT);
-	reg &= ~(ADC_CFGR1_EXTEN_MASK);
-	reg |= polarity | (trigger << ADC_CFGR1_EXTSEL_SHIFT);
-	ADC_CFGR1(adc) = reg;
+	uint32_t reg32 = ADC_CFGR1(adc);
+	reg32 &= ~((ADC_CFGR1_EXTSEL_MASK << ADC_CFGR1_EXTSEL_SHIFT) | ADC_CFGR1_EXTEN_MASK);
+	reg32 |= (trigger << ADC_CFGR1_EXTSEL_SHIFT) | polarity;
+	ADC_CFGR1(adc) = reg32;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -308,7 +307,9 @@ void adc_clear_eoc_sequence_flag(uint32_t adc)
 
 void adc_set_clk_source(uint32_t adc, uint32_t source)
 {
-	ADC_CFGR2(adc) = ((ADC_CFGR2(adc) & ~ADC_CFGR2_CKMODE) | source);
+	uint32_t reg32 = ADC_CFGR2(adc);
+	reg32 &= ~(ADC_CFGR2_CKMODE_MASK << ADC_CFGR2_CKMODE_SHIFT);
+	ADC_CFGR2(adc) = reg32 | (source << ADC_CFGR2_CKMODE_SHIFT);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -374,7 +375,9 @@ void adc_set_regular_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 
 void adc_set_sample_time_on_all_channels(uint32_t adc, uint8_t time)
 {
-	ADC_SMPR(adc) = time & ADC_SMPR_SMP;
+	uint32_t reg32 = ADC_SMPR(adc);
+	reg32 &= ~(ADC_SMPR_SMP_MASK << ADC_SMPR_SMP_SHIFT);
+	ADC_SMPR(adc) = reg32 | (time << ADC_SMPR_SMP_SHIFT);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/stm32/g0/adc.c
+++ b/lib/stm32/g0/adc.c
@@ -86,8 +86,11 @@ void adc_set_channel_sample_time_selection(uint32_t adc, uint8_t channel, uint8_
 	uint32_t reg32;
 
 	reg32 = ADC_SMPR1(adc);
-	reg32 &= ~(ADC_SMPR_SMPSEL_CHANNEL_MASK << ADC_SMPR_SMPSEL_CHANNEL_SHIFT(channel));
-	reg32 |= (selection << ADC_SMPR_SMPSEL_CHANNEL_SHIFT(channel));
+	if (selection) {
+		reg32 |= ADC_SMPR_SMPSEL(channel);
+	} else {
+		reg32 &= ~ADC_SMPR_SMPSEL(channel);
+	}
 	ADC_SMPR1(adc) = reg32;
 }
 


### PR DESCRIPTION
Hello!

I extensively use libopencm3 in my projects for bare-metal programming. In particular, here's the link to a piece of BLDC motor control firmware that runs on the F0 and G0 chips: https://github.com/neoxic/ESCape32

Recently, I added support for ADC for current/temperature/voltage measurements to that project, but I'm unable to publish it until the following PR is accepted and merged. So hopefully, you'll find these fixes consistent and useful. Besides being successfully tested and used in the above project, they have also been checked against libopencm3-examples (no conflicts found). I made explicit effort to maintain your code style (tab size 8, etc.) and made a couple of corrections here and there where it was necessary.

The PR consists of three parts:

1. G0: add ADC compatibility macros that already exist across other families.
2. F0/G0/L0: add `ADC_CFGR1_EXTSEL` values.
3. G0/G4: fix `*_SHIFT/*_MASK` macros that didn't match the general approach (breaking change).
