### PR TITLE
Add ARMv8-M.Main support (Cortex-M33)

### DIFF
--- a/include/libopencm3/cm3/itm.h
+++ b/include/libopencm3/cm3/itm.h
@@ -27,8 +27,8 @@
  */
 
 /* Those defined only on ARMv7 and above */
-#if !defined(__ARM_ARCH_7M__) && !defined(__ARM_ARCH_7EM__)
-#error "Instrumentation Trace Macrocell not available in CM0"
+#if !defined(__ARM_ARCH_7M__) && !defined(__ARM_ARCH_7EM__) && !defined(__ARM_ARCH_8M_MAIN__)
+#error "Instrumentation Trace Macrocell not available in CM0 or CM23"
 #endif
 
 /* --- ITM registers ------------------------------------------------------- */

--- a/include/libopencm3/cm3/memorymap.h
+++ b/include/libopencm3/cm3/memorymap.h
@@ -26,7 +26,7 @@
 #define PPBI_BASE                       (0xE0000000U)
 
 /* Those defined only on ARMv7 and above */
-#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__)
 /* ITM: Instrumentation Trace Macrocell */
 #define ITM_BASE                        (PPBI_BASE + 0x0000)
 

--- a/lib/usb/usb_dwc_common.c
+++ b/lib/usb/usb_dwc_common.c
@@ -240,7 +240,7 @@ uint16_t dwc_ep_write_packet(usbd_device *const usbd_dev, const uint8_t addr, co
 	const uint32_t *buf32 = buf;
 	/* Copy buffer to endpoint FIFO, note - memcpy does not work.
 	 * ARMv7M supports non-word-aligned accesses, ARMv6M does not. */
-#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__)
 	for (size_t i = 0; i < len; i += 4) {
 		REBASE(OTG_FIFO(ep)) = *buf32++;
 	}
@@ -293,7 +293,7 @@ uint16_t dwc_ep_read_packet(usbd_device *usbd_dev, uint8_t addr, void *buf, uint
 	int i = 0;
 	uint32_t *buf32 = buf;
 	/* ARMv7M supports non-word-aligned accesses, ARMv6M does not. */
-#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__)
 	for (i = len; i >= 4; i -= 4) {
 		*buf32++ = REBASE(OTG_FIFO(0));
 		usbd_dev->rxbcnt -= 4;


### PR DESCRIPTION
* libopencm3_stm32u5 leads to FTBFS in gadget-zero test (pending).
* This PR updates the macro guards for ITM to avoid a preprocessor error "Instrumentation Trace Macrocell not available in CM0" when compiling for STM32U5 which is Cortex-M33 and implements ARMv8-M.Main profile. There are DWT, ITM, and TPIU in it.
* There are lots more macro guards in /cm3/ for most PPB blocks, which have to do with ARMv6-M not implementing them. This does not block gadget0.
* Likewise, it updates similar macro guards in DWC2 driver so that the OTG_FS peripheral works faster (in endpoint read/write packet FIFO).