### PR TITLE
gadget0: Add WeActStudio.MiniSTM32F4x1 board

### DIFF
--- a/tests/gadget-zero/Makefile.stm32f411-generic
+++ b/tests/gadget-zero/Makefile.stm32f411-generic
@@ -1,0 +1,40 @@
+##
+## This file is part of the libopencm3 project.
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BOARD = stm32f411-generic
+PROJECT = usb-gadget0-$(BOARD)
+BUILD_DIR = bin-$(BOARD)
+
+SHARED_DIR = ../shared
+
+CFILES = main-$(BOARD).c
+CFILES += usb-gadget0.c trace.c trace_stdio.c
+CFILES += delay.c
+
+VPATH += $(SHARED_DIR)
+
+INCLUDES += $(patsubst %,-I%, . $(SHARED_DIR))
+
+OPENCM3_DIR=../..
+
+### This section can go to an arch shared rules eventually...
+DEVICE=stm32f411ce
+OOCD_FILE = openocd.$(BOARD).cfg
+
+include $(OPENCM3_DIR)/mk/genlink-config.mk
+include $(OPENCM3_DIR)/mk/genlink-rules.mk
+include ../rules.mk

--- a/tests/gadget-zero/main-stm32f411-generic.c
+++ b/tests/gadget-zero/main-stm32f411-generic.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/usb/dwc/otg_fs.h>
+
+#include <stdio.h>
+#include "usb-gadget0.h"
+
+#define ER_DEBUG
+#ifdef ER_DEBUG
+#define ER_DPRINTF(fmt, ...) \
+	do { printf(fmt, ## __VA_ARGS__); } while (0)
+#else
+#define ER_DPRINTF(fmt, ...) \
+	do { } while (0)
+#endif
+
+int main(void)
+{
+	rcc_clock_setup_pll(&rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_96MHZ]);
+	rcc_periph_clock_enable(RCC_GPIOA);
+	rcc_periph_clock_enable(RCC_OTGFS);
+
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
+	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
+
+	/* LED to indicate boot process */
+	rcc_periph_clock_enable(RCC_GPIOC);
+	gpio_mode_setup(GPIOC, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO13);
+	gpio_set(GPIOC, GPIO13);
+
+	/* https://github.com/libopencm3/libopencm3/pull/1256#issuecomment-779424001 */
+	OTG_FS_GCCFG |= OTG_GCCFG_NOVBUSSENS | OTG_GCCFG_PWRDWN;
+	OTG_FS_GCCFG &= ~(OTG_GCCFG_VBUSBSEN | OTG_GCCFG_VBUSASEN);
+
+	usbd_device *usbd_dev = gadget0_init(&otgfs_usb_driver, "stm32f411-generic");
+
+	ER_DPRINTF("bootup complete\n");
+	gpio_clear(GPIOC, GPIO13);
+	while (1) {
+		gadget0_run(usbd_dev);
+	}
+
+}
+


### PR DESCRIPTION
This adds another F4-based board to gadget zero test suite. Also known as `blackpill-f411ce` platform in Black Magic Debug sourcetree.

I believe the board is very suitable for HITL setups due to being cheaper, smaller than 32F407VG Discovery (MB997) and 32F429ZI Discovery (MB1075), because of UFQFN48 package and no onboard debugger/display/peripheral ICs. Hopefully this helps weed out remaining bugs in "USBOTG_FS" driver.
A 25MHz HSE into 96MHz Hclk PLL config is used, but be aware that 84MHz F401 chips could work with one line edited, too. The new 8MHz HSE board was not tested with this and would require a different line. Unsure if this works on Nucleo-F411RE, as it lacks an HSE and USB port (maybe its STLINK/V2-1 provides 8MHz via MCO?).

Trace is provided via in-tree ITM_Write8() to SWO pin PB3, a debugger is expected to configure it.
I'm not adding an `openocd.stm32f411ce.cfg` file because I don't use it, but if HITL requires it then I'll copy from something.

Tested in June of 2024. Copyright string might be wrong, inherited from f103-generic.