### PR TITLE
Fix: st_usbfs_v2 data copy from packet memory

### DIFF
--- a/lib/stm32/st_usbfs_v2.c
+++ b/lib/stm32/st_usbfs_v2.c
@@ -63,28 +63,34 @@ void st_usbfs_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
  * @param vPM Source pointer into packet memory.
  * @param len Number of bytes to copy.
  */
-void st_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
+void st_usbfs_copy_from_pm(void *const buf, const volatile void *vPM, const uint16_t len)
 {
-	const volatile uint16_t *PM = vPM;
-	uint8_t odd = len & 1;
-	len >>= 1;
+	const volatile uint16_t *packet_memory = vPM;
+	const size_t blocks = len >> 1U;
 
-	if (((uintptr_t)buf) & 0x01) {
-		uint8_t *dest = (uint8_t *)buf;
-		for (; len; PM++, len--) {
-			uint16_t value = *PM;
-			*(uint8_t *)dest++ = value;
-			*(uint8_t *)dest++ = value >> 8;
+	/* If the buffer to write into is at an unaligned address for uint16_t access */
+	if (((uintptr_t)buf) & 0x01U) {
+		uint8_t *const dest = (uint8_t *)buf;
+		for (size_t idx = 0; idx < blocks; ++idx, ++packet_memory) {
+			/* Extract the next data block from packet memory */
+			uint16_t value = *packet_memory;
+			/* Copy it into the output buffer byte at a time to handle the misalignment */
+			dest[(idx << 1U) + 0U] = value;
+			dest[(idx << 1U) + 1U] = value >> 8;
 		}
 	} else {
-		uint16_t *dest = (uint16_t *)buf;
-		for (; len; PM++, dest++, len--) {
-			*dest = *PM;
+		/* The buffer to write into is aligned, so do things the easy way */
+		uint16_t *const dest = (uint16_t *)buf;
+		for (size_t idx = 0; idx < blocks; ++idx, ++packet_memory) {
+			/* Extract the next data block from packet memory and stuff it into the output buffer */
+			dest[idx] = *packet_memory;
 		}
 	}
 
-	if (odd) {
-		*(uint8_t *)buf = *(uint8_t *)PM;
+	/* If the number of bytes needed is not a full number of packet memory blocks, handle the odd byte out */
+	if (len & 1U) {
+		uint8_t *const dest = (uint8_t *)buf;
+		dest[blocks << 1U] = *(uint8_t *)packet_memory;
 	}
 }
 

--- a/lib/stm32/st_usbfs_v2.c
+++ b/lib/stm32/st_usbfs_v2.c
@@ -36,8 +36,7 @@ static usbd_device *st_usbfs_v2_usbd_init(void)
 	SET_REG(USB_ISTR_REG, 0);
 
 	/* Enable RESET, SUSPEND, RESUME and CTR interrupts. */
-	SET_REG(USB_CNTR_REG, USB_CNTR_RESETM | USB_CNTR_CTRM |
-		USB_CNTR_SUSPM | USB_CNTR_WKUPM);
+	SET_REG(USB_CNTR_REG, USB_CNTR_RESETM | USB_CNTR_CTRM | USB_CNTR_SUSPM | USB_CNTR_WKUPM);
 	SET_REG(USB_BCDR_REG, USB_BCDR_DPPU);
 	return &st_usbfs_dev;
 }
@@ -49,10 +48,9 @@ void st_usbfs_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
 	 * that don't support unaligned accesses.
 	 */
 	const uint8_t *lbuf = buf;
-	volatile uint16_t *PM = vPM;
-	uint32_t i;
-	for (i = 0; i < len; i += 2) {
-		*PM++ = (uint16_t)lbuf[i+1] << 8 | lbuf[i];
+	volatile uint16_t *const packet_memory = vPM;
+	for (size_t idx = 0; idx < len; idx += 2) {
+		packet_memory[idx >> 1U] = ((uint16_t)lbuf[idx + 1U] << 8U) | lbuf[idx];
 	}
 }
 


### PR DESCRIPTION
In this PR we address the bug identified in #1631 caused by a buffer mishandling mistake in the code used to unload packets from the ST USB controller's packet memory.

What's surprising is that this hadn't bitten BMD yet, despite having a high probability of firing.

Fixes #1631