### PR TITLE
Correction of the adc_set_injected_sequence() STM32 G4 function

### DIFF
--- a/include/libopencm3/stm32/g4/adc.h
+++ b/include/libopencm3/stm32/g4/adc.h
@@ -228,7 +228,7 @@
 #define ADC_JSQR_JSQ2_LSB		15
 #define ADC_JSQR_JSQ1_LSB		9
 
-#define ADC_JSQR_JSQ_VAL(n, val)	((val) << (((n) - 1) * 6 + 8))
+#define ADC_JSQR_JSQ_VAL(n, val)	((val) << (((n) - 1) * 6 + 9))
 #define ADC_JSQR_JL_VAL(val)		(((val) - 1) << ADC_JSQR_JL_SHIFT)
 
 /* Bits 31:27 JSQ4[4:0]: 4th conversion in the injected sequence */

--- a/include/libopencm3/stm32/g4/adc.h
+++ b/include/libopencm3/stm32/g4/adc.h
@@ -221,6 +221,7 @@
 
 /*------- ADC_JSQR values ---------*/
 
+#define ADC_JSQR_JL_MASK	(0x3 << 0)
 #define ADC_JSQR_JL_LSB			0
 #define ADC_JSQR_JL_SHIFT		0
 #define ADC_JSQR_JSQ4_LSB		27

--- a/lib/stm32/g4/adc.c
+++ b/lib/stm32/g4/adc.c
@@ -406,8 +406,9 @@ void adc_set_watchdog_low_threshold(uint32_t adc, uint16_t threshold)
 
 void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[])
 {
-	uint32_t reg32 = 0;
+	uint32_t reg32;
 	uint8_t i = 0;
+	reg32 = (ADC_JSQR_JEXTEN_MASK | ADC_JSQR_JEXTSEL_MASK | ADC_JSQR_JL_MASK) & ADC_JSQR(adc);
 
 	/* Maximum sequence length is 4 channels. Minimum sequence is 1.*/
 	if ((length - 1) > 3) {


### PR DESCRIPTION
It does not correctly configure the injected channels, and removes the configurations previously made in the ADC_JSQR reg, follow the corrections.