### PR TITLE
Add support for overdrive for STM32F4

### DIFF
--- a/include/libopencm3/stm32/f4/pwr.h
+++ b/include/libopencm3/stm32/f4/pwr.h
@@ -45,6 +45,23 @@ LGPL License Terms @ref lgpl_license
 
 /* --- PWR_CR values ------------------------------------------------------- */
 
+/** UDEN[19:18]: Under-drive enable in stop mode */
+#define PWR_CR_UDEN_LSB			18
+/** @defgroup pwr_uden Under-drive enable in stop mode
+@ingroup STM32F_pwr_defines
+
+@{*/
+#define PWR_CR_UDEN_DISABLED		(0x0 << PWR_CR1_UDEN_LSB)
+#define PWR_CR_UDEN_ENABLED		(0x3 << PWR_CR1_UDEN_LSB)
+/**@}*/
+#define PWR_CR_UDEN_MASK		(0x3 << PWR_CR1_UDEN_LSB)
+
+/** ODSWEN: Over-drive switching enabled */
+#define PWR_CR_ODSWEN			(1 << 17)
+
+/** ODEN: Over-drive enable */
+#define PWR_CR_ODEN			(1 << 16)
+
 /** VOS: Regulator voltage scaling output selection */
 #define PWR_CR_VOS_SHIFT			14
 #define PWR_CR_VOS_MASK			0x3
@@ -64,6 +81,12 @@ LGPL License Terms @ref lgpl_license
 #define PWR_CR_FPDS			(1 << 9)
 
 /* --- PWR_CSR values ------------------------------------------------------ */
+
+/** ODSWRDY: Over-drive mode switching ready */
+#define PWR_CSR_ODSWRDY			(1 << 17)
+
+/** ODRDY: Over-drive mode ready */
+#define PWR_CSR_ODRDY			(1 << 16)
 
 /** VOSRDY: Regulator voltage scaling output selection ready bit */
 #define PWR_CSR_VOSRDY			(1 << 14)
@@ -85,6 +108,8 @@ enum pwr_vos_scale {
 BEGIN_DECLS
 
 void pwr_set_vos_scale(enum pwr_vos_scale scale);
+void pwr_enable_overdrive(void);
+void pwr_disable_overdrive(void);
 
 END_DECLS
 

--- a/include/libopencm3/stm32/f4/rcc.h
+++ b/include/libopencm3/stm32/f4/rcc.h
@@ -1130,6 +1130,7 @@ void rcc_set_main_pll_hse(uint32_t pllm, uint32_t plln, uint32_t pllp,
 			  uint32_t pllq, uint32_t pllr);
 uint32_t rcc_system_clock_source(void);
 void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
+void rcc_clock_setup_pll_x(const struct rcc_clock_scale *clock, int overdrive);
 void __attribute__((deprecated("Use rcc_clock_setup_pll as direct replacement"))) rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock);
 uint32_t rcc_get_usart_clk_freq(uint32_t usart);
 uint32_t rcc_get_timer_clk_freq(uint32_t timer);

--- a/lib/stm32/f4/pwr.c
+++ b/lib/stm32/f4/pwr.c
@@ -46,4 +46,18 @@ void pwr_set_vos_scale(enum pwr_vos_scale scale)
 	PWR_CR = reg32;
 }
 
+void pwr_enable_overdrive(void)
+{
+	PWR_CR |= PWR_CR_ODEN;
+	while (!(PWR_CSR & PWR_CSR_ODRDY));
+	PWR_CR |= PWR_CR_ODSWEN;
+	while (!(PWR_CSR & PWR_CSR_ODSWRDY));
+}
+
+void pwr_disable_overdrive(void)
+{
+	PWR_CR &= ~(PWR_CR_ODEN | PWR_CR_ODSWEN);
+	while (!(PWR_CSR & PWR_CSR_ODSWRDY));
+}
+
 /**@}*/

--- a/lib/stm32/f4/rcc.c
+++ b/lib/stm32/f4/rcc.c
@@ -785,8 +785,9 @@ uint32_t rcc_system_clock_source(void)
  * needed to establish a system clock.
  *
  * @param clock clock information structure.
+ * @param overdrive boolean to request OverDrive.
  */
-void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
+void rcc_clock_setup_pll_x(const struct rcc_clock_scale *clock, int overdrive)
 {
 	/* Enable internal high-speed oscillator (HSI). */
 	rcc_osc_on(RCC_HSI);
@@ -804,6 +805,11 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 	/* Set the VOS scale mode */
 	rcc_periph_clock_enable(RCC_PWR);
 	pwr_set_vos_scale(clock->voltage_scale);
+
+	/* Enable overDrive if requested */
+	if (overdrive) {
+		pwr_enable_overdrive();
+	}
 
 	/*
 	 * Set prescalers for AHB, ADC, APB1, APB2.
@@ -857,6 +863,19 @@ void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
 	if (clock->pll_source == RCC_CFGR_PLLSRC_HSE_CLK) {
 		rcc_osc_off(RCC_HSI);
 	}
+}
+
+/**
+ * Setup clocks to run from PLL.
+ *
+ * The arguments provide the pll source, multipliers, dividers, all that's
+ * needed to establish a system clock. OverDrive cannot be enabled.
+ *
+ * @param clock clock information structure.
+ */
+void rcc_clock_setup_pll(const struct rcc_clock_scale *clock)
+{
+	rcc_clock_setup_pll_x(clock, 0);
 }
 
 /**


### PR DESCRIPTION
Some STM32F4 boards such as stm32f446re are able to enable overdrive.

I added the constants and functions (mainly copying from the stm32f5 corresponding files).
As overdrive should generally be set while setting clocks, I renamed `rcc_clock_setup_pll` into `rcc_clock_setup_pll_x`
so that I can add a boolean parameter (to enable overdrive or not)
and I provided a `rcc_clock_setup_pll` function for backward compatibility.
Indeed, calling `pwr_enable_overdrive` before or after the previous `rcc_clock_setup_pll`  does not work.

I'm sure the design can be improved but, being new to libopencm3, I just share this code. If you tell me which design should be used, I can rewrite this patch.

Regards,
  Vincent