### PR TITLE
Correct shebang lines to get python3

### DIFF
--- a/scripts/data/lpc43xx/csv2yaml.py
+++ b/scripts/data/lpc43xx/csv2yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 import yaml

--- a/scripts/data/lpc43xx/gen.py
+++ b/scripts/data/lpc43xx/gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 import yaml

--- a/scripts/lpcvtcksum
+++ b/scripts/lpcvtcksum
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Compute and insert the vector table checksum required for booting the
 # LPC43xx and some other NXP ARM microcontrollers.


### PR DESCRIPTION
Change shebang line to use python3 instead of previous versions of python