### PR TITLE
Add LPUART support for STM32G4 and fix baud rate calculation selector 

### DIFF
--- a/include/libopencm3/stm32/g4/usart.h
+++ b/include/libopencm3/stm32/g4/usart.h
@@ -43,6 +43,7 @@
 #define USART3				USART3_BASE
 #define UART4				UART4_BASE
 #define UART5				UART5_BASE
+#define LPUART1             LPUART1_BASE
 /**@}*/
 
 BEGIN_DECLS

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -63,8 +63,8 @@ void usart_set_baudrate(uint32_t usart, uint32_t baud)
 	 * Note: We round() the value rather than floor()ing it, for more
 	 * accurate divisor selection.
 	 */
-#ifdef LPUART1
-	if (usart == LPUART1) {
+#ifdef LPUART1_BASE
+	if (usart == LPUART1_BASE) {
 		USART_BRR(usart) = (clock / baud) * 256
 			+ ((clock % baud) * 256 + baud / 2) / baud;
 		return;


### PR DESCRIPTION
Added support for LPUART1  for STM32G4, and modified usart_common_all.c to fix the preprocessor baud rate selection. LPUART1 is defined after the check for LPUART1 in usart_set_baudrate() resulting in incorrect baud rate calculation for LPUART peripherals.

Using LPUART1_BASE instead resolves this