### PR TITLE
Small makefile change to clean up debugging path resolutions.

### DIFF
--- a/lib/Makefile.include
+++ b/lib/Makefile.include
@@ -38,7 +38,7 @@ $(SRCLIBDIR)/$(LIBNAME).a: $(OBJS)
 
 %.o: %.c
 	@printf "  CC      $(<F)\n"
-	$(Q)$(CC) $(TGT_CFLAGS) $(CFLAGS) -o $@ -c $<
+	$(Q)$(CC) $(TGT_CFLAGS) $(CFLAGS) -o $@ -c $(abspath $<)
 
 clean:
 	$(Q)rm -f *.o *.d ../*.o ../*.d


### PR DESCRIPTION
Changed the compilation command to utilize absolute paths for source files. This helps resolve file locations during debugging more cleanly.

This change avoids confusion in debuggers with trying to resolve relative paths to track down the source files.