### PR TITLE
stm32g4: fix NVIC "tim1_trg_tim17" -> "tim1_trg_com_tim17"

### DIFF
--- a/include/libopencm3/stm32/g4/irq.json
+++ b/include/libopencm3/stm32/g4/irq.json
@@ -26,7 +26,7 @@
         "exti9_5",
         "tim1_brk_tim15",
         "tim1_up_tim16",
-        "tim1_trg_tim17",
+        "tim1_trg_com_tim17",
         "tim1_cc",
         "tim2",
         "tim3",


### PR DESCRIPTION
<img width="675" alt="image" src="https://github.com/libopencm3/libopencm3/assets/958340/138e63cf-b6f9-42fc-9195-d6a4f1b527dd">
