### PR TITLE
Add function to setup clock without PLL for STM32L0.

### DIFF
--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -714,6 +714,7 @@ void rcc_set_pll_source(uint32_t pllsrc);
 void rcc_set_ppre2(uint32_t ppre2);
 void rcc_set_ppre1(uint32_t ppre1);
 void rcc_set_hpre(uint32_t hpre);
+void rcc_clock_setup(const struct rcc_clock_scale *clock);
 void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
 
 void rcc_set_msi_range(uint32_t msi_range);

--- a/lib/stm32/l0/rcc.c
+++ b/lib/stm32/l0/rcc.c
@@ -572,6 +572,41 @@ uint32_t rcc_get_spi_clk_freq(uint32_t spi) {
 	}
 }
 
+/** @brief RCC Setup for given clock and use it as Sysclk source.
+ *
+ * @param[in] clock full struct with desired parameters
+ *
+ */
+void rcc_clock_setup(const struct rcc_clock_scale *clock)
+{
+	/* Turn on the appropriate source */
+	if (clock->pll_source == RCC_CFGR_PLLSRC_HSE_CLK) {
+		rcc_osc_on(RCC_HSE);
+		rcc_wait_for_osc_ready(RCC_HSE);
+	} else {
+		rcc_osc_on(RCC_HSI16);
+		rcc_wait_for_osc_ready(RCC_HSI16);
+	}
+
+	rcc_set_hpre(clock->hpre);
+	rcc_set_ppre1(clock->ppre1);
+	rcc_set_ppre2(clock->ppre2);
+
+	rcc_periph_clock_enable(RCC_PWR);
+	pwr_set_vos_scale(clock->voltage_scale);
+
+	flash_prefetch_enable();
+	flash_set_ws(clock->flash_waitstates);
+
+	rcc_set_sysclk_source(clock->pll_source);
+
+	/* Set the peripheral clock frequencies used. */
+	rcc_ahb_frequency = clock->ahb_frequency;
+	rcc_apb1_frequency = clock->apb1_frequency;
+	rcc_apb2_frequency = clock->apb2_frequency;
+}
+
+/**@}*/
 /** @brief RCC Setup PLL and use it as Sysclk source.
  *
  * @param[in] clock full struct with desired parameters


### PR DESCRIPTION
For.. reasons.. the PLL on my board does not work so I wrote this function to setup the clock without it.
It (ab)uses pll_source to in rcc_clock_scale but I think that is a minor sin.
