### PR TITLE
Adds functions to enter all of the L4 power modes

### DIFF
--- a/include/libopencm3/cm3/scb.h
+++ b/include/libopencm3/cm3/scb.h
@@ -554,6 +554,10 @@ struct scb_exception_stack_frame {
 	} while (0)
 
 void scb_reset_system(void) __attribute__((noreturn));
+void scb_set_sleepdeep(void);
+void scb_clear_sleepdeep(void);
+void scb_set_sleeponexit(void);
+void scb_clear_sleeponexit(void);
 
 /* Those defined only on ARMv7 and above */
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)

--- a/include/libopencm3/stm32/l4/pwr.h
+++ b/include/libopencm3/stm32/l4/pwr.h
@@ -77,11 +77,15 @@ specific memorymap.h header before including this header file.*/
 
 #define PWR_CR1_LPMS_SHIFT		0
 #define PWR_CR1_LPMS_MASK		0x07
+/** @defgroup pwr_cr1_lpms LPMS mode selection
+ * @ingroup STM32L4_pwr_defines
+ @{*/
 #define PWR_CR1_LPMS_STOP_0		0
 #define PWR_CR1_LPMS_STOP_1		1
 #define PWR_CR1_LPMS_STOP_2		2
 #define PWR_CR1_LPMS_STANDBY		3
 #define PWR_CR1_LPMS_SHUTDOWN		4
+/**@}*/
 
 /* --- PWR_CR2 values ------------------------------------------------------- */
 
@@ -172,6 +176,10 @@ BEGIN_DECLS
 void pwr_set_vos_scale(enum pwr_vos_scale scale);
 void pwr_disable_backup_domain_write_protect(void);
 void pwr_enable_backup_domain_write_protect(void);
+
+void pwr_enable_low_power_run(void);
+void pwr_disable_low_power_run(void);
+void pwr_set_low_power_mode_selection(uint32_t lpms);
 
 END_DECLS
 

--- a/lib/cm3/scb.c
+++ b/lib/cm3/scb.c
@@ -58,6 +58,26 @@ void scb_reset_system(void)
 	while (1);
 }
 
+void scb_set_sleepdeep(void)
+{
+	SCB_SCR |= SCB_SCR_SLEEPDEEP;
+}
+
+void scb_clear_sleepdeep(void)
+{
+	SCB_SCR &= ~SCB_SCR_SLEEPDEEP;
+}
+
+void scb_set_sleeponexit(void)
+{
+	SCB_SCR |= SCB_SCR_SLEEPONEXIT;
+}
+
+void scb_clear_sleeponexit(void)
+{
+	SCB_SCR &= ~SCB_SCR_SLEEPONEXIT;
+}
+
 /* Those are defined only on CM3 or CM4 */
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
 void scb_set_priority_grouping(uint32_t prigroup)

--- a/lib/stm32/l4/pwr.c
+++ b/lib/stm32/l4/pwr.c
@@ -72,4 +72,38 @@ void pwr_enable_backup_domain_write_protect(void)
 	PWR_CR1 &= ~PWR_CR1_DBP;
 }
 
+/** Enable Low Power Run
+ * 
+ * This enables low power run mode. The clock frequency is limited to 2 MHz in this mode 
+ * and must be set before entering low power run mode.
+ */
+void pwr_enable_low_power_run(void)
+{
+	PWR_CR1 |= PWR_CR1_LPR;
+}
+
+/** Disable Low Power Run
+ * 
+ * This disables low power run mode
+ */
+void pwr_disable_low_power_run(void)
+{
+	PWR_CR1 &= ~PWR_CR1_LPR;
+}
+
+/** @brief Select the low power mode used in deep sleep.
+ * 
+ * Set which power mode is entered when the processor enters deep sleep.
+ * 
+ * @param[in] lpms low power mode @ref pwr_cr1_lpms
+ */
+void pwr_set_low_power_mode_selection(uint32_t lpms)
+{
+	uint32_t reg32;
+
+	reg32 = PWR_CR1;
+	reg32 &= ~(PWR_CR1_LPMS_MASK << PWR_CR1_LPMS_SHIFT);
+	PWR_CR1 = (reg32 | (lpms << PWR_CR1_LPMS_SHIFT));
+}
+
 /**@}*/


### PR DESCRIPTION
Added the following 7 functions which can be used to enter all of the power modes available on the L4. 
- `scb_set_deepsleep(void)`
  - sets the deepsleep bit in the m3 registers. This bit controls whether or not the cpu enter sleep mode or one of the deeper sleeps
- `scb_clear_deepsleep(void)`
  - clears the deepsleep bit
- `scb_set_sleeponexit(void)`
  - sets the sleeponexit bit in the appropriate register. Setting this bit will make the cpu enter into a low power mode when exiting an interrupt
- `scb_clear_sleeponexit(void)`
  - clears the sleeponexit bit
- `pwr_set_low_power_run(void)`
  - sets the low-power run bit. This bit controls whether the L4 will enters into low-power run or low-power sleep
- `pwr_clear_low_power_run(void)`
  - clears the low-power run bit
- `pwr_set_low_power_mode_selection(lpms)`
  - Sets the lpms bits in the pwr_cr1 register. Setting these bits is how the cpu reaches the stop modes and standby and shutdown modes. This function uses existing defines in pwr.h as parameters to enter stop modes and standby and shutdown modes