### PR TITLE
Feature: ST USBFS driver cleanup

### DIFF
--- a/lib/stm32/st_usbfs_v1.c
+++ b/lib/stm32/st_usbfs_v1.c
@@ -71,17 +71,17 @@ void st_usbfs_copy_to_pm(volatile void *const vPM, const void *const buf, const 
  * @param vPM Destination pointer into packet memory.
  * @param len Number of bytes to copy.
  */
-void st_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
+void st_usbfs_copy_from_pm(void *const buf, const volatile void *const vPM, const uint16_t len)
 {
-	uint16_t *lbuf = buf;
-	const volatile uint16_t *PM = vPM;
-	uint8_t odd = len & 1;
+	uint16_t *const dest = buf;
+	const volatile uint16_t *const packet_memory = vPM;
+	const size_t blocks = len >> 1U;
 
-	for (len >>= 1; len; PM += 2, lbuf++, len--) {
-		*lbuf = *PM;
+	for (size_t idx = 0; idx < blocks; ++idx) {
+		dest[idx] = packet_memory[idx << 1U];
 	}
 
-	if (odd) {
-		*(uint8_t *) lbuf = *(uint8_t *) PM;
+	if (len & 1U) {
+		*(uint8_t *)(dest + blocks) = packet_memory[blocks << 1U];
 	}
 }

--- a/lib/stm32/st_usbfs_v1.c
+++ b/lib/stm32/st_usbfs_v1.c
@@ -50,17 +50,17 @@ static usbd_device *st_usbfs_v1_usbd_init(void)
 	SET_REG(USB_ISTR_REG, 0);
 
 	/* Enable RESET, SUSPEND, RESUME and CTR interrupts. */
-	SET_REG(USB_CNTR_REG, USB_CNTR_RESETM | USB_CNTR_CTRM |
-		USB_CNTR_SUSPM | USB_CNTR_WKUPM);
+	SET_REG(USB_CNTR_REG, USB_CNTR_RESETM | USB_CNTR_CTRM | USB_CNTR_SUSPM | USB_CNTR_WKUPM);
 	return &st_usbfs_dev;
 }
 
-void st_usbfs_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
+void st_usbfs_copy_to_pm(volatile void *const vPM, const void *const buf, const uint16_t len)
 {
-	const uint16_t *lbuf = buf;
-	volatile uint32_t *PM = vPM;
-	for (len = (len + 1) >> 1; len; len--) {
-		*PM++ = *lbuf++;
+	const uint16_t *const src = buf;
+	volatile uint32_t *const packet_memory = vPM;
+	const size_t blocks = (len + 1U) >> 1U;
+	for (size_t idx = 0U; idx < blocks; ++idx) {
+		packet_memory[idx] = src[idx];
 	}
 }
 

--- a/lib/stm32/st_usbfs_v2.c
+++ b/lib/stm32/st_usbfs_v2.c
@@ -61,17 +61,17 @@ void st_usbfs_copy_to_pm(volatile void *const vPM, const void *const buf, const 
  * @param vPM Source pointer into packet memory.
  * @param len Number of bytes to copy.
  */
-void st_usbfs_copy_from_pm(void *const buf, const volatile void *vPM, const uint16_t len)
+void st_usbfs_copy_from_pm(void *const buf, const volatile void *const vPM, const uint16_t len)
 {
-	const volatile uint16_t *packet_memory = vPM;
+	const volatile uint16_t *const packet_memory = vPM;
 	const size_t blocks = len >> 1U;
 
 	/* If the buffer to write into is at an unaligned address for uint16_t access */
 	if (((uintptr_t)buf) & 0x01U) {
 		uint8_t *const dest = (uint8_t *)buf;
-		for (size_t idx = 0; idx < blocks; ++idx, ++packet_memory) {
+		for (size_t idx = 0U; idx < blocks; ++idx) {
 			/* Extract the next data block from packet memory */
-			uint16_t value = *packet_memory;
+			const uint16_t value = packet_memory[idx];
 			/* Copy it into the output buffer byte at a time to handle the misalignment */
 			dest[(idx << 1U) + 0U] = value;
 			dest[(idx << 1U) + 1U] = value >> 8;
@@ -79,16 +79,16 @@ void st_usbfs_copy_from_pm(void *const buf, const volatile void *vPM, const uint
 	} else {
 		/* The buffer to write into is aligned, so do things the easy way */
 		uint16_t *const dest = (uint16_t *)buf;
-		for (size_t idx = 0; idx < blocks; ++idx, ++packet_memory) {
+		for (size_t idx = 0U; idx < blocks; ++idx) {
 			/* Extract the next data block from packet memory and stuff it into the output buffer */
-			dest[idx] = *packet_memory;
+			dest[idx] = packet_memory[idx];
 		}
 	}
 
 	/* If the number of bytes needed is not a full number of packet memory blocks, handle the odd byte out */
 	if (len & 1U) {
 		uint8_t *const dest = (uint8_t *)buf;
-		dest[blocks << 1U] = *(uint8_t *)packet_memory;
+		dest[blocks << 1U] = packet_memory[blocks];
 	}
 }
 

--- a/lib/stm32/st_usbfs_v2.c
+++ b/lib/stm32/st_usbfs_v2.c
@@ -41,16 +41,16 @@ static usbd_device *st_usbfs_v2_usbd_init(void)
 	return &st_usbfs_dev;
 }
 
-void st_usbfs_copy_to_pm(volatile void *vPM, const void *buf, uint16_t len)
+void st_usbfs_copy_to_pm(volatile void *const vPM, const void *const buf, const uint16_t len)
 {
 	/*
 	 * This is a bytewise copy, so it always works, even on CM0(+)
 	 * that don't support unaligned accesses.
 	 */
-	const uint8_t *lbuf = buf;
+	const uint8_t *const src = buf;
 	volatile uint16_t *const packet_memory = vPM;
 	for (size_t idx = 0; idx < len; idx += 2) {
-		packet_memory[idx >> 1U] = ((uint16_t)lbuf[idx + 1U] << 8U) | lbuf[idx];
+		packet_memory[idx >> 1U] = ((uint16_t)src[idx + 1U] << 8U) | src[idx];
 	}
 }
 


### PR DESCRIPTION
In this PR we apply some code quality improvements and general cleanup of the packet memory management code for both ST USB controller drivers to bring them both up to the same code quality and pointer arithmetic cleanliness standard.

Tested on BMPv2 for the v1 driver. The v2 driver has no functional changes and thus should remain the same as in PR #1632.