### PR TITLE
Fix: USB DWC2 on ARMv6

### DIFF
--- a/lib/usb/usb_dwc_common.c
+++ b/lib/usb/usb_dwc_common.c
@@ -265,7 +265,7 @@ uint16_t dwc_ep_write_packet(
 		for (size_t offset = 0U; offset < aligned_length; offset += 4U) {
 			uint32_t data;
 			memcpy(&data, buffer8 + offset, 4U);
-			REBASE(OTG_FIFO(0U)) = data;
+			REBASE(OTG_FIFO(ep)) = data;
 		}
 	}
 #endif


### PR DESCRIPTION
This PR fixes a bug identified by ALTracer where the transmit endpoint packet enqueue function would only work for EP0 on ARMv6 devices due to a copypasta mistake in the data queueing function.