### PR TITLE
stm32g4: fix ST_TSENSE_CAL2_110C -> ST_TSENSE_CAL2_130C

### DIFF
--- a/include/libopencm3/stm32/g4/memorymap.h
+++ b/include/libopencm3/stm32/g4/memorymap.h
@@ -135,6 +135,6 @@
 /* ST provided factory calibration values @ 3.0V */
 #define ST_VREFINT_CAL			MMIO16((INFO_BASE + 0x75aa))
 #define ST_TSENSE_CAL1_30C		MMIO16((INFO_BASE + 0x75a8))
-#define ST_TSENSE_CAL2_110C		MMIO16((INFO_BASE + 0x75ca))
+#define ST_TSENSE_CAL2_130C		MMIO16((INFO_BASE + 0x75ca))
 
 #endif


### PR DESCRIPTION
<img width="569" alt="image" src="https://github.com/libopencm3/libopencm3/assets/958340/2e9cd747-6ba8-4e6b-89ca-ef5c236db737">
