### PR TITLE
stm32l0: rcc: fix incorrect bit shift in rcc_set_lpuart1_sel()

### DIFF
--- a/lib/stm32/l0/rcc.c
+++ b/lib/stm32/l0/rcc.c
@@ -420,8 +420,8 @@ void rcc_set_lptim1_sel(uint32_t lptim1_sel)
  */
 void rcc_set_lpuart1_sel(uint32_t lpuart1_sel)
 {
-	RCC_CCIPR &= ~(RCC_CCIPR_LPUARTxSEL_MASK << RCC_CCIPR_LPTIM1SEL_SHIFT);
-	RCC_CCIPR |= (lpuart1_sel << RCC_CCIPR_LPTIM1SEL_SHIFT);
+	RCC_CCIPR &= ~(RCC_CCIPR_LPUARTxSEL_MASK << RCC_CCIPR_LPUART1SEL_SHIFT);
+	RCC_CCIPR |= (lpuart1_sel << RCC_CCIPR_LPUART1SEL_SHIFT);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The function `rcc_set_lpuart1_sel()` was incorrectly using `RCC_CCIPR_LPTIM1SEL_SHIFT` instead of `RCC_CCIPR_LPUART1SEL_SHIFT`, causing incorrect LPUART1 clock source selection.

This patch corrects the bit shift to ensure the LPUART1SEL field is properly updated.

To verify check [RM0377 Reference manual section 7.3.19](https://www.st.com/resource/en/reference_manual/rm0377-ultralowpower-stm32l0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf).