### PR TITLE
Feature: individual STM32 timer oc mode calls

### DIFF
--- a/include/libopencm3/stm32/common/timer_common_all.h
+++ b/include/libopencm3/stm32/common/timer_common_all.h
@@ -1192,6 +1192,10 @@ void timer_enable_oc_clear(uint32_t timer_peripheral, enum tim_oc_id oc_id);
 void timer_disable_oc_clear(uint32_t timer_peripheral, enum tim_oc_id oc_id);
 void timer_set_oc_fast_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id);
 void timer_set_oc_slow_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id);
+void timer_set_oc1_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode);
+void timer_set_oc2_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode);
+void timer_set_oc3_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode);
+void timer_set_oc4_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode);
 void timer_set_oc_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id,
 		       enum tim_oc_mode oc_mode);
 void timer_enable_oc_preload(uint32_t timer_peripheral, enum tim_oc_id oc_id);

--- a/lib/stm32/common/timer_common_all.c
+++ b/lib/stm32/common/timer_common_all.c
@@ -864,6 +864,40 @@ void timer_set_oc1_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode)
 	}
 }
 
+void timer_set_oc2_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode)
+{
+	TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_CC2S_MASK;
+	TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_CC2S_OUT;
+	TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_OC2M_MASK;
+	switch (oc_mode) {
+	case TIM_OCM_FROZEN:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_FROZEN;
+		break;
+	case TIM_OCM_ACTIVE:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_ACTIVE;
+		break;
+	case TIM_OCM_INACTIVE:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_INACTIVE;
+		break;
+	case TIM_OCM_TOGGLE:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_TOGGLE;
+		break;
+	case TIM_OCM_FORCE_LOW:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_FORCE_LOW;
+		break;
+	case TIM_OCM_FORCE_HIGH:
+		TIM_CCMR1(timer_peripheral) |=
+			TIM_CCMR1_OC2M_FORCE_HIGH;
+		break;
+	case TIM_OCM_PWM1:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_PWM1;
+		break;
+	case TIM_OCM_PWM2:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_PWM2;
+		break;
+	}
+}
+
 /*---------------------------------------------------------------------------*/
 /** @brief Timer Set Output Compare Mode
 
@@ -899,36 +933,7 @@ void timer_set_oc_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id,
 		timer_set_oc1_mode(timer_peripheral, oc_mode);
 		break;
 	case TIM_OC2:
-		TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_CC2S_MASK;
-		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_CC2S_OUT;
-		TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_OC2M_MASK;
-		switch (oc_mode) {
-		case TIM_OCM_FROZEN:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_FROZEN;
-			break;
-		case TIM_OCM_ACTIVE:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_ACTIVE;
-			break;
-		case TIM_OCM_INACTIVE:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_INACTIVE;
-			break;
-		case TIM_OCM_TOGGLE:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_TOGGLE;
-			break;
-		case TIM_OCM_FORCE_LOW:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_FORCE_LOW;
-			break;
-		case TIM_OCM_FORCE_HIGH:
-			TIM_CCMR1(timer_peripheral) |=
-			    TIM_CCMR1_OC2M_FORCE_HIGH;
-			break;
-		case TIM_OCM_PWM1:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_PWM1;
-			break;
-		case TIM_OCM_PWM2:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC2M_PWM2;
-			break;
-		}
+		timer_set_oc2_mode(timer_peripheral, oc_mode);
 		break;
 	case TIM_OC3:
 		TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_CC3S_MASK;

--- a/lib/stm32/common/timer_common_all.c
+++ b/lib/stm32/common/timer_common_all.c
@@ -898,6 +898,40 @@ void timer_set_oc2_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode)
 	}
 }
 
+void timer_set_oc3_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode)
+{
+	TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_CC3S_MASK;
+	TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_CC3S_OUT;
+	TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_OC3M_MASK;
+	switch (oc_mode) {
+	case TIM_OCM_FROZEN:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_FROZEN;
+		break;
+	case TIM_OCM_ACTIVE:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_ACTIVE;
+		break;
+	case TIM_OCM_INACTIVE:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_INACTIVE;
+		break;
+	case TIM_OCM_TOGGLE:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_TOGGLE;
+		break;
+	case TIM_OCM_FORCE_LOW:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_FORCE_LOW;
+		break;
+	case TIM_OCM_FORCE_HIGH:
+		TIM_CCMR2(timer_peripheral) |=
+			TIM_CCMR2_OC3M_FORCE_HIGH;
+		break;
+	case TIM_OCM_PWM1:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_PWM1;
+		break;
+	case TIM_OCM_PWM2:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_PWM2;
+		break;
+	}
+}
+
 /*---------------------------------------------------------------------------*/
 /** @brief Timer Set Output Compare Mode
 
@@ -936,36 +970,7 @@ void timer_set_oc_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id,
 		timer_set_oc2_mode(timer_peripheral, oc_mode);
 		break;
 	case TIM_OC3:
-		TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_CC3S_MASK;
-		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_CC3S_OUT;
-		TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_OC3M_MASK;
-		switch (oc_mode) {
-		case TIM_OCM_FROZEN:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_FROZEN;
-			break;
-		case TIM_OCM_ACTIVE:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_ACTIVE;
-			break;
-		case TIM_OCM_INACTIVE:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_INACTIVE;
-			break;
-		case TIM_OCM_TOGGLE:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_TOGGLE;
-			break;
-		case TIM_OCM_FORCE_LOW:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_FORCE_LOW;
-			break;
-		case TIM_OCM_FORCE_HIGH:
-			TIM_CCMR2(timer_peripheral) |=
-			    TIM_CCMR2_OC3M_FORCE_HIGH;
-			break;
-		case TIM_OCM_PWM1:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_PWM1;
-			break;
-		case TIM_OCM_PWM2:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC3M_PWM2;
-			break;
-		}
+		timer_set_oc3_mode(timer_peripheral, oc_mode);
 		break;
 	case TIM_OC4:
 		TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_CC4S_MASK;

--- a/lib/stm32/common/timer_common_all.c
+++ b/lib/stm32/common/timer_common_all.c
@@ -932,6 +932,40 @@ void timer_set_oc3_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode)
 	}
 }
 
+void timer_set_oc4_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode)
+{
+	TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_CC4S_MASK;
+	TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_CC4S_OUT;
+	TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_OC4M_MASK;
+	switch (oc_mode) {
+	case TIM_OCM_FROZEN:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_FROZEN;
+		break;
+	case TIM_OCM_ACTIVE:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_ACTIVE;
+		break;
+	case TIM_OCM_INACTIVE:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_INACTIVE;
+		break;
+	case TIM_OCM_TOGGLE:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_TOGGLE;
+		break;
+	case TIM_OCM_FORCE_LOW:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_FORCE_LOW;
+		break;
+	case TIM_OCM_FORCE_HIGH:
+		TIM_CCMR2(timer_peripheral) |=
+			TIM_CCMR2_OC4M_FORCE_HIGH;
+		break;
+	case TIM_OCM_PWM1:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_PWM1;
+		break;
+	case TIM_OCM_PWM2:
+		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_PWM2;
+		break;
+	}
+}
+
 /*---------------------------------------------------------------------------*/
 /** @brief Timer Set Output Compare Mode
 
@@ -973,36 +1007,7 @@ void timer_set_oc_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id,
 		timer_set_oc3_mode(timer_peripheral, oc_mode);
 		break;
 	case TIM_OC4:
-		TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_CC4S_MASK;
-		TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_CC4S_OUT;
-		TIM_CCMR2(timer_peripheral) &= ~TIM_CCMR2_OC4M_MASK;
-		switch (oc_mode) {
-		case TIM_OCM_FROZEN:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_FROZEN;
-			break;
-		case TIM_OCM_ACTIVE:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_ACTIVE;
-			break;
-		case TIM_OCM_INACTIVE:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_INACTIVE;
-			break;
-		case TIM_OCM_TOGGLE:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_TOGGLE;
-			break;
-		case TIM_OCM_FORCE_LOW:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_FORCE_LOW;
-			break;
-		case TIM_OCM_FORCE_HIGH:
-			TIM_CCMR2(timer_peripheral) |=
-			    TIM_CCMR2_OC4M_FORCE_HIGH;
-			break;
-		case TIM_OCM_PWM1:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_PWM1;
-			break;
-		case TIM_OCM_PWM2:
-			TIM_CCMR2(timer_peripheral) |= TIM_CCMR2_OC4M_PWM2;
-			break;
-		}
+		timer_set_oc4_mode(timer_peripheral, oc_mode);
 		break;
 	case TIM_OC1N:
 	case TIM_OC2N:
@@ -1899,4 +1904,3 @@ void timer_slave_set_extclockmode2(uint32_t timer_peripheral,
 /* TODO Timer DMA burst */
 
 /**@}*/
-

--- a/lib/stm32/common/timer_common_all.c
+++ b/lib/stm32/common/timer_common_all.c
@@ -830,6 +830,40 @@ void timer_set_oc_slow_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id)
 	}
 }
 
+void timer_set_oc1_mode(uint32_t timer_peripheral, enum tim_oc_mode oc_mode)
+{
+	TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_CC1S_MASK;
+	TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_CC1S_OUT;
+	TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_OC1M_MASK;
+	switch (oc_mode) {
+	case TIM_OCM_FROZEN:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_FROZEN;
+		break;
+	case TIM_OCM_ACTIVE:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_ACTIVE;
+		break;
+	case TIM_OCM_INACTIVE:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_INACTIVE;
+		break;
+	case TIM_OCM_TOGGLE:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_TOGGLE;
+		break;
+	case TIM_OCM_FORCE_LOW:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_FORCE_LOW;
+		break;
+	case TIM_OCM_FORCE_HIGH:
+		TIM_CCMR1(timer_peripheral) |=
+			TIM_CCMR1_OC1M_FORCE_HIGH;
+		break;
+	case TIM_OCM_PWM1:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_PWM1;
+		break;
+	case TIM_OCM_PWM2:
+		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_PWM2;
+		break;
+	}
+}
+
 /*---------------------------------------------------------------------------*/
 /** @brief Timer Set Output Compare Mode
 
@@ -862,36 +896,7 @@ void timer_set_oc_mode(uint32_t timer_peripheral, enum tim_oc_id oc_id,
 {
 	switch (oc_id) {
 	case TIM_OC1:
-		TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_CC1S_MASK;
-		TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_CC1S_OUT;
-		TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_OC1M_MASK;
-		switch (oc_mode) {
-		case TIM_OCM_FROZEN:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_FROZEN;
-			break;
-		case TIM_OCM_ACTIVE:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_ACTIVE;
-			break;
-		case TIM_OCM_INACTIVE:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_INACTIVE;
-			break;
-		case TIM_OCM_TOGGLE:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_TOGGLE;
-			break;
-		case TIM_OCM_FORCE_LOW:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_FORCE_LOW;
-			break;
-		case TIM_OCM_FORCE_HIGH:
-			TIM_CCMR1(timer_peripheral) |=
-			    TIM_CCMR1_OC1M_FORCE_HIGH;
-			break;
-		case TIM_OCM_PWM1:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_PWM1;
-			break;
-		case TIM_OCM_PWM2:
-			TIM_CCMR1(timer_peripheral) |= TIM_CCMR1_OC1M_PWM2;
-			break;
-		}
+		timer_set_oc1_mode(timer_peripheral, oc_mode);
 		break;
 	case TIM_OC2:
 		TIM_CCMR1(timer_peripheral) &= ~TIM_CCMR1_CC2S_MASK;


### PR DESCRIPTION
When implementing a new feature in Black Magic Debug to soft-start the target power output, we wound up having too interact with the timers and set up the output compare block mode for a channel. This pulls in an extra ~400 bytes of code due to the complex unoptimisable nature of the switch-case-in-switch-case setup of the STM32 `timer_set_oc_mode()` function.

This PR addresses some of this by splitting out the case logic of the outer switch-case into per-channel functions (still exposed by this unified mode set function), saving around 332 bytes when only a single channel is used. It otherwise maintains the exact same logic and call structure for existing code.