### PR TITLE
Add LPUART1 definition to usart.h for stm32g4x

### DIFF
--- a/include/libopencm3/stm32/g4/usart.h
+++ b/include/libopencm3/stm32/g4/usart.h
@@ -31,6 +31,7 @@
 
 #include <libopencm3/stm32/common/usart_common_all.h>
 #include <libopencm3/stm32/common/usart_common_v2.h>
+#include <libopencm3/stm32/common/usart_common_fifos.h>
 
 /**@{*/
 

--- a/lib/stm32/g4/Makefile
+++ b/lib/stm32/g4/Makefile
@@ -55,7 +55,7 @@ OBJS += rng_common_v1.o
 OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o timer_common_f0234.o
 OBJS += quadspi_common_v1.o
-OBJS += usart_common_v2.o usart_common_all.o
+OBJS += usart_common_v2.o usart_common_all.o usart_common_fifos.o
 
 OBJS += usb.o usb_control.o usb_standard.o
 OBJS += usb_audio.o


### PR DESCRIPTION
Add LPUART1 definition for the STM32G4xx LPUART as per the L4 family.
Without the LPUART1 definition, usart_set_baudrate will calculate BRR incorrectly and the UART will not work due to an ifdef. Tested working @ 115200 on a NUCLEO-G474RE.