### PR TITLE
lib:lmXX:Makefile: Remove the redundant object file declaration

### DIFF
--- a/lib/lm3s/Makefile
+++ b/lib/lm3s/Makefile
@@ -34,11 +34,9 @@ TGT_CFLAGS	+= $(STANDARD_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
 
-OBJS += assert.o
 OBJS += gpio.o
 OBJS += rcc.o
 OBJS += usart.o
-OBJS += vector.o
 
 VPATH += ../cm3
 

--- a/lib/lm4f/Makefile
+++ b/lib/lm4f/Makefile
@@ -36,12 +36,10 @@ TGT_CFLAGS	+= $(STANDARD_FLAGS)
 # ARFLAGS	= rcsv
 ARFLAGS		= rcs
 
-OBJS += assert.o
 OBJS += gpio.o
 OBJS += rcc.o
 OBJS += systemcontrol.o
 OBJS += uart.o
-OBJS += vector.o
 
 OBJS += usb.o usb_control.o usb_standard.o usb_msc.o
 OBJS += usb_hid.o


### PR DESCRIPTION
Objects 'assert.o' and 'vector.o' are already being added in
'Makefile.include'. So we can remove redundant declaration.

Without this commits, the commands:
```bash
ar t lib/libopencm3_lm3s.a
ar t lib/libopencm3_lm4f.a
```
will show the presence of two object files 'assert.o' and two
object files 'vector.o' in the static library.