### PR TITLE
stm32g4: exti: add exti support

### DIFF
--- a/include/libopencm3/stm32/common/spi_common_all.h
+++ b/include/libopencm3/stm32/common/spi_common_all.h
@@ -71,6 +71,7 @@ specific memorymap.h header before including this header file.*/
 #define SPI1_SR				SPI_SR(SPI1_BASE)
 #define SPI2_SR				SPI_SR(SPI2_BASE)
 #define SPI3_SR				SPI_SR(SPI3_BASE)
+#define SPI4_SR				SPI_SR(SPI4_BASE)
 
 /* Data register (SPIx_DR) */
 #define SPI_DR(spi_base)		MMIO32((spi_base) + 0x0c)

--- a/include/libopencm3/stm32/common/spi_common_all.h
+++ b/include/libopencm3/stm32/common/spi_common_all.h
@@ -78,6 +78,7 @@ specific memorymap.h header before including this header file.*/
 #define SPI1_DR				SPI_DR(SPI1_BASE)
 #define SPI2_DR				SPI_DR(SPI2_BASE)
 #define SPI3_DR				SPI_DR(SPI3_BASE)
+#define SPI4_DR				SPI_DR(SPI4_BASE)
 
 /* CRC polynomial register (SPIx_CRCPR) */
 /* Note: Not used in I2S mode. */

--- a/include/libopencm3/stm32/common/spi_common_v2.h
+++ b/include/libopencm3/stm32/common/spi_common_v2.h
@@ -98,11 +98,15 @@ specific memorymap.h header before including this header file.*/
 #define SPI_SR_FTLVL_HALF_FIFO		(0x2 << 11)
 #define SPI_SR_FTLVL_FIFO_FULL		(0x3 << 11)
 
+#define SPI_SR_FTLVL_MASK		(0x3 << 11)
+
 /* FRLVL[1:0]: FIFO Reception Level */
 #define SPI_SR_FRLVL_FIFO_EMPTY		(0x0 << 9)
 #define SPI_SR_FRLVL_QUARTER_FIFO	(0x1 << 9)
 #define SPI_SR_FRLVL_HALF_FIFO		(0x2 << 9)
 #define SPI_SR_FRLVL_FIFO_FULL		(0x3 << 9)
+
+#define SPI_SR_FRLVL_MASK		(0x3 << 9)
 
 /* FRE : TI frame format error */
 #define SPI_SR_FRE			(1 << 8)

--- a/include/libopencm3/stm32/exti.h
+++ b/include/libopencm3/stm32/exti.h
@@ -40,8 +40,10 @@
 #       include <libopencm3/stm32/l1/exti.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/exti.h>
-#elif defined(STM32G0) || defined(STM32G4) // NOTE: The G4 did not have an implementation for the EXTI, but the one from the G0 also works. ( checked on a STM32G491 )
+#elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/exti.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/exti.h>
 #elif defined(STM32H7)
 #       include <libopencm3/stm32/h7/exti.h>
 #else

--- a/include/libopencm3/stm32/exti.h
+++ b/include/libopencm3/stm32/exti.h
@@ -40,11 +40,10 @@
 #       include <libopencm3/stm32/l1/exti.h>
 #elif defined(STM32L4)
 #       include <libopencm3/stm32/l4/exti.h>
-#elif defined(STM32G0)
+#elif defined(STM32G0) || defined(STM32G4) // NOTE: The G4 did not have an implementation for the EXTI, but the one from the G0 also works. ( checked on a STM32G491 )
 #       include <libopencm3/stm32/g0/exti.h>
 #elif defined(STM32H7)
 #       include <libopencm3/stm32/h7/exti.h>
 #else
 #       error "stm32 family not defined."
 #endif
-

--- a/include/libopencm3/stm32/g4/exti.h
+++ b/include/libopencm3/stm32/g4/exti.h
@@ -1,0 +1,57 @@
+/** @defgroup exti_defines EXTI Defines
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G4xx EXTI Control</b>
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ *  */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+#ifndef LIBOPENCM3_EXTI_H
+#define LIBOPENCM3_EXTI_H
+
+#include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v2.h>
+
+/** EXTI External Interrupt Selection Registers */
+#define EXTI_EXTICR(i)    MMIO32(EXTI_BASE + 0x60 + (i)*4)
+#define EXTI_EXTICR1    MMIO32(EXTI_BASE + 0x60)
+#define EXTI_EXTICR2    MMIO32(EXTI_BASE + 0x64)
+#define EXTI_EXTICR3    MMIO32(EXTI_BASE + 0x68)
+#define EXTI_EXTICR4    MMIO32(EXTI_BASE + 0x6c)
+
+/** EXTI Rising Edge Pending Register */
+#define EXTI_RPR1     MMIO32(EXTI_BASE + 0x0c)
+/** EXTI Falling Edge Pending Register */
+#define EXTI_FPR1     MMIO32(EXTI_BASE + 0x10)
+
+BEGIN_DECLS
+
+END_DECLS
+
+#else
+/** @cond */
+#warning "exti_common_v1.h should not be included directly, only via exti.h"
+#endif
+/** @endcond */
+
+/**@}*/

--- a/include/libopencm3/stm32/g4/exti.h
+++ b/include/libopencm3/stm32/g4/exti.h
@@ -25,33 +25,10 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**@{*/
 #ifndef LIBOPENCM3_EXTI_H
 #define LIBOPENCM3_EXTI_H
 
 #include <libopencm3/stm32/common/exti_common_all.h>
-#include <libopencm3/stm32/common/exti_common_v2.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
 
-/** EXTI External Interrupt Selection Registers */
-#define EXTI_EXTICR(i)    MMIO32(EXTI_BASE + 0x60 + (i)*4)
-#define EXTI_EXTICR1    MMIO32(EXTI_BASE + 0x60)
-#define EXTI_EXTICR2    MMIO32(EXTI_BASE + 0x64)
-#define EXTI_EXTICR3    MMIO32(EXTI_BASE + 0x68)
-#define EXTI_EXTICR4    MMIO32(EXTI_BASE + 0x6c)
-
-/** EXTI Rising Edge Pending Register */
-#define EXTI_RPR1     MMIO32(EXTI_BASE + 0x0c)
-/** EXTI Falling Edge Pending Register */
-#define EXTI_FPR1     MMIO32(EXTI_BASE + 0x10)
-
-BEGIN_DECLS
-
-END_DECLS
-
-#else
-/** @cond */
-#warning "exti_common_v1.h should not be included directly, only via exti.h"
 #endif
-/** @endcond */
-
-/**@}*/

--- a/lib/stm32/g4/Makefile
+++ b/lib/stm32/g4/Makefile
@@ -39,6 +39,7 @@ OBJS += adc.o adc_common_v2.o adc_common_v2_multi.o
 OBJS += cordic_common_v1.o
 OBJS += crs_common_all.o
 OBJS += crc_common_all.o crc_v2.o
+OBJS += exti_common_all.o
 OBJS += dac_common_all.o dac_common_v2.o
 OBJS += desig_common_all.o desig_common_v1.o
 OBJS += dma_common_l1f013.o


### PR DESCRIPTION
Continuing #1550.

exti common is compatible with stm32g4. It also use exti v1 not v2 api.