### PR TITLE
stm32/f2/f4 bug:dma: add missing volatile qualifiers

### DIFF
--- a/include/libopencm3/stm32/common/dma_common_f24.h
+++ b/include/libopencm3/stm32/common/dma_common_f24.h
@@ -152,7 +152,7 @@ specific memorymap.h header before including this header file.*/
 #define DMA2_S7NDTR			DMA2_SNDTR(7)
 
 /* DMA Stream x peripheral address register (DMA_SxPAR) */
-#define DMA_SPAR(port, n)		(*(volatile void **)\
+#define DMA_SPAR(port, n)		(*(volatile void * volatile *) \
 					 (DMA_STREAM((port), (n)) + 0x08))
 #define DMA1_SPAR(n)			DMA_SPAR(DMA1, (n))
 #define DMA2_SPAR(n)			DMA_SPAR(DMA2, (n))
@@ -176,7 +176,7 @@ specific memorymap.h header before including this header file.*/
 #define DMA2_S7PAR			DMA2_SPAR(7)
 
 /* DMA Stream x memory address 0 register (DMA_SxM0AR) */
-#define DMA_SM0AR(port, n)		(*(volatile void **) \
+#define DMA_SM0AR(port, n)		(*(volatile void * volatile *) \
 					 (DMA_STREAM((port), (n)) + 0x0c))
 #define DMA1_SM0AR(n)			DMA_SM0AR(DMA1, (n))
 #define DMA2_SM0AR(n)			DMA_SM0AR(DMA2, (n))
@@ -200,7 +200,7 @@ specific memorymap.h header before including this header file.*/
 #define DMA2_S7M0AR			DMA2_SM0AR(7)
 
 /* DMA Stream x memory address 1 register (DMA_SxM1AR) */
-#define DMA_SM1AR(port, n)		(*(volatile void **)\
+#define DMA_SM1AR(port, n)		(*(volatile void * volatile *) \
 					 (DMA_STREAM((port), (n)) + 0x10))
 #define DMA1_SM1AR(n)			DMA_SM1AR(DMA1, (n))
 #define DMA2_SM1AR(n)			DMA_SM1AR(DMA2, (n))


### PR DESCRIPTION
Found and fixed a bug in `libopencm3` for the STM32F2/4 DMA header definitions. The bug manifests as a miscompilation of the following abridged code at high optimization levels (`-O3`) using `arm-gcc`:

```c
static const uint16_t taps[16] = {
	1,  2,  3,  4,
	5,  6,  7,  8,
	9, 10, 11, 12,
	13, 14, 15,  0,
};

DMA2_S3CR   = 0;
DMA2_S3NDTR = NELEM(taps);
DMA2_S3PAR  = &TIM1_DMAR;
DMA2_S3M0AR = (void *) taps;
DMA2_S3CR
        = DMA_SxCR_CHSEL_6
        | DMA_SxCR_MINC
        | DMA_SxCR_CIRC
        | DMA_SxCR_DIR_MEM_TO_PERIPHERAL
        | DMA_SxCR_MSIZE_16BIT
        | DMA_SxCR_PSIZE_16BIT
        | DMA_SxCR_EN
        ;
```

This would work fine at `-O0` and `-O1`, but mysteriously fail at higher optimization levels.

I eventually tracked this down to a missing `volatile` qualifier in the definitions of `DMA_SPAR`, `DMA_SM0AR` and  `DMA_SM1AR`. These registers are currently defined as:

```c
#define DMA_SPAR(port, n)               (*(volatile void **)\
                                         (DMA_STREAM((port), (n)) + 0x08))
```

Meaning that they are the dereference of a pointer to a pointer to volatile void. The dereferenced pointer itself is not volatile.

The bug occurred when `DMA2_S3PAR` and `DMA2_S3M0AR` are used in the code snippet above. Because the registers are not volatile, the compiler is free to reorder the writes to them as it sees fit under the "as if" rule. The writes to these registers were being moved to beyond the final write to `DMA2_S3CR`, at which point the DMA engine is enabled and updates to those registers are blocked.

This can be proved by adding an optimization barrier, `__asm volatile("nop")`, before the final write to `DMA2_S3CR`. The code would then compile fine under all optimization levels.

The fix is to add an extra `volatile` qualifier on the double pointer as follows:

```c
#define DMA_SPAR(port, n)               (*(volatile void * volatile *) \
                                         (DMA_STREAM((port), (n)) + 0x08))
```

which is what this PR does.

Found, fixed and verified on an STM32F429ZI Nucleo board.