### PR TITLE
iwdg: START and UNLOCK values before polling Busy

### DIFF
--- a/lib/stm32/common/iwdg_common_all.c
+++ b/lib/stm32/common/iwdg_common_all.c
@@ -102,11 +102,11 @@ void iwdg_set_period_ms(uint32_t period)
 		prescale = PRESCALER_MAX;
 	}
 
-	while (iwdg_prescaler_busy());
+	IWDG_KR = IWDG_KR_START;
 	IWDG_KR = IWDG_KR_UNLOCK;
+	while (iwdg_prescaler_busy());
 	IWDG_PR = prescale;
 	while (iwdg_reload_busy());
-	IWDG_KR = IWDG_KR_UNLOCK;
 	IWDG_RLR = count & COUNT_MASK;
 	
 	/* Refresh counter after configuration is complete */


### PR DESCRIPTION
With code that uses IWDG and these operations:

- user code initializes iwdg
- user code jumps to USB-DFU
- USB host triggers a USB exit (e.g. after reflashing, or even just a `dfu-util -R -s 0x8000000:leave ....` command)
- user code will hang in `iwdg_prescaler_busy()` called from `iwdg_set_period_ms()`

F070 Datasheet excerpts : 
```
/* (1) Activate IWDG (not needed if done in option bytes) */
/* (2) Enable write access to IWDG registers */
/* (3) Set prescaler by 8 */
/* (4) Set reload value to have a rollover each 100ms */
/* (5) Check if flags are reset */
/* (6) Refresh counter */
IWDG->KR = IWDG_START; /* (1) */
IWDG->KR = IWDG_WRITE_ACCESS; /* (2) */
IWDG->PR = IWDG_PR_PR_0; /* (3) */
IWDG->RLR = IWDG_RELOAD; /* (4) */
while (IWDG->SR) /* (5) */
{
	/* add time out here for a robust application */
}
IWDG->KR = IWDG_REFRESH; /* (6) */
```

with this patch, "worksforme".

I'm not sure polling for those Busy bits is even necessary in this function since we reset the iwdg anyway.