### PR TITLE
Feature: compute effective USART baudrate

### DIFF
--- a/include/libopencm3/lm4f/uart.h
+++ b/include/libopencm3/lm4f/uart.h
@@ -443,6 +443,7 @@ enum uart_fifo_tx_trigger_level {
 BEGIN_DECLS
 
 void uart_set_baudrate(uint32_t uart, uint32_t baud);
+uint32_t uart_get_baudrate(uint32_t uart);
 void uart_set_databits(uint32_t uart, uint8_t databits);
 uint8_t uart_get_databits(uint32_t uart);
 void uart_set_stopbits(uint32_t uart, uint8_t stopbits);

--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -99,6 +99,7 @@ specific memorymap.h header before including this header file.*/
 BEGIN_DECLS
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud);
+uint32_t usart_get_baudrate(uint32_t usart);
 void usart_set_databits(uint32_t usart, uint32_t bits);
 uint32_t usart_get_databits(uint32_t usart);
 void usart_set_stopbits(uint32_t usart, uint32_t stopbits);

--- a/lib/lm4f/uart.c
+++ b/lib/lm4f/uart.c
@@ -131,6 +131,25 @@ void uart_set_baudrate(uint32_t uart, uint32_t baud)
 }
 
 /**
+ * \brief Get UART baudrate
+ *
+ * @param[in] uart UART block register address base @ref uart_reg_base
+ * @return Baud rate in bits per second (bps)
+ */
+uint32_t uart_get_baudrate(uint32_t uart)
+{
+	/* Are we running off the internal clock or system clock? */
+	const uint32_t clock = UART_CC(uart) == UART_CC_CS_PIOSC ? 16000000U : rcc_get_system_clock_frequency();
+
+	/* Read back divisor parts. Baudrate = clock/16 / (ibrd+fbrd/64). */
+	const uint16_t ibrd = UART_IBRD(uart);
+	const uint16_t fbrd = UART_FBRD(uart);
+	uint32_t div = ibrd * 64U + fbrd;
+	/* Recalculate the actual baudrate. Note that 4 comes from 1/(16/64). */
+	return 4U * clock / div;
+}
+
+/**
  * \brief Set UART databits
  *
  * @param[in] uart UART block register address base @ref uart_reg_base


### PR DESCRIPTION
This adds a function, `usart_get_baudrate()`, to all STM32 USART IP, which allows confirming effective baudrate computed from usart_ker_ck and BRR. It may differ from previously requested `usart_set_baudrate()` because of integer prescalers.

Tested for 1 year https://github.com/blackmagic-debug/blackmagic/pull/1864 and merged in downstream https://github.com/blackmagic-debug/libopencm3/pull/5 and https://github.com/blackmagic-debug/libopencm3/pull/6, on STM32F103 and STM32F411, which additionally supports OVER8. Used to report UART-encoded SWO baudrate expected by Black Magic Probe (has to match DUT-transmitted SWO to about <2% precision).
LPUART tested on G071, not tested on G4/H7.
An implementation for TM4C123 UART (Arm PrimeCell PL011) is also provided to satisfy [downstream] CI, but I didn't test it myself, because I don't have a `launchpad-icdi` board. Other vendor MCU not considered.

Function requires 32-bit division, which incurs a libgcc `__udivsi3` library call on Cortex-M0 (like many clock-computing functions) i.e. F0/G0/L0/C0/U0. Function eliminated by linker when unused.