### PR TITLE
fix the build for standalone stm32h7 lib.

### DIFF
--- a/lib/stm32/h7/Makefile
+++ b/lib/stm32/h7/Makefile
@@ -48,7 +48,7 @@ OBJS += rcc_common_all.o
 OBJS += rng_common_v1.o
 OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o
-OBJS += usart_common_v2.o usart_common_fifos.o
+OBJS += usart_common_all.o usart_common_v2.o usart_common_fifos.o
 OBJS += quadspi_common_v1.o
 
 VPATH += ../../usb:../:../../cm3:../common


### PR DESCRIPTION
Hi,

Here is a patch to fix the stm32h7 build, otherwise the final link just complains:
```
arm-none-eabi/bin/ld: bootloader.o: in function `_write':
arm-none-eabi/bin/ld: bootloader.c:217: undefined reference to `usart_send_blocking'
arm-none-eabi/bin/ld: bootloader.o: in function `usart_setup':
undefined reference to `usart_set_baudrate'
arm-none-eabi/bin/ld: bootloader.c:64: undefined reference to `usart_set_databits'
arm-none-eabi/bin/ld: bootloader.c:65: undefined reference to `usart_set_stopbits'
arm-none-eabi/bin/ld: bootloader.c:66: undefined reference to `usart_set_mode'
arm-none-eabi/bin/ld: bootloader.c:67: undefined reference to `usart_set_parity'
arm-none-eabi/bin/ld: bootloader.c:68: undefined reference to `usart_set_flow_control'
arm-none-eabi/bin/ld: bootloader.c:71: undefined reference to `usart_enable'
```
Thanks.