### PR TITLE
Feature: Meson build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ include/libopencmsis/stm32/
 include/libopencmsis/swm050/
 include/libopencmsis/vf6xx/
 
+# default Meson build directory
+/build/
+
 # Editor/IDE config files
 nbproject/
 .idea/

--- a/cross-files/arm-none-eabi.ini
+++ b/cross-files/arm-none-eabi.ini
@@ -1,0 +1,21 @@
+[constants]
+# Allow easy overridding of the default path and prefix
+gcc_path = ''
+gcc_prefix = 'arm-none-eabi-'
+gcc_base = gcc_path / gcc_prefix
+
+[binaries]
+c = gcc_base + 'gcc'
+ld = gcc_base + 'gcc'
+ar = gcc_base + 'ar'
+nm = gcc_base + 'nm'
+strip = gcc_base + 'strip'
+objcopy = gcc_base + 'objcopy'
+objdump = gcc_base + 'objdump'
+size = gcc_base + 'size'
+
+[host_machine]
+system = 'bare-metal'
+cpu_family = 'arm'
+cpu = 'arm'
+endian = 'little'

--- a/include/libopencm3/lm3s/meson.build
+++ b/include/libopencm3/lm3s/meson.build
@@ -28,22 +28,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+lm3s_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/lm3s/nvic.h
+	# - lib/lm3s/vector_nvic.c
+	# - include/libopencmsis/lm3s/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-	'stm32f3': 'stm32/f3',
-	'stm32f4': 'stm32/f4',
-	'stm32f7': 'stm32/f7',
-	'lm4f': 'lm3s',
-}
-
-if target_platform != 'all'
-	target_path = target_paths.get(target_platform, target_platform)
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+lm3s_vector_nvic = declare_dependency(
+	sources: lm3s_nvic_header,
+)

--- a/include/libopencm3/stm32/f0/meson.build
+++ b/include/libopencm3/stm32/f0/meson.build
@@ -28,18 +28,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+stm32f0_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/stm32/f0/nvic.h
+	# - lib/stm32/f0/vector_nvic.c
+	# - include/libopencmsis/stm32/f0/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-}
-
-if target_platform != 'all'
-	target_path = target_paths[target_platform]
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+stm32f0_vector_nvic = declare_dependency(
+	sources: stm32f0_nvic_header,
+)

--- a/include/libopencm3/stm32/f1/meson.build
+++ b/include/libopencm3/stm32/f1/meson.build
@@ -1,0 +1,46 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+stm32f1_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/stm32/f1/nvic.h
+	# - lib/stm32/f1/vector_nvic.c
+	# - include/libopencmsis/stm32/f1/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
+)
+
+stm32f1_vector_nvic = declare_dependency(
+	sources: stm32f1_nvic_header,
+)

--- a/include/libopencm3/stm32/f3/meson.build
+++ b/include/libopencm3/stm32/f3/meson.build
@@ -28,36 +28,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Bring in all the common STM32 definitions
-subdir('common')
-
-# Sources specific to STM32 parts
-libstm32_can_sources = files('can.c')
-# Sources for the USB FS peripherals
-libstm32_usb_fs_v1_sources = files('st_usbfs_v1.c')
-libstm32_usb_fs_v2_sources = files('st_usbfs_v2.c')
-
-# Define a dependency for each generation of USB FS peripheral
-libstm32_usb_fs_v1 = declare_dependency(
-	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v1_sources]
+stm32f3_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/stm32/f3/nvic.h
+	# - lib/stm32/f3/vector_nvic.c
+	# - include/libopencmsis/stm32/f3/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
 )
 
-libstm32_usb_fs_v2 = declare_dependency(
-	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v2_sources]
+stm32f3_vector_nvic = declare_dependency(
+	sources: stm32f3_nvic_header,
 )
-
-# Mapping of target platform names to subdirs
-subdirs = {
-	'stm32f0': 'f0',
-	'stm32f1': 'f1',
-	'stm32f3': 'f3',
-}
-
-# Bring in the proper target subdir for the requested target platform
-if target_platform != 'all'
-	subdir(subdirs[target_platform])
-else
-	foreach subdir_name, subdir_path : subdirs
-		subdir(subdir_path)
-	endforeach
-endif

--- a/include/libopencm3/stm32/f4/meson.build
+++ b/include/libopencm3/stm32/f4/meson.build
@@ -28,37 +28,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Bring in all the common STM32 definitions
-subdir('common')
-
-# Sources specific to STM32 parts
-libstm32_can_sources = files('can.c')
-# Sources for the USB FS peripherals
-libstm32_usb_fs_v1_sources = files('st_usbfs_v1.c')
-libstm32_usb_fs_v2_sources = files('st_usbfs_v2.c')
-
-# Define a dependency for each generation of USB FS peripheral
-libstm32_usb_fs_v1 = declare_dependency(
-	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v1_sources]
+stm32f4_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/stm32/f4/nvic.h
+	# - lib/stm32/f4/vector_nvic.c
+	# - include/libopencmsis/stm32/f4/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
 )
 
-libstm32_usb_fs_v2 = declare_dependency(
-	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v2_sources]
+stm32f4_vector_nvic = declare_dependency(
+	sources: stm32f4_nvic_header,
 )
-
-# Mapping of target platform names to subdirs
-subdirs = {
-	'stm32f0': 'f0',
-	'stm32f1': 'f1',
-	'stm32f3': 'f3',
-	'stm32f4': 'f4',
-}
-
-# Bring in the proper target subdir for the requested target platform
-if target_platform != 'all'
-	subdir(subdirs[target_platform])
-else
-	foreach subdir_name, subdir_path : subdirs
-		subdir(subdir_path)
-	endforeach
-endif

--- a/include/libopencm3/stm32/f7/meson.build
+++ b/include/libopencm3/stm32/f7/meson.build
@@ -28,21 +28,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+stm32f7_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/stm32/f7/nvic.h
+	# - lib/stm32/f7/vector_nvic.c
+	# - include/libopencmsis/stm32/f7/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-	'stm32f3': 'stm32/f3',
-	'stm32f4': 'stm32/f4',
-	'stm32f7': 'stm32/f7',
-}
-
-if target_platform != 'all'
-	target_path = target_paths[target_platform]
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+stm32f7_vector_nvic = declare_dependency(
+	sources: stm32f7_nvic_header,
+)

--- a/include/libopencm3/stm32/h7/meson.build
+++ b/include/libopencm3/stm32/h7/meson.build
@@ -1,6 +1,6 @@
 # This file is part of the libopencm3 project.
 #
-# Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+# Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
 # Written by Rachel Mant <git@dragonmux.network>
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,23 +28,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+stm32h7_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/stm32/h7/nvic.h
+	# - lib/stm32/h7/vector_nvic.c
+	# - include/libopencmsis/stm32/h7/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-	'stm32f3': 'stm32/f3',
-	'stm32f4': 'stm32/f4',
-	'stm32f7': 'stm32/f7',
-	'stm32h7': 'stm32/h7',
-	'lm4f': 'lm3s',
-}
-
-if target_platform != 'all'
-	target_path = target_paths.get(target_platform, target_platform)
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+stm32h7_vector_nvic = declare_dependency(
+	sources: stm32h7_nvic_header,
+)

--- a/include/libopencm3/stm32/l4/meson.build
+++ b/include/libopencm3/stm32/l4/meson.build
@@ -1,7 +1,8 @@
 # This file is part of the libopencm3 project.
 #
-# Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
 # Written by Rachel Mant <git@dragonmux.network>
+# Modified by Kat Mitchell <kat@northernpaws.io>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -28,24 +29,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+stm32l4_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# We only name one of the 3 output files due to how this all works.
+	# This script will write:
+	# - include/libopencm3/stm32/l4/nvic.h
+	# - lib/stm32/l4/vector_nvic.c
+	# - include/libopencmsis/stm32/l4/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-	'stm32f3': 'stm32/f3',
-	'stm32f4': 'stm32/f4',
-	'stm32f7': 'stm32/f7',
-	'stm32h7': 'stm32/h7',
-	'stm32l4': 'stm32/l4',
-	'lm4f': 'lm3s',
-}
-
-if target_platform != 'all'
-	target_path = target_paths.get(target_platform, target_platform)
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+stm32l4_vector_nvic = declare_dependency(
+	sources: stm32l4_nvic_header,
+)

--- a/include/meson.build
+++ b/include/meson.build
@@ -34,9 +34,11 @@ target_paths = {
 	'stm32f1': 'stm32/f1'
 }
 
-target_path = target_paths[target_platform]
-subdir(f'libopencm3/@target_path@')
-
-target_vector_nvic = declare_dependency(
-	sources: target_nvic_header,
-)
+if target_platform != 'all'
+	target_path = target_paths[target_platform]
+	subdir(f'libopencm3/@target_path@')
+else
+	foreach target_name, target_path : target_paths
+		subdir(f'libopencm3/@target_path@')
+	endforeach
+endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -34,6 +34,7 @@ target_paths = {
 	'stm32f0': 'stm32/f0',
 	'stm32f1': 'stm32/f1',
 	'stm32f3': 'stm32/f3',
+	'stm32f4': 'stm32/f4',
 }
 
 if target_platform != 'all'

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,42 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+common_includes = include_directories('.')
+
+target_paths = {
+	'stm32f1': 'stm32/f1'
+}
+
+target_path = target_paths[target_platform]
+subdir(f'libopencm3/@target_path@')
+
+target_vector_nvic = declare_dependency(
+	sources: target_nvic_header,
+)

--- a/include/meson.build
+++ b/include/meson.build
@@ -33,6 +33,7 @@ common_includes = include_directories('.')
 target_paths = {
 	'stm32f0': 'stm32/f0',
 	'stm32f1': 'stm32/f1',
+	'stm32f3': 'stm32/f3',
 }
 
 if target_platform != 'all'

--- a/lib/cm3/meson.build
+++ b/lib/cm3/meson.build
@@ -1,0 +1,41 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cm3_sources = files(
+	'assert.c',
+	'dwt.c',
+	'nvic.c',
+	'scb.c',
+	'sync.c',
+	'systick.c',
+	'vector.c',
+)
+
+cm3_includes = include_directories('.')

--- a/lib/ethernet/meson.build
+++ b/lib/ethernet/meson.build
@@ -1,0 +1,39 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Sources common to all Ethernet implementations
+ethernet_common_sources = files(
+	'mac.c',
+	'phy.c',
+)
+
+# Sources for specific device families and PHYs
+ethernet_stm32_sources = files('mac_stm32fxx7.c')
+ethernet_phy_ksz80x1_sources = files('phy_ksz80x1.c')

--- a/lib/lm4f/meson.build
+++ b/lib/lm4f/meson.build
@@ -28,22 +28,51 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+lm4f_cm3 = declare_dependency(
+	sources: cm3_sources,
+	dependencies: lm3s_vector_nvic,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-	'stm32f3': 'stm32/f3',
-	'stm32f4': 'stm32/f4',
-	'stm32f7': 'stm32/f7',
-	'lm4f': 'lm3s',
-}
+# Sources specific to the LM4F (Tiva-C) series
+liblm4f_sources = files(
+	'gpio.c',
+	'rcc.c',
+	'systemcontrol.c',
+	'uart.c',
+)
 
-if target_platform != 'all'
-	target_path = target_paths.get(target_platform, target_platform)
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+liblm4f_compile_args = [
+	'-mfloat-abi=hard',
+	'-mfpu=fpv4-sp-d16',
+	'-mcpu=cortex-m4',
+	'-mthumb',
+	'-DLM4F',
+]
+
+# Build a static library for the target platform
+liblm4f = static_library(
+	'opencm3_lm4f',
+	[
+		liblm4f_sources,
+		usb_lm4f_sources,
+	],
+	c_args: liblm4f_compile_args,
+	include_directories: common_includes,
+	dependencies: [
+		lm4f_cm3,
+		usb_common,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+libopencm3_lm4f = declare_dependency(
+	compile_args: liblm4f_compile_args,
+	include_directories: common_includes,
+	link_with: liblm4f,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_lm4f', libopencm3_lm4f)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,0 +1,41 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Start by bringing in all the utility components like USB and Ethernet
+subdir('ethernet')
+subdir('usb')
+subdir('cm3')
+
+locm3_ld_script_path = meson.current_source_dir()
+
+# Now take the platform target and map it to a suitable target family
+if target_platform.startswith('stm32')
+	subdir('stm32')
+endif

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -39,3 +39,6 @@ locm3_ld_script_path = meson.current_source_dir()
 if target_platform.startswith('stm32') or target_platform == 'all'
 	subdir('stm32')
 endif
+if target_platform == 'lm4f' or target_platform == 'all'
+	subdir('lm4f')
+endif

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -36,6 +36,6 @@ subdir('cm3')
 locm3_ld_script_path = meson.current_source_dir()
 
 # Now take the platform target and map it to a suitable target family
-if target_platform.startswith('stm32')
+if target_platform.startswith('stm32') or target_platform == 'all'
 	subdir('stm32')
 endif

--- a/lib/stm32/common/meson.build
+++ b/lib/stm32/common/meson.build
@@ -38,12 +38,14 @@ libstm32_adc_v2_multi_sources = [
 	libstm32_adc_v2_sources,
 	files('adc_common_v2_multi.c'),
 ]
+libstm32_adc_f47_sources = files('adc_common_f47.c')
 libstm32_crc_v1_sources = files('crc_common_all.c')
 libstm32_crc_v2_sources = [
 	libstm32_crc_v1_sources,
 	files('crc_v2.c'),
 ]
 libstm32_crs_sources = files('crs_common_all.c')
+libstm32_crypto_f24_sources = files('crypto_common_f24.c')
 libstm32_dac_sources = files('dac_common_all.c')
 libstm32_dac_v1_sources = [
 	libstm32_dac_sources,
@@ -53,15 +55,19 @@ libstm32_dac_v2_sources = [
 	libstm32_dac_sources,
 	files('dac_common_v2.c'),
 ]
+libstm32_dcmi_f47_sources = files('dcmi_common_f47.c')
 libstm32_desig_v1_sources = files(
 	'desig_common_all.c',
 	'desig_common_v1.c'
 )
 libstm32_dma_sources = files('dma_common_l1f013.c')
+libstm32_dma_f24_sources = files('dma_common_f24.c')
 libstm32_dma_csel_sources = [
 	libstm32_dma_sources,
 	files('dma_common_csel.c'),
 ]
+libstm32_dma2d_f47_sources = files('dma2d_common_f47.c')
+libstm32_dsi_f47_sources = files('dsi_common_f47.c')
 libstm32_exti_sources = files('exti_common_all.c')
 libstm32_flash_sources = files('flash_common_all.c')
 libstm32_flash_f_sources = [
@@ -72,14 +78,23 @@ libstm32_flash_f01_sources = [
 	libstm32_flash_f_sources,
 	files('flash_common_f01.c'),
 ]
+libstm32_flash_f24_sources = [
+	libstm32_flash_f_sources,
+	files('flash_common_f24.c'),
+]
+libstm32_flash_idcache_sources = files('flash_common_idcache.c')
+libstm32_fmc_f47_sources = files('fmc_common_f47.c')
 libstm32_gpio_sources = files('gpio_common_all.c')
 libstm32_gpio_f0234_sources = [
 	libstm32_gpio_sources,
 	files('gpio_common_f0234.c'),
 ]
+libstm32_hash_f24_sources = files('hash_common_f24.c')
 libstm32_iwdg_sources = files('iwdg_common_all.c')
 libstm32_i2c_v1_sources = files('i2c_common_v1.c')
 libstm32_i2c_v2_sources = files('i2c_common_v2.c')
+libstm32_lptimer_sources = files('lptimer_common_all.c')
+libstm32_ltdc_f47_sources = files('ltdc_common_f47.c')
 libstm32_opamp_sources = files('opamp_common_all.c')
 libstm32_opamp_v1_sources = [
 	libstm32_opamp_sources,
@@ -91,12 +106,17 @@ libstm32_opamp_v2_sources = [
 ]
 libstm32_pwr_v1_sources = files('pwr_common_v1.c')
 libstm32_pwr_v2_sources = files('pwr_common_v2.c')
+libstm32_qspi_v1_sources = files('quadspi_common_v1.c')
 libstm32_rcc_sources = files('rcc_common_all.c')
 libstm32_rtc_l1f024_sources = files('rtc_common_l1f024.c')
 libstm32_spi_sources = files('spi_common_all.c')
 libstm32_spi_v1_sources = [
 	libstm32_spi_sources,
 	files('spi_common_v1.c'),
+]
+libstm32_spi_v1_frf_sources = [
+	libstm32_spi_v1_sources,
+	files('spi_common_v1_frf.c'),
 ]
 libstm32_spi_v2_sources = [
 	libstm32_spi_sources,
@@ -106,6 +126,10 @@ libstm32_timer_sources = files('timer_common_all.c')
 libstm32_timer_f0234_sources = [
 	libstm32_timer_sources,
 	files('timer_common_f0234.c'),
+]
+libstm32_timer_f24_sources = [
+	libstm32_timer_f0234_sources,
+	files('timer_common_f24.c'),
 ]
 libstm32_usart_sources = files('usart_common_all.c')
 libstm32_usart_f124_sources = [

--- a/lib/stm32/common/meson.build
+++ b/lib/stm32/common/meson.build
@@ -56,10 +56,11 @@ libstm32_dac_v2_sources = [
 	files('dac_common_v2.c'),
 ]
 libstm32_dcmi_f47_sources = files('dcmi_common_f47.c')
-libstm32_desig_v1_sources = files(
-	'desig_common_all.c',
-	'desig_common_v1.c'
-)
+libstm32_desig_sources = files('desig_common_all.c')
+libstm32_desig_v1_sources = [
+	libstm32_desig_sources,
+	files('desig_common_v1.c'),
+]
 libstm32_dma_sources = files('dma_common_l1f013.c')
 libstm32_dma_f24_sources = files('dma_common_f24.c')
 libstm32_dma_csel_sources = [
@@ -108,6 +109,7 @@ libstm32_pwr_v1_sources = files('pwr_common_v1.c')
 libstm32_pwr_v2_sources = files('pwr_common_v2.c')
 libstm32_qspi_v1_sources = files('quadspi_common_v1.c')
 libstm32_rcc_sources = files('rcc_common_all.c')
+libstm32_rng_v1_sources = files('rng_common_v1.c')
 libstm32_rtc_l1f024_sources = files('rtc_common_l1f024.c')
 libstm32_spi_sources = files('spi_common_all.c')
 libstm32_spi_v1_sources = [

--- a/lib/stm32/common/meson.build
+++ b/lib/stm32/common/meson.build
@@ -29,17 +29,31 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 libstm32_adc_v1_sources = files('adc_common_v1.c')
+libstm32_adc_v2_sources = files('adc_common_v2.c')
 libstm32_crc_v1_sources = files('crc_common_all.c')
+libstm32_crc_v2_sources = [
+	libstm32_crc_v1_sources,
+	files('crc_v2.c'),
+]
+libstm32_crs_sources = files('crs_common_all.c')
 libstm32_dac_sources = files('dac_common_all.c')
 libstm32_dac_v1_sources = [
 	libstm32_dac_sources,
 	files('dac_common_v1.c'),
+]
+libstm32_dac_v2_sources = [
+	libstm32_dac_sources,
+	files('dac_common_v2.c'),
 ]
 libstm32_desig_v1_sources = files(
 	'desig_common_all.c',
 	'desig_common_v1.c'
 )
 libstm32_dma_sources = files('dma_common_l1f013.c')
+libstm32_dma_csel_sources = [
+	libstm32_dma_sources,
+	files('dma_common_csel.c'),
+]
 libstm32_exti_sources = files('exti_common_all.c')
 libstm32_flash_sources = files('flash_common_all.c')
 libstm32_flash_f_sources = [
@@ -51,20 +65,38 @@ libstm32_flash_f01_sources = [
 	files('flash_common_f01.c'),
 ]
 libstm32_gpio_sources = files('gpio_common_all.c')
+libstm32_gpio_f0234_sources = [
+	libstm32_gpio_sources,
+	files('gpio_common_f0234.c'),
+]
 libstm32_iwdg_sources = files('iwdg_common_all.c')
 libstm32_i2c_v1_sources = files('i2c_common_v1.c')
+libstm32_i2c_v2_sources = files('i2c_common_v2.c')
 libstm32_pwr_v1_sources = files('pwr_common_v1.c')
 libstm32_rcc_sources = files('rcc_common_all.c')
+libstm32_rtc_l1f024_sources = files('rtc_common_l1f024.c')
 libstm32_spi_sources = files('spi_common_all.c')
 libstm32_spi_v1_sources = [
 	libstm32_spi_sources,
 	files('spi_common_v1.c'),
 ]
+libstm32_spi_v2_sources = [
+	libstm32_spi_sources,
+	files('spi_common_v2.c'),
+]
 libstm32_timer_sources = files('timer_common_all.c')
+libstm32_timer_f0234_sources = [
+	libstm32_timer_sources,
+	files('timer_common_f0234.c'),
+]
 libstm32_usart_sources = files('usart_common_all.c')
 libstm32_usart_f124_sources = [
 	libstm32_usart_sources,
 	files('usart_common_f124.c'),
+]
+libstm32_usart_v2_sources = [
+	libstm32_usart_sources,
+	files('usart_common_v2.c'),
 ]
 
 libstm32_usb_fs_sources = files('st_usbfs_core.c')

--- a/lib/stm32/common/meson.build
+++ b/lib/stm32/common/meson.build
@@ -1,0 +1,70 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+libstm32_adc_v1_sources = files('adc_common_v1.c')
+libstm32_crc_v1_sources = files('crc_common_all.c')
+libstm32_dac_sources = files('dac_common_all.c')
+libstm32_dac_v1_sources = [
+	libstm32_dac_sources,
+	files('dac_common_v1.c'),
+]
+libstm32_desig_v1_sources = files(
+	'desig_common_all.c',
+	'desig_common_v1.c'
+)
+libstm32_dma_sources = files('dma_common_l1f013.c')
+libstm32_exti_sources = files('exti_common_all.c')
+libstm32_flash_sources = files('flash_common_all.c')
+libstm32_flash_f_sources = [
+	libstm32_flash_sources,
+	files('flash_common_f.c'),
+]
+libstm32_flash_f01_sources = [
+	libstm32_flash_f_sources,
+	files('flash_common_f01.c'),
+]
+libstm32_gpio_sources = files('gpio_common_all.c')
+libstm32_iwdg_sources = files('iwdg_common_all.c')
+libstm32_i2c_v1_sources = files('i2c_common_v1.c')
+libstm32_pwr_v1_sources = files('pwr_common_v1.c')
+libstm32_rcc_sources = files('rcc_common_all.c')
+libstm32_spi_sources = files('spi_common_all.c')
+libstm32_spi_v1_sources = [
+	libstm32_spi_sources,
+	files('spi_common_v1.c'),
+]
+libstm32_timer_sources = files('timer_common_all.c')
+libstm32_usart_sources = files('usart_common_all.c')
+libstm32_usart_f124_sources = [
+	libstm32_usart_sources,
+	files('usart_common_f124.c'),
+]
+
+libstm32_usb_fs_sources = files('st_usbfs_core.c')

--- a/lib/stm32/common/meson.build
+++ b/lib/stm32/common/meson.build
@@ -29,7 +29,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 libstm32_adc_v1_sources = files('adc_common_v1.c')
+libstm32_adc_v1_multi_sources = [
+	libstm32_adc_v1_sources,
+	files('adc_common_v1_multi.c'),
+]
 libstm32_adc_v2_sources = files('adc_common_v2.c')
+libstm32_adc_v2_multi_sources = [
+	libstm32_adc_v2_sources,
+	files('adc_common_v2_multi.c'),
+]
 libstm32_crc_v1_sources = files('crc_common_all.c')
 libstm32_crc_v2_sources = [
 	libstm32_crc_v1_sources,
@@ -72,7 +80,17 @@ libstm32_gpio_f0234_sources = [
 libstm32_iwdg_sources = files('iwdg_common_all.c')
 libstm32_i2c_v1_sources = files('i2c_common_v1.c')
 libstm32_i2c_v2_sources = files('i2c_common_v2.c')
+libstm32_opamp_sources = files('opamp_common_all.c')
+libstm32_opamp_v1_sources = [
+	libstm32_opamp_sources,
+	files('opamp_common_v1.c'),
+]
+libstm32_opamp_v2_sources = [
+	libstm32_opamp_sources,
+	files('opamp_common_v2.c'),
+]
 libstm32_pwr_v1_sources = files('pwr_common_v1.c')
+libstm32_pwr_v2_sources = files('pwr_common_v2.c')
 libstm32_rcc_sources = files('rcc_common_all.c')
 libstm32_rtc_l1f024_sources = files('rtc_common_l1f024.c')
 libstm32_spi_sources = files('spi_common_all.c')

--- a/lib/stm32/common/meson.build
+++ b/lib/stm32/common/meson.build
@@ -68,8 +68,10 @@ libstm32_dma_csel_sources = [
 	files('dma_common_csel.c'),
 ]
 libstm32_dma2d_f47_sources = files('dma2d_common_f47.c')
+libstm32_dmamux_sources = files('dmamux.c')
 libstm32_dsi_f47_sources = files('dsi_common_f47.c')
 libstm32_exti_sources = files('exti_common_all.c')
+libstm32_fdcan_sources = files('fdcan_common.c')
 libstm32_flash_sources = files('flash_common_all.c')
 libstm32_flash_f_sources = [
 	libstm32_flash_sources,
@@ -142,5 +144,6 @@ libstm32_usart_v2_sources = [
 	libstm32_usart_sources,
 	files('usart_common_v2.c'),
 ]
+libstm32_usart_fifos_sources = files('usart_common_fifos.c')
 
 libstm32_usb_fs_sources = files('st_usbfs_core.c')

--- a/lib/stm32/f0/meson.build
+++ b/lib/stm32/f0/meson.build
@@ -28,18 +28,71 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+stm32f0_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: stm32f0_vector_nvic,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-}
+# Sources specific to the F0 series
+libstm32f0_sources = files(
+	'adc.c',
+	'comparator.c',
+	'flash.c',
+	#'i2c.c', # XXX: This source is unused for some reason
+	'rcc.c',
+	#'syscfg.c', # XXX: This source is unused for some reason
+)
 
-if target_platform != 'all'
-	target_path = target_paths[target_platform]
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+libstm32f0_compile_args = [
+	'-mcpu=cortex-m0',
+	'-mthumb',
+	'-DSTM32F0',
+]
+
+# Build a static library for the target platform
+libstm32f0 = static_library(
+	'opencm3_stm32f0',
+	[
+		libstm32f0_sources,
+		libstm32_adc_v2_sources,
+		libstm32_crc_v2_sources,
+		libstm32_crs_sources,
+		libstm32_dac_v1_sources,
+		libstm32_desig_v1_sources,
+		libstm32_dma_csel_sources,
+		libstm32_exti_sources,
+		libstm32_flash_f01_sources,
+		libstm32_gpio_f0234_sources,
+		libstm32_iwdg_sources,
+		libstm32_i2c_v2_sources,
+		libstm32_pwr_v1_sources,
+		libstm32_rcc_sources,
+		libstm32_rtc_l1f024_sources,
+		libstm32_spi_v2_sources,
+		libstm32_timer_f0234_sources,
+		libstm32_usart_v2_sources,
+		libstm32_can_sources,
+	],
+	c_args: libstm32f0_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		stm32f0_cm3,
+		usb_common,
+		libstm32_usb_fs_v2,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+opencm3_stm32f0 = declare_dependency(
+	compile_args: libstm32f0_compile_args,
+	include_directories: common_includes,
+	link_with: libstm32f0,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_stm32f0', opencm3_stm32f0)

--- a/lib/stm32/f1/meson.build
+++ b/lib/stm32/f1/meson.build
@@ -1,0 +1,102 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+stm32f1_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: stm32f1_vector_nvic,
+)
+
+# Sources specific to the F1 series
+libstm32f1_sources = files(
+	'adc.c',
+	'flash.c',
+	'gpio.c',
+	#'i2c.c', # XXX: This source is unused for some reason
+	'rcc.c',
+	'rtc.c',
+	'timer.c',
+)
+
+libstm32f1_compile_args = [
+	'-mcpu=cortex-m3',
+	'-mthumb',
+	'-DSTM32F1',
+]
+
+# Build a static library for the target platform
+libstm32f1 = static_library(
+	'opencm3_stm32f1',
+	[
+		libstm32f1_sources,
+		libstm32_adc_v1_sources,
+		libstm32_crc_v1_sources,
+		libstm32_dac_v1_sources,
+		libstm32_desig_v1_sources,
+		libstm32_dma_sources,
+		libstm32_exti_sources,
+		libstm32_flash_f01_sources,
+		libstm32_gpio_sources,
+		libstm32_iwdg_sources,
+		libstm32_i2c_v1_sources,
+		libstm32_pwr_v1_sources,
+		libstm32_rcc_sources,
+		libstm32_spi_v1_sources,
+		libstm32_timer_sources,
+		libstm32_usart_f124_sources,
+		libstm32_can_sources,
+		usb_stm32_f107_sources,
+		ethernet_common_sources,
+		ethernet_stm32_sources,
+		ethernet_phy_ksz80x1_sources,
+	],
+	c_args: libstm32f1_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		stm32f1_cm3,
+		usb_common,
+		usb_stm32_dwc,
+		libstm32_usb_fs_v1,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+libopencm3_stm32f1 = declare_dependency(
+	compile_args: libstm32f1_compile_args,
+	include_directories: common_includes,
+	link_with: libstm32f1,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_stm32f1', libopencm3_stm32f1)

--- a/lib/stm32/f3/meson.build
+++ b/lib/stm32/f3/meson.build
@@ -28,36 +28,72 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Bring in all the common STM32 definitions
-subdir('common')
-
-# Sources specific to STM32 parts
-libstm32_can_sources = files('can.c')
-# Sources for the USB FS peripherals
-libstm32_usb_fs_v1_sources = files('st_usbfs_v1.c')
-libstm32_usb_fs_v2_sources = files('st_usbfs_v2.c')
-
-# Define a dependency for each generation of USB FS peripheral
-libstm32_usb_fs_v1 = declare_dependency(
-	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v1_sources]
+stm32f3_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: stm32f3_vector_nvic,
 )
 
-libstm32_usb_fs_v2 = declare_dependency(
-	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v2_sources]
+# Sources specific to the F3 series
+libstm32f3_sources = files(
+	'adc.c',
+	'flash.c',
+	#'i2c.c', # XXX: This source is unused for some reason
+	'rcc.c',
+	#'vector_chipset.c', # XXX: This source is unused for some reason
 )
 
-# Mapping of target platform names to subdirs
-subdirs = {
-	'stm32f0': 'f0',
-	'stm32f1': 'f1',
-	'stm32f3': 'f3',
-}
+libstm32f3_compile_args = [
+	'-mfloat-abi=hard',
+	'-mfpu=fpv4-sp-d16',
+	'-mcpu=cortex-m4',
+	'-mthumb',
+	'-DSTM32F3',
+]
 
-# Bring in the proper target subdir for the requested target platform
-if target_platform != 'all'
-	subdir(subdirs[target_platform])
-else
-	foreach subdir_name, subdir_path : subdirs
-		subdir(subdir_path)
-	endforeach
-endif
+# Build a static library for the target platform
+libstm32f3 = static_library(
+	'opencm3_stm32f3',
+	[
+		libstm32f3_sources,
+		libstm32_adc_v2_multi_sources,
+		libstm32_crc_v2_sources,
+		libstm32_dac_v1_sources,
+		libstm32_desig_v1_sources,
+		libstm32_dma_sources,
+		libstm32_exti_sources,
+		libstm32_flash_f_sources,
+		libstm32_gpio_f0234_sources,
+		libstm32_iwdg_sources,
+		libstm32_i2c_v2_sources,
+		libstm32_opamp_v1_sources,
+		libstm32_pwr_v1_sources,
+		libstm32_rcc_sources,
+		libstm32_rtc_l1f024_sources,
+		libstm32_spi_v2_sources,
+		libstm32_timer_f0234_sources,
+		libstm32_usart_v2_sources,
+		libstm32_can_sources,
+	],
+	c_args: libstm32f3_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		stm32f3_cm3,
+		usb_common,
+		libstm32_usb_fs_v1,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+libopencm3_stm32f3 = declare_dependency(
+	compile_args: libstm32f3_compile_args,
+	include_directories: common_includes,
+	link_with: libstm32f3,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_stm32f3', libopencm3_stm32f3)

--- a/lib/stm32/f4/meson.build
+++ b/lib/stm32/f4/meson.build
@@ -1,0 +1,117 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+stm32f4_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: stm32f4_vector_nvic,
+)
+
+# Sources specific to the F4 series
+libstm32f4_sources = files(
+	'crypto.c',
+	'flash.c',
+	#'i2c.c', # XXX: This source is unused for some reason
+	'pwr.c',
+	'rcc.c',
+	#'rng.c', # XXX: This source is unused for some reason
+	'rtc.c',
+	#'vector_chipset.c', # XXX: This source is unused for some reason
+)
+
+libstm32f4_compile_args = [
+	'-mfloat-abi=hard',
+	'-mfpu=fpv4-sp-d16',
+	'-mcpu=cortex-m4',
+	'-mthumb',
+	'-DSTM32F4',
+]
+
+# Build a static library for the target platform
+libstm32f4 = static_library(
+	'opencm3_stm32f4',
+	[
+		libstm32f4_sources,
+		libstm32_adc_v1_multi_sources,
+		libstm32_adc_f47_sources,
+		libstm32_crc_v1_sources,
+		libstm32_crypto_f24_sources,
+		libstm32_dac_v1_sources,
+		libstm32_dcmi_f47_sources,
+		libstm32_desig_v1_sources,
+		libstm32_dma_f24_sources,
+		libstm32_dma2d_f47_sources,
+		libstm32_dsi_f47_sources,
+		libstm32_exti_sources,
+		libstm32_flash_f24_sources,
+		libstm32_flash_idcache_sources,
+		libstm32_fmc_f47_sources,
+		libstm32_gpio_f0234_sources,
+		libstm32_hash_f24_sources,
+		libstm32_iwdg_sources,
+		libstm32_i2c_v1_sources,
+		libstm32_lptimer_sources,
+		libstm32_ltdc_f47_sources,
+		libstm32_pwr_v1_sources,
+		libstm32_qspi_v1_sources,
+		libstm32_rcc_sources,
+		libstm32_rtc_l1f024_sources,
+		libstm32_spi_v1_frf_sources,
+		libstm32_timer_f24_sources,
+		libstm32_usart_f124_sources,
+		libstm32_can_sources,
+		usb_stm32_f107_sources,
+		usb_stm32_f207_sources,
+		ethernet_common_sources,
+		ethernet_stm32_sources,
+		ethernet_phy_ksz80x1_sources,
+	],
+	c_args: libstm32f4_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		stm32f4_cm3,
+		usb_common,
+		usb_stm32_dwc,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+libopencm3_stm32f4 = declare_dependency(
+	compile_args: libstm32f4_compile_args,
+	include_directories: common_includes,
+	link_with: libstm32f4,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_stm32f4', libopencm3_stm32f4)

--- a/lib/stm32/f7/meson.build
+++ b/lib/stm32/f7/meson.build
@@ -1,0 +1,110 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+stm32f7_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: stm32f7_vector_nvic,
+)
+
+# Sources specific to the F7 series
+libstm32f7_sources = files(
+	'desig.c',
+	'flash.c',
+	'pwr.c',
+	'rcc.c',
+	#'vector_chipset.c', # XXX: This source is unused for some reason
+)
+
+libstm32f7_compile_args = [
+	'-mfloat-abi=hard',
+	'-mfpu=fpv5-sp-d16',
+	'-mcpu=cortex-m7',
+	'-mthumb',
+	'-DSTM32F7',
+]
+
+# Build a static library for the target platform
+libstm32f7 = static_library(
+	'opencm3_stm32f7',
+	[
+		libstm32f7_sources,
+		libstm32_adc_v1_multi_sources,
+		libstm32_adc_f47_sources,
+		libstm32_crc_v2_sources,
+		libstm32_dac_v1_sources,
+		libstm32_dcmi_f47_sources,
+		libstm32_desig_sources,
+		libstm32_dma_f24_sources,
+		libstm32_dma2d_f47_sources,
+		libstm32_dsi_f47_sources,
+		libstm32_exti_sources,
+		libstm32_flash_f24_sources,
+		libstm32_fmc_f47_sources,
+		libstm32_gpio_f0234_sources,
+		libstm32_i2c_v2_sources,
+		libstm32_iwdg_sources,
+		libstm32_lptimer_sources,
+		libstm32_ltdc_f47_sources,
+		libstm32_qspi_v1_sources,
+		libstm32_rcc_sources,
+		libstm32_rng_v1_sources,
+		libstm32_spi_v2_sources,
+		libstm32_timer_sources,
+		libstm32_usart_v2_sources,
+		libstm32_can_sources,
+		usb_stm32_f107_sources,
+		usb_stm32_f207_sources,
+		ethernet_common_sources,
+		ethernet_stm32_sources,
+		ethernet_phy_ksz80x1_sources,
+	],
+	c_args: libstm32f7_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		stm32f7_cm3,
+		usb_common,
+		usb_stm32_dwc,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+libopencm3_stm32f7 = declare_dependency(
+	compile_args: libstm32f7_compile_args,
+	include_directories: [common_includes, usb_includes],
+	link_with: libstm32f7,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_stm32f7', libopencm3_stm32f7)

--- a/lib/stm32/h7/meson.build
+++ b/lib/stm32/h7/meson.build
@@ -1,6 +1,6 @@
 # This file is part of the libopencm3 project.
 #
-# Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+# Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
 # Written by Rachel Mant <git@dragonmux.network>
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,23 +28,70 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-common_includes = include_directories('.')
+stm32h7_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: stm32h7_vector_nvic,
+)
 
-target_paths = {
-	'stm32f0': 'stm32/f0',
-	'stm32f1': 'stm32/f1',
-	'stm32f3': 'stm32/f3',
-	'stm32f4': 'stm32/f4',
-	'stm32f7': 'stm32/f7',
-	'stm32h7': 'stm32/h7',
-	'lm4f': 'lm3s',
-}
+# Sources specific to the H7 series
+libstm32h7_sources = files(
+	'fdcan.c',
+	'flash.c',
+	'pwr.c',
+	'rcc.c',
+	#'vector_chipset.c', # This source is included by lib/dispatch/vector_chipset.c
+)
 
-if target_platform != 'all'
-	target_path = target_paths.get(target_platform, target_platform)
-	subdir(f'libopencm3/@target_path@')
-else
-	foreach target_name, target_path : target_paths
-		subdir(f'libopencm3/@target_path@')
-	endforeach
-endif
+libstm32h7_compile_args = [
+	'-mfloat-abi=hard',
+	'-mfpu=fpv5-d16',
+	'-mcpu=cortex-m7',
+	'-mthumb',
+	'-DSTM32H7',
+]
+
+# Build a static library for the target platform
+libstm32h7 = static_library(
+	'opencm3_stm32h7',
+	[
+		libstm32h7_sources,
+		libstm32_crc_v2_sources,
+		libstm32_crs_sources,
+		libstm32_dac_v2_sources,
+		libstm32_dma_f24_sources,
+		libstm32_dmamux_sources,
+		libstm32_exti_sources,
+		libstm32_fdcan_sources,
+		libstm32_fmc_f47_sources,
+		libstm32_gpio_f0234_sources,
+		libstm32_qspi_v1_sources,
+		libstm32_rcc_sources,
+		libstm32_rng_v1_sources,
+		libstm32_spi_v2_sources,
+		libstm32_timer_sources,
+		libstm32_usart_v2_sources,
+		libstm32_usart_fifos_sources,
+	],
+	c_args: libstm32h7_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		stm32h7_cm3,
+		usb_common,
+		usb_stm32_dwc,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+libopencm3_stm32h7 = declare_dependency(
+	compile_args: libstm32h7_compile_args,
+	include_directories: common_includes,
+	link_with: libstm32h7,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_stm32h7', libopencm3_stm32h7)

--- a/lib/stm32/l4/meson.build
+++ b/lib/stm32/l4/meson.build
@@ -1,0 +1,105 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+# Modified by Kat Mitchell <kat@northernpaws.io>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+stm32l4_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: stm32l4_vector_nvic,
+)
+
+# Sources specific to the F4 series
+libstm32l4_sources = files(
+	'adc.c',
+	'flash.c',
+	'i2c.c',
+	'pwr.c',
+	'rcc.c',
+	#'vector_chipset.c', # This source is included by lib/dispatch/vector_chipset.c 
+
+)
+
+libstm32l4_compile_args = [
+	'-mfloat-abi=hard',
+	'-mfpu=fpv4-sp-d16',
+	'-mcpu=cortex-m4',
+	'-mthumb',
+	'-DSTM32L4',
+]
+
+# Build a static library for the target platform
+libstm32l4 = static_library(
+	'opencm3_stm32l4',
+	[
+		libstm32l4_sources,
+		libstm32_adc_v2_multi_sources,
+		libstm32_crc_v1_sources,
+		libstm32_crc_v2_sources,
+		libstm32_crs_sources,
+		libstm32_dac_v1_sources,
+		libstm32_dma_csel_sources,
+		libstm32_exti_sources,
+		libstm32_flash_f_sources,
+		libstm32_flash_idcache_sources,
+		libstm32_gpio_f0234_sources,
+		libstm32_i2c_v2_sources,
+		libstm32_iwdg_sources,
+		libstm32_lptimer_sources,
+		libstm32_rcc_sources,
+		libstm32_rng_v1_sources,
+		libstm32_rtc_l1f024_sources,
+		libstm32_spi_v2_sources,
+		libstm32_timer_sources,
+		libstm32_usart_v2_sources,
+		libstm32_qspi_v1_sources,
+		usb_stm32_f107_sources,
+	],
+	c_args: libstm32l4_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		stm32l4_cm3,
+		usb_common,
+		usb_stm32_dwc,
+	],
+	pic: false,
+)
+
+# Make the dependency available to use
+libopencm3_stm32l4 = declare_dependency(
+	compile_args: libstm32l4_compile_args,
+	include_directories: common_includes,
+	link_with: libstm32l4,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_stm32l4', libopencm3_stm32l4)

--- a/lib/stm32/meson.build
+++ b/lib/stm32/meson.build
@@ -1,0 +1,55 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Bring in all the common STM32 definitions
+subdir('common')
+
+# Sources specific to STM32 parts
+libstm32_can_sources = files('can.c')
+# Sources for the USB FS peripherals
+libstm32_usb_fs_v1_sources = files('st_usbfs_v1.c')
+libstm32_usb_fs_v2_sources = files('st_usbfs_v2.c')
+
+# Define a dependency for each generation of USB FS peripheral
+libstm32_usb_fs_v1 = declare_dependency(
+	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v1_sources]
+)
+
+libstm32_usb_fs_v2 = declare_dependency(
+	sources: [libstm32_usb_fs_sources, libstm32_usb_fs_v2_sources]
+)
+
+# Mapping of target platform names to subdirs
+subdirs = {
+	'stm32f1': 'f1',
+}
+
+# Bring in the proper target subdir for the requested target platform
+subdir(subdirs[target_platform])

--- a/lib/stm32/meson.build
+++ b/lib/stm32/meson.build
@@ -1,6 +1,6 @@
 # This file is part of the libopencm3 project.
 #
-# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
 # Written by Rachel Mant <git@dragonmux.network>
 #
 # Redistribution and use in source and binary forms, with or without
@@ -53,6 +53,7 @@ subdirs = {
 	'stm32f3': 'f3',
 	'stm32f4': 'f4',
 	'stm32f7': 'f7',
+	'stm32h7': 'h7',
 }
 
 # Bring in the proper target subdir for the requested target platform

--- a/lib/stm32/meson.build
+++ b/lib/stm32/meson.build
@@ -52,6 +52,7 @@ subdirs = {
 	'stm32f1': 'f1',
 	'stm32f3': 'f3',
 	'stm32f4': 'f4',
+	'stm32f7': 'f7',
 }
 
 # Bring in the proper target subdir for the requested target platform

--- a/lib/stm32/meson.build
+++ b/lib/stm32/meson.build
@@ -52,4 +52,10 @@ subdirs = {
 }
 
 # Bring in the proper target subdir for the requested target platform
-subdir(subdirs[target_platform])
+if target_platform != 'all'
+	subdir(subdirs[target_platform])
+else
+	foreach subdir_name, subdir_path : subdirs
+		subdir(subdir_path)
+	endforeach
+endif

--- a/lib/stm32/meson.build
+++ b/lib/stm32/meson.build
@@ -48,6 +48,7 @@ libstm32_usb_fs_v2 = declare_dependency(
 
 # Mapping of target platform names to subdirs
 subdirs = {
+	'stm32f0': 'f0',
 	'stm32f1': 'f1',
 }
 

--- a/lib/stm32/meson.build
+++ b/lib/stm32/meson.build
@@ -54,6 +54,7 @@ subdirs = {
 	'stm32f4': 'f4',
 	'stm32f7': 'f7',
 	'stm32h7': 'h7',
+	'stm32l4': 'l4',
 }
 
 # Bring in the proper target subdir for the requested target platform

--- a/lib/usb/meson.build
+++ b/lib/usb/meson.build
@@ -1,0 +1,68 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Sources common to all USB implementations
+usb_common_sources = files(
+	# Base USB implementation
+	'usb.c',
+	'usb_control.c',
+	'usb_standard.c',
+	# Descriptor extension implementations
+	'usb_bos.c',
+	'usb_microsoft.c',
+	# Specific protocol implementations
+	'usb_audio.c',
+	'usb_cdc.c',
+	'usb_hid.c',
+	'usb_midi.c',
+	'usb_msc.c',
+)
+
+# Platform-specific USB sources, gruped by peripheral family
+usb_efm32_sources = files('usb_efm32.c')
+usb_efm32hg_sources = files('usb_efm32hg.c')
+usb_stm32_dwc_sources = files('usb_dwc_common.c')
+usb_stm32_f107_sources = files('usb_f107.c')
+usb_stm32_f207_sources = files('usb_f207.c')
+usb_lm4f_sources = files('usb_lm4f.c')
+
+usb_includes = include_directories('..')
+
+# Define a dependency for the common part
+usb_common = declare_dependency(
+	sources: usb_common_sources,
+	include_directories: usb_includes,
+)
+
+# Define a dependency for the DWC peripheral
+usb_stm32_dwc = declare_dependency(
+	sources: usb_stm32_dwc_sources,
+	dependencies: usb_common
+)

--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,7 @@ extended_warnings = [
 	'-Wstringop-overflow',
 	'-Wunknown-pragmas',
 	'-Wunsafe-loop-optimizations',
-	'-Wunsuffixed-float-constant',
+	'-Wunsuffixed-float-constants',
 	'-Wunused-const-variable=2',
 	'-Wunused-local-typedefs',
 	'-Wunused',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,119 @@
+# This file is part of the libopencm3 project.
+#
+# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Written by Rachel Mant <git@dragonmux.network>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+project(
+	'libopencm3',
+	'c',
+	default_options: [
+		'c_std=c99',
+		'warning_level=3',
+		'b_ndebug=if-release',
+	],
+	version: '0.8.0',
+	license: 'GPL-3.0-or-later OR BSD-3-Clause OR MIT',
+)
+
+# Ensure we are cross-compiling and not building for the build host
+assert(meson.is_cross_build(), 'libopencm3 must be cross-compiled')
+
+# Ensure we are using a GCC compiler
+cc = meson.get_compiler('c')
+assert(cc.get_id() == 'gcc', 'libopencm3 must be compiled with GCC')
+
+# Project wide flags
+extended_warnings = [
+	'-Warith-conversion',
+	'-Wbad-function-cast',
+	# '-Wcast-align=strict',
+	'-Wcast-function-type',
+	# '-Wcast-qual',
+	# '-Wconversion',
+	'-Wdangling-else',
+	'-Wdouble-promotion',
+	'-Wduplicated-branches',
+	'-Wfloat-conversion',
+	'-Wformat-overflow=2',
+	'-Wformat-signedness',
+	'-Wformat-truncation',
+	'-Wformat=2',
+	'-Wimplicit-fallthrough',
+	'-Wmaybe-uninitialized',
+	'-Wmissing-attributes',
+	'-Wmissing-braces',
+	'-Wno-char-subscripts',
+	'-Wnull-dereference',
+	# '-Wpacked',
+	'-Wredundant-decls',
+	'-Wreturn-type',
+	'-Wsequence-point',
+	'-Wshadow=local',
+	# '-Wsign-conversion',
+	'-Wstack-protector',
+	'-Wstrict-aliasing',
+	'-Wstrict-overflow=2',
+	'-Wstring-compare',
+	'-Wstringop-overflow',
+	'-Wunknown-pragmas',
+	'-Wunsafe-loop-optimizations',
+	'-Wunsuffixed-float-constant',
+	'-Wunused-const-variable=2',
+	'-Wunused-local-typedefs',
+	'-Wunused',
+	'-Wvla-parameter',
+	# '-Wvla',
+]
+add_project_arguments(
+	cc.get_supported_arguments(extended_warnings),
+	language: 'c',
+)
+
+# Options controlling how object files are generated for linking
+common_args = [
+	'-ffunction-sections',
+	'-fdata-sections',
+]
+add_project_arguments(
+	common_args,
+	language: 'c',
+)
+
+# Grab the IRQ -> nvic.h script and Python for the include system
+python = import('python').find_installation()
+irq2nvic = [
+	python,
+	files('scripts/irq2nvic_h'),
+	'--builddir',
+	meson.current_build_dir(),
+]
+
+# Extract what we're supposed to build for and start traversing to the appropriate library
+target_platform = get_option('target')
+subdir('include')
+subdir('lib')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,7 @@ option(
 		'all',
 		'stm32f0',
 		'stm32f1',
+		'stm32f3',
 	],
 	value: 'all',
 	description: 'The hardware platform you wish to target'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,9 @@ option(
 	'target',
 	type: 'combo',
 	choices: [
+		'all',
 		'stm32f1'
 	],
+	value: 'all',
 	description: 'The hardware platform you wish to target'
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,7 @@ option(
 		'stm32f3',
 		'stm32f4',
 		'stm32f7',
+		'lm4f',
 	],
 	value: 'all',
 	description: 'The hardware platform you wish to target'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,7 @@ option(
 		'stm32f1',
 		'stm32f3',
 		'stm32f4',
+		'stm32f7',
 	],
 	value: 'all',
 	description: 'The hardware platform you wish to target'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,8 @@ option(
 	type: 'combo',
 	choices: [
 		'all',
-		'stm32f1'
+		'stm32f0',
+		'stm32f1',
 	],
 	value: 'all',
 	description: 'The hardware platform you wish to target'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+option(
+	'target',
+	type: 'combo',
+	choices: [
+		'stm32f1'
+	],
+	description: 'The hardware platform you wish to target'
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option(
 		'stm32f0',
 		'stm32f1',
 		'stm32f3',
+		'stm32f4',
 	],
 	value: 'all',
 	description: 'The hardware platform you wish to target'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,7 @@ option(
 		'stm32f3',
 		'stm32f4',
 		'stm32f7',
+		'stm32l4',
 		'lm4f',
 	],
 	value: 'all',

--- a/scripts/irq2nvic_h
+++ b/scripts/irq2nvic_h
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 
 # This file is part of the libopencm3 project.
-# 
+#
 # Copyright (C) 2012 chrysn <chrysn@fsfe.org>
-# 
+#
 # This library is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library. If not, see <http://www.gnu.org/licenses/>.
 
@@ -30,6 +30,8 @@ import sys
 import os
 import os.path
 import json
+from pathlib import Path
+from typing import List
 
 template_nvic_h = '''\
 /* This file is part of the libopencm3 project.
@@ -77,7 +79,6 @@ template_vector_nvic_c = '''\
  * This part needs to get included in the compilation unit where
  * blocking_handler gets defined due to the way #pragma works.
  */
-
 
 /** @defgroup CM3_nvic_isrdecls_{partname_doxygen} User interrupt service routines (ISR) defaults for {partname_humanreadable}
     @ingroup CM3_nvic_isrdecls
@@ -131,47 +132,75 @@ def convert(infile, outfile_nvic, outfile_vectornvic, outfile_cmsis):
     outfile_vectornvic.write(template_vector_nvic_c.format(**data))
     outfile_cmsis.write(template_cmsis_h.format(**data))
 
-def makeparentdir(filename):
+def makeparentdir(filename: Path):
     try:
-        os.makedirs(os.path.dirname(filename))
+        filename.parent.mkdir(parents = True)
     except OSError:
         # where is my 'mkdir -p'?
         pass
 
-def needs_update(infiles, outfiles):
-    timestamp = lambda filename: os.stat(filename).st_mtime
-    return any(not os.path.exists(o) for o in outfiles) or max(map(timestamp, infiles)) > min(map(timestamp, outfiles))
+def needs_update(infiles: List[Path], outfiles: List[Path]):
+    timestamp = lambda filename: filename.stat().st_mtime
+    return any(not o.exists() for o in outfiles) or max(map(timestamp, infiles)) > min(map(timestamp, outfiles))
 
 def main():
+    # If the tool's been invoked in remove mode, set up for that
     if sys.argv[1] == '--remove':
         remove = True
         del sys.argv[1]
     else:
         remove = False
-    infile = sys.argv[1]
-    if not infile.startswith('./include/libopencm3/') or not infile.endswith('/irq.json'):
+
+    # If the tool's been invoked with the output directory explicitly noted, use that for cwd
+    if sys.argv[1] == '--builddir':
+        cwd = Path(sys.argv[2])
+        del sys.argv[1:3]
+    else:
+        cwd = Path.cwd()
+
+    # Check to make sure infile refers to a valid irq.json in the tree
+    libopencm3_root = Path(__file__).parent.parent.resolve()
+    infile = Path(sys.argv[1]).resolve()
+    root_path = libopencm3_root.parts
+    infile_path = infile.parts[:len(root_path)]
+    # Check that the file is a irq.json and it exists
+    if root_path != infile_path or infile.name != 'irq.json' or not infile.exists():
         raise ValueError("Argument must match ./include/libopencm3/**/irq.json")
-    nvic_h = infile.replace('irq.json', 'nvic.h')
-    vector_nvic_c = infile.replace('./include/libopencm3/', './lib/').replace('irq.json', 'vector_nvic.c')
-    cmsis = infile.replace('irq.json', 'irqhandlers.h').replace('/libopencm3/', '/libopencmsis/')
+    # Now construct the paths to the new files
+    # Start by chopping off the 'irq.json' component
+    path_parts = infile.parts[:-1]
+    # Now iterate backwards till we find the index of 'include' before that
+    include_index = len(path_parts) - 1
+    while include_index > 0 and path_parts[include_index] != 'include':
+        include_index -= 1
+    # Having found the right start index, chop out the target name from the parts and construct a path segment
+    target = Path(*path_parts[include_index + 2:])
+    # Build the paths for all the output files
+    nvic_h = cwd / 'include' / 'libopencm3' / target / 'nvic.h'
+    vector_nvic_c = cwd / 'lib' / target / 'vector_nvic.c'
+    cmsis = cwd / 'include' / 'libopencmsis' / target / 'irqhandlers.h'
 
     if remove:
-        if os.path.exists(nvic_h):
-            os.unlink(nvic_h)
-        if os.path.exists(vector_nvic_c):
-            os.unlink(vector_nvic_c)
-        if os.path.exists(cmsis):
-            os.unlink(cmsis)
+        if nvic_h.exists():
+            nvic_h.unlink()
+        if vector_nvic_c.exists():
+            vector_nvic_c.unlink()
+        if cmsis.exists():
+            cmsis.unlink()
         sys.exit(0)
 
-    if not needs_update([__file__, infile], [nvic_h, vector_nvic_c]):
+    if not needs_update([Path(__file__), infile], [nvic_h, vector_nvic_c]):
         sys.exit(0)
 
     makeparentdir(nvic_h)
     makeparentdir(vector_nvic_c)
     makeparentdir(cmsis)
 
-    convert(open(infile), open(nvic_h, 'w'), open(vector_nvic_c, 'w'), open(cmsis, 'w'))
+    convert(infile.open('r'), nvic_h.open('w'), vector_nvic_c.open('w'), cmsis.open('w'))
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except ValueError as error:
+        print(error, file = sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
In this PR we add support for using the project with the Meson build system. While not a 100% complete port of the Makefile build system, this provides support for all the platforms BMD uses and a few extra we've had people like @northernpaws contribute to the fork project.

This is all tested working on the upstream project and should in theory simplify the CI rebuild process due to how Meson cross files work and operate.

Importantly, this does **not** replace the existing Makefile build system but is instead implemented in tandem with it to provide options for consumers of the project.