### PR TITLE
NEEDSTEST: stm32f0: comparator: fix memory accesses

### DIFF
--- a/include/libopencm3/stm32/f0/comparator.h
+++ b/include/libopencm3/stm32/f0/comparator.h
@@ -38,16 +38,18 @@
 /* Module definitions                                                        */
 /*****************************************************************************/
 
+/** @defgroup comp_ids Comparator IDs
+ @{
+ */
 #define COMP1	0
-#define COMP2	1
+#define COMP2	16
+/**@}*/
 
 /*****************************************************************************/
 /* Register definitions                                                      */
 /*****************************************************************************/
 
-#define COMP_CSR(i)			MMIO16(SYSCFG_COMP_BASE + 0x1c + (i)*2)
-#define COMP_CSR1			COMP_CSR(COMP1)
-#define COMP_CSR2			COMP_CSR(COMP2)
+#define COMP_CSR			MMIO32(SYSCFG_COMP_BASE + 0x1c)
 
 /*****************************************************************************/
 /* Register values                                                           */
@@ -111,7 +113,15 @@
 
 BEGIN_DECLS
 
+/**
+ * Enable a comparator.
+ * @param id which comparator @ref comp_ids
+ */
 void comp_enable(uint8_t id);
+/**
+ * Disable a comparator.
+ * @param id which comparator @ref comp_ids
+ */
 void comp_disable(uint8_t id);
 void comp_select_input(uint8_t id, uint32_t input);
 void comp_select_output(uint8_t id, uint32_t output);

--- a/lib/stm32/f0/comparator.c
+++ b/lib/stm32/f0/comparator.c
@@ -33,32 +33,32 @@
 
 void comp_enable(uint8_t id)
 {
-	COMP_CSR(id) |= COMP_CSR_EN;
+	COMP_CSR |= (COMP_CSR_EN << id);
 }
 
 void comp_disable(uint8_t id)
 {
-	COMP_CSR(id) &= ~COMP_CSR_EN;
+	COMP_CSR &= ~(COMP_CSR_EN << id);
 }
 
 void comp_select_input(uint8_t id, uint32_t input)
 {
-	COMP_CSR(id) = (COMP_CSR(id) & ~COMP_CSR_INSEL) | input;
+	COMP_CSR = (COMP_CSR & ~(COMP_CSR_INSEL << id)) | (input << id);
 }
 
 void comp_select_output(uint8_t id, uint32_t output)
 {
-	COMP_CSR(id) = (COMP_CSR(id) & ~COMP_CSR_OUTSEL) | output;
+	COMP_CSR = (COMP_CSR & ~(COMP_CSR_OUTSEL << id)) | (output << id);
 }
 
 void comp_select_hyst(uint8_t id, uint32_t hyst)
 {
-	COMP_CSR(id) = (COMP_CSR(id) & ~COMP_CSR_HYST) | hyst;
+	COMP_CSR = (COMP_CSR & ~(COMP_CSR_HYST << id)) | (hyst << id);
 }
 
 void comp_select_speed(uint8_t id, uint32_t speed)
 {
-	COMP_CSR(id) = (COMP_CSR(id) & ~COMP_CSR_SPEED) | speed;
+	COMP_CSR = (COMP_CSR & ~(COMP_CSR_SPEED << id)) | (speed << id);
 }
 /**@}*/
 


### PR DESCRIPTION
Fixes: https://github.com/libopencm3/libopencm3/issues/1289

While it had seemed a clever trick to access COMP_CSR as two 16bit registers, apparently in the real world, this didn't behave as expected.

Switch the register definitions to 32bit and adjust all the functions to auto select the correct portion of the register.

NEEDSTEST: this has been coded only, I personally have no code using this, but it seems like the correct approach, and the current code is obviously broken.

Signed-off-by: Karl Palsson <karlp@tweak.au>