### PR TITLE
Update Makefile fix issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ Q := @
 MAKEFLAGS += --no-print-directory
 endif
 
+# Define the make command
+MAKE := make
+
 # Avoid the use of shell find, for windows compatibility
 IRQ_DEFN_FILES  := $(foreach TARGET,$(TARGETS),$(wildcard include/libopencm3/$(TARGET)/irq.json))
 NVIC_H := $(IRQ_DEFN_FILES:%/irq.json=%/nvic.h)


### PR DESCRIPTION
# Fixed issue from Stack Overflow

https://stackoverflow.com/questions/36365752/make-error-127-when-running-trying-to-compile-code

## Issue description

The command `make` runs into an error (shown in the image below) were the compilation of the `libopencm3/` directory fails to build several files
![image](https://github.com/libopencm3/libopencm3/assets/47105148/c341de36-99d9-40ba-a3df-83bb5930f124)

It looks like in the makefile at `libopencm3/makefile` is missing the variable where the default compiler should be defined, since this variable (`MAKE`) is used in the rest of the code, the execution of `make` command fails because (_in the makefile_) the `MAKE` variable is evaluated as _undefined_. This explains why we face the **error code 127**, because there is no command installed known as `undefined`

## Solution

The solution is simple, just add the missing variable in the makefile so the `MAKE` variable is evaluated as it should be (_the make command_)

```
MAKE := make
```

> This solition worked for me since I encounterd the same issue as the stack overflow question