### PR TITLE
stm32: g0: Fix FLASH_CR_PNB_MASK for devices with >64 pages per bank

### DIFF
--- a/include/libopencm3/stm32/g0/flash.h
+++ b/include/libopencm3/stm32/g0/flash.h
@@ -153,7 +153,7 @@
 #define FLASH_CR_STRT		(1 << 16)
 
 #define FLASH_CR_PNB_SHIFT		3
-#define FLASH_CR_PNB_MASK		0x3f
+#define FLASH_CR_PNB_MASK		0x3ff
 
 /** FLASH_CR_MER Mass erase **/
 #define FLASH_CR_MER			(1 << 2)


### PR DESCRIPTION
The page number mask was set to 0x3F (6 bits) which only supports page numbers 0-63. STM32G0B1 and similar devices have 128 pages per bank, requiring a larger mask, now changed to 0x3FF

This bug caused page number wraparound when erasing pages >= 64, resulting in unintended erasure of lower-numbered pages. For example, attempting to erase page 64 would actually erase page 0 (64 & 0x3F = 0).

Tested on STM32G0B1RE (Nucleo-G0B1RE board) with 128 pages per bank.

Related: https://github.com/stlink-org/stlink/issues/1321