### PR TITLE
stm32g4: add IWDG support

### DIFF
--- a/include/libopencm3/stm32/g4/iwdg.h
+++ b/include/libopencm3/stm32/g4/iwdg.h
@@ -1,0 +1,33 @@
+/** @defgroup iwdg_defines IWDG Defines
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G4xx Independent Watchdog Timer</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_IWDG_H
+#define LIBOPENCM3_IWDG_H
+
+#include <libopencm3/stm32/common/iwdg_common_v2.h>
+
+#endif

--- a/include/libopencm3/stm32/iwdg.h
+++ b/include/libopencm3/stm32/iwdg.h
@@ -40,6 +40,8 @@
 #       include <libopencm3/stm32/l4/iwdg.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/iwdg.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/iwdg.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/lib/stm32/g4/Makefile
+++ b/lib/stm32/g4/Makefile
@@ -47,6 +47,7 @@ OBJS += fdcan.o fdcan_common.o
 OBJS += flash.o flash_common_all.o flash_common_f.o flash_common_idcache.o
 OBJS += gpio_common_all.o gpio_common_f0234.o
 OBJS += i2c_common_v2.o
+OBJS += iwdg_common_all.o
 OBJS += opamp_common_all.o opamp_common_v2.o
 OBJS += pwr.o
 OBJS += rcc.o rcc_common_all.o


### PR DESCRIPTION
Add missing IWDG support to the G4 family. It's 100% identical to the G0 according to the RM.