### PR TITLE
Add USB Gadget Zero test for generic STM32U575

### DIFF
--- a/tests/gadget-zero/Makefile.stm32u575-generic
+++ b/tests/gadget-zero/Makefile.stm32u575-generic
@@ -1,0 +1,40 @@
+##
+## This file is part of the libopencm3 project.
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BOARD = stm32u575-generic
+PROJECT = usb-gadget0-$(BOARD)
+BUILD_DIR = bin-$(BOARD)
+
+SHARED_DIR = ../shared
+
+CFILES = main-$(BOARD).c
+CFILES += usb-gadget0.c trace.c trace_stdio.c
+CFILES += delay.c
+
+VPATH += $(SHARED_DIR)
+
+INCLUDES += $(patsubst %,-I%, . $(SHARED_DIR))
+
+OPENCM3_DIR=../..
+
+### This section can go to an arch shared rules eventually...
+DEVICE=stm32u575ci
+OOCD_FILE = openocd.$(BOARD).cfg
+
+include $(OPENCM3_DIR)/mk/genlink-config.mk
+include $(OPENCM3_DIR)/mk/genlink-rules.mk
+include ../rules.mk

--- a/tests/gadget-zero/delay.c
+++ b/tests/gadget-zero/delay.c
@@ -32,6 +32,9 @@ void delay_setup(void)
 {
 	/* set up a microsecond free running timer for ... things... */
 	rcc_periph_clock_enable(RCC_TIM6);
+#if defined(STM32U5)
+	const uint32_t rcc_apb1_frequency = rcc_get_bus_clk_freq(RCC_APB1CLK);
+#endif
 	/* microsecond counter */
 	timer_set_prescaler(TIM6, rcc_apb1_frequency / 1000000 - 1);
 	timer_set_period(TIM6, 0xffff);

--- a/tests/gadget-zero/main-stm32u575-generic.c
+++ b/tests/gadget-zero/main-stm32u575-generic.c
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/usb/dwc/otg_fs.h>
+
+#include <stdio.h>
+#include "usb-gadget0.h"
+
+#define ER_DEBUG
+#ifdef ER_DEBUG
+#define ER_DPRINTF(fmt, ...) \
+	do { printf(fmt, ## __VA_ARGS__); } while (0)
+#else
+#define ER_DPRINTF(fmt, ...) \
+	do { } while (0)
+#endif
+
+int main(void)
+{
+	rcc_clock_setup_hsi(&rcc_hsi16mhz_configs);
+	rcc_osc_on(RCC_HSI48);
+	while (!rcc_is_osc_ready(RCC_HSI48));
+	crs_autotrim_usb_enable();
+	rcc_periph_clock_enable(RCC_GPIOA);
+	rcc_periph_clock_enable(RCC_OTGFS);
+
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
+	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
+
+	/* LED to indicate boot process */
+	rcc_periph_clock_enable(RCC_GPIOC);
+	gpio_mode_setup(GPIOC, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO13);
+	gpio_set(GPIOC, GPIO13);
+
+	usbd_device *usbd_dev = gadget0_init(&otgfs_usb_driver, "stm32u575-generic");
+	/* Disable Vbus detection */
+	OTG_FS_GCCFG &= ~(OTG_GCCFG_VBDEN);
+
+	ER_DPRINTF("bootup complete\n");
+	gpio_clear(GPIOC, GPIO13);
+	while (1) {
+		gadget0_run(usbd_dev);
+	}
+
+}
+

--- a/tests/gadget-zero/main-stm32u575-generic.c
+++ b/tests/gadget-zero/main-stm32u575-generic.c
@@ -20,6 +20,7 @@
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/crs.h>
 #include <libopencm3/usb/dwc/otg_fs.h>
 
 #include <stdio.h>

--- a/tests/gadget-zero/main-stm32u575-generic.c
+++ b/tests/gadget-zero/main-stm32u575-generic.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the libopencm3 project.
  *
- * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ * Copyright (C) 2025 ALTracer <11005378+ALTracer@users.noreply.github.com>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/tests/gadget-zero/main-stm32u575-generic.c
+++ b/tests/gadget-zero/main-stm32u575-generic.c
@@ -21,6 +21,7 @@
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/crs.h>
+#include <libopencm3/stm32/pwr.h>
 #include <libopencm3/usb/dwc/otg_fs.h>
 
 #include <stdio.h>
@@ -38,6 +39,7 @@
 #define OTG_GOTGCTL_BVALOVAL		(1U << 7U)
 #define OTG_GOTGCTL_BVALOEN		(1U << 6U)
 
+#ifndef PWR_SVMCR_USV
 // #include <libopencm3/stm32/u5/pwr.h>
 #define PWR_SVMCR		MMIO32(PWR_BASE + 0x10)
 #define PWR_SVMSR		MMIO32(PWR_BASE + 0x3C)
@@ -46,6 +48,7 @@
 #define PWR_SVMCR_UVMEN		(1U << 24U)
 
 #define PWR_SVMSR_VDDUSBRDY		(1U << 24U)
+#endif
 
 int main(void)
 {
@@ -66,9 +69,13 @@ int main(void)
 
 	/* Remove Vddusb power isolation */
 	rcc_periph_clock_enable(RCC_PWR);
+#if 0
 	PWR_SVMCR |= PWR_SVMCR_USV;
 	uint32_t pwr_svmsr = PWR_SVMSR;
 	(void) (pwr_svmsr & PWR_SVMSR_VDDUSBRDY);
+#else
+	pwr_enable_vddusb();
+#endif
 
 	usbd_device *usbd_dev = gadget0_init(&otgfs_usb_driver, "stm32u575-generic");
 	/* Disable Vbus detection and override B-session valid */

--- a/tests/gadget-zero/main-stm32u575-generic.c
+++ b/tests/gadget-zero/main-stm32u575-generic.c
@@ -59,6 +59,8 @@ int main(void)
 	pwr_enable_vddusb();
 
 	usbd_device *usbd_dev = gadget0_init(&otgfs_usb_driver, "stm32u575-generic");
+	/* Adjust TRDT to 15-16MHz AHB, force device mode */
+	OTG_FS_GUSBCFG = OTG_GUSBCFG_FDMOD | ((0xeU << 10U) & OTG_GUSBCFG_TRDT_MASK);
 	/* Disable Vbus detection and override B-session valid */
 	uint32_t core_id = OTG_FS_CID;
 	if (core_id >= 0x2000) {

--- a/tests/gadget-zero/main-stm32u575-generic.c
+++ b/tests/gadget-zero/main-stm32u575-generic.c
@@ -39,25 +39,12 @@
 #define OTG_GOTGCTL_BVALOVAL		(1U << 7U)
 #define OTG_GOTGCTL_BVALOEN		(1U << 6U)
 
-#ifndef PWR_SVMCR_USV
-// #include <libopencm3/stm32/u5/pwr.h>
-#define PWR_SVMCR		MMIO32(PWR_BASE + 0x10)
-#define PWR_SVMSR		MMIO32(PWR_BASE + 0x3C)
-
-#define PWR_SVMCR_USV		(1U << 28U)
-#define PWR_SVMCR_UVMEN		(1U << 24U)
-
-#define PWR_SVMSR_VDDUSBRDY		(1U << 24U)
-#endif
-
 int main(void)
 {
 	rcc_clock_setup_hsi(&rcc_hsi16mhz_configs);
-	rcc_osc_on(RCC_HSI48);
-	while (!rcc_is_osc_ready(RCC_HSI48));
+	rcc_clock_setup_hsi48();
 	crs_autotrim_usb_enable();
 	rcc_periph_clock_enable(RCC_GPIOA);
-	//rcc_periph_clock_enable(RCC_OTGFS);
 
 	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
 	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
@@ -69,13 +56,7 @@ int main(void)
 
 	/* Remove Vddusb power isolation */
 	rcc_periph_clock_enable(RCC_PWR);
-#if 0
-	PWR_SVMCR |= PWR_SVMCR_USV;
-	uint32_t pwr_svmsr = PWR_SVMSR;
-	(void) (pwr_svmsr & PWR_SVMSR_VDDUSBRDY);
-#else
 	pwr_enable_vddusb();
-#endif
 
 	usbd_device *usbd_dev = gadget0_init(&otgfs_usb_driver, "stm32u575-generic");
 	/* Disable Vbus detection and override B-session valid */


### PR DESCRIPTION
* STM32U575/U585 contains a USBOTG_FS peripheral with internal FS PHY, but it is different enough that it does not work out-of-the-box with existing drivers. U59x/U5Ax and U5Fx/U5Gx boast HS, that's not handled. U535/U545 contain a different USB FS host/device peripheral (like STM32G0B1 probably), that's not handled.
* Add a minimal gadget0 main.c and Makefile to be able to test driver changes (license/copyright is probably wrong again).
* Incorporate required PWR->SVMCR and OTG_FS->GCCFG, OTG_FS->GOTGCTL reg pokes in it, so that USB PHY power is enabled, and Vbus detection for B-session valid is disabled/forced valid (no resistive divider between PA9 and Vbus).

TIM6 microsecond delay works, ITM/SWO likely works, HSI48/CRS works, Hclk is default HSI16 (no PLL support yet).
I can refactor some of the code once you tell me what form it should conform to. Note there's more endpoints and FIFO space, too, but test_gadget0.py passes already. Performance is not representative of max capabilities because of delay_us(100), slow memset from newlib-nano, slow Hclk (HSI16) with disabled ICACHE, and ITM-related function calls everywhere. 386/225 kps otherwise becomes 749/511 kps.
Tested on https://github.com/WeActStudio/WeActStudio.STM32U585Cx_CoreBoard
Depends on #1610, #1611.

```
Running (user) tests for DUT:  stm32u575-generic
...............ss....................
----------------------------------------------------------------------
Ran 37 tests in 0.463s

OK (skipped=2)
Running (user) tests for DUT:  stm32u575-generic
...............read 5324800 bytes in 0:00:13.468740 for 386.0791729590147 kps
.wrote 5324800 bytes in 0:00:23.054369 for 225.55377681341005 kps
.....................
----------------------------------------------------------------------
Ran 37 tests in 36.921s

OK
```