### PR TITLE
Change PLL source from HSI to HSE

### DIFF
--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -1130,7 +1130,7 @@ void rcc_clock_setup_in_hse_16mhz_out_72mhz(void)
 	 */
 	rcc_set_pll_multiplication_factor(RCC_CFGR_PLLMUL_PLL_CLK_MUL9);
 
-	/* Select HSI as PLL source. */
+	/* Select HSE as PLL source. */
 	rcc_set_pll_source(RCC_CFGR_PLLSRC_HSE_CLK);
 
 	/*


### PR DESCRIPTION
Fixed the comment in stm32\\f1\\rcc.c describing where HSE is used but HSI is commented.