### PR TITLE
stm32/l0: Export HSI clock configuration presets in header

### DIFF
--- a/include/libopencm3/stm32/l0/rcc.h
+++ b/include/libopencm3/stm32/l0/rcc.h
@@ -549,6 +549,7 @@ struct rcc_clock_scale {
 extern uint32_t rcc_ahb_frequency;
 extern uint32_t rcc_apb1_frequency;
 extern uint32_t rcc_apb2_frequency;
+extern const struct rcc_clock_scale rcc_hsi_configs[];
 
 /* --- Function prototypes ------------------------------------------------- */
 


### PR DESCRIPTION
This PR is a follow-up to the recent STM32L0 HSI clock implementation.

It adds the extern declaration for rcc_hsi_configs to the public header file (rcc.h), allowing the presets to be visible and usable from application code. Without this declaration, the configurations remain internal to the library's implementation.