### PR TITLE
stm32f1: rcc: fix inline doc of rcc_system_clock_source()

### DIFF
--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -720,9 +720,9 @@ void rcc_set_prediv1_source(uint32_t rccsrc)
 /** @brief RCC Get the System Clock Source.
 
 @returns Unsigned int32. System clock source:
-@li 00 indicates HSE
-@li 01 indicates LSE
-@li 02 indicates PLL
+@li 00 indicates HSI (see @ref RCC_CFGR_SWS_SYSCLKSEL_HSICLK)
+@li 01 indicates HSE (see @ref RCC_CFGR_SWS_SYSCLKSEL_HSECLK)
+@li 02 indicates PLL (see @ref RCC_CFGR_SWS_SYSCLKSEL_PLLCLK)
 */
 
 uint32_t rcc_system_clock_source(void)


### PR DESCRIPTION
The documented return values were previously wrong. Make them consistent with the ST Reference Manual (7.3.2 Clock configuration register) and add references to the RCC_CFGR_SWS_SYSCLKSEL_* constants.