### PR TITLE
compilation fixes USB for stm32 H7

### DIFF
--- a/include/libopencm3/stm32/h7/rcc.h
+++ b/include/libopencm3/stm32/h7/rcc.h
@@ -441,8 +441,6 @@ LGPL License Terms @ref lgpl_license
 
 #define RCC_HSI_BASE_FREQUENCY              64000000UL
 
-extern uint32_t rcc_ahb_frequency;
-
 /** Enumerations for core system/bus clocks for user/driver/system access to base bus clocks
   * not directly associated with a peripheral. */
 enum rcc_clock_source {

--- a/include/libopencm3/stm32/h7/rcc.h
+++ b/include/libopencm3/stm32/h7/rcc.h
@@ -441,6 +441,8 @@ LGPL License Terms @ref lgpl_license
 
 #define RCC_HSI_BASE_FREQUENCY              64000000UL
 
+extern uint32_t rcc_ahb_frequency;
+
 /** Enumerations for core system/bus clocks for user/driver/system access to base bus clocks
   * not directly associated with a peripheral. */
 enum rcc_clock_source {
@@ -498,10 +500,10 @@ enum rcc_periph_clken {
 	RCC_ETH1MAC     = _REG_BIT(0xD8, 15),
 	RCC_ETH1TX      = _REG_BIT(0xD8, 16),
 	RCC_ETH1RX      = _REG_BIT(0xD8, 17),
-	RCC_USB2OTGHSULPI = _REG_BIT(0xD8, 18),
 	RCC_USB1OTGHS   = _REG_BIT(0xD8, 25),
 	RCC_USB1OTGHSULPI = _REG_BIT(0xD8, 26),
-	RCC_USB2OTGHS  = _REG_BIT(0xD8, 27),
+	RCC_USB2OTGHS   = _REG_BIT(0xD8, 27),
+	RCC_USB2OTGHSULPI = _REG_BIT(0xD8, 28),
 
 	/* AHB2 peripherals */
 	RCC_DCMI        = _REG_BIT(0xDC, 0),

--- a/include/libopencm3/usb/dwc/otg_fs.h
+++ b/include/libopencm3/usb/dwc/otg_fs.h
@@ -28,8 +28,11 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_FS_BASE address */
-#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4) || defined(STM32F7) || defined(STM32L4) || defined(STM32U5)
+#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4) || defined(STM32F7) || defined(STM32L4) || defined(STM32U5) || defined(STM32H7)
 #	include <libopencm3/stm32/memorymap.h>
+#if defined(STM32H7)
+#define USB_OTG_FS_BASE USB2_OTG_FS_BASE
+#endif
 #elif defined(EFM32HG)
 #	include <libopencm3/efm32/memorymap.h>
 #else

--- a/include/libopencm3/usb/dwc/otg_hs.h
+++ b/include/libopencm3/usb/dwc/otg_hs.h
@@ -28,8 +28,11 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_HS_BASE address */
-#if defined(STM32F2) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32U5)
+#if defined(STM32F2) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32U5) || defined(STM32H7)
 #	include <libopencm3/stm32/memorymap.h>
+#if defined(STM32H7)
+#define USB_OTG_HS_BASE USB1_OTG_HS_BASE
+#endif
 #else
 #	error "device family not supported by dwc/otg_hs."
 #endif

--- a/lib/stm32/h7/rcc.c
+++ b/lib/stm32/h7/rcc.c
@@ -15,6 +15,9 @@
 #define HZ_PER_MHZ		 	1000000UL
 #define HZ_PER_KHZ			1000UL
 
+
+uint32_t rcc_ahb_frequency = 96000000;
+
 /* Local private copy of the clock configuration for providing user with clock tree data. */
 static struct {
 	uint32_t sysclk;
@@ -182,6 +185,18 @@ static void rcc_clock_setup_domain3(const struct rcc_pll_config *config)
 		rcc_prediv_3bit_log_div(rcc_clock_tree.hclk, config->ppre4);
 }
 
+static void rcc_clock_setup_cfgr(uint8_t sysclock_src, uint8_t sysclock_sws)
+{
+	uint32_t cfgr_sws = ((RCC_CFGR >> RCC_CFGR_SWS_SHIFT) & RCC_CFGR_SWS_MASK);
+	if (cfgr_sws != sysclock_sws) {
+		/* Domains dividers are all configured, now we can switchover to PLL. */
+		RCC_CFGR = (RCC_CFGR & ~(RCC_CFGR_SW_MASK << RCC_CFGR_SW_SHIFT)) | (sysclock_src << RCC_CFGR_SW_SHIFT);
+		while (cfgr_sws != sysclock_sws) {
+			cfgr_sws = ((RCC_CFGR >> RCC_CFGR_SWS_SHIFT) & RCC_CFGR_SWS_MASK);
+		}
+	}
+}
+
 void rcc_clock_setup_pll(const struct rcc_pll_config *config)
 {
 	/* First, set system clock to utilize HSI, then disable all but HSI. */
@@ -223,11 +238,16 @@ void rcc_clock_setup_pll(const struct rcc_pll_config *config)
 
 	/* TODO: Configure custom kernel mappings. */
 
-	/* Domains dividers are all configured, now we can switchover to PLL. */
-	RCC_CFGR |= RCC_CFGR_SW_PLL1;
-	uint32_t cfgr_sws = ((RCC_CFGR >> RCC_CFGR_SWS_SHIFT) & RCC_CFGR_SWS_MASK);
-	while (cfgr_sws != RCC_CFGR_SWS_PLL1) {
-		cfgr_sws = ((RCC_CFGR >> RCC_CFGR_SWS_SHIFT) & RCC_CFGR_SWS_MASK);
+	switch (config->sysclock_source) {
+	case RCC_PLL:
+		rcc_clock_setup_cfgr(RCC_CFGR_SW_PLL1, RCC_CFGR_SWS_PLL1);
+		break;
+	case RCC_HSE:
+		rcc_clock_setup_cfgr(RCC_CFGR_SW_HSE, RCC_CFGR_SWS_HSE);
+		break;
+	default:
+		cm3_assert_not_reached();
+		return;
 	}
 }
 

--- a/lib/stm32/h7/rcc.c
+++ b/lib/stm32/h7/rcc.c
@@ -15,9 +15,6 @@
 #define HZ_PER_MHZ		 	1000000UL
 #define HZ_PER_KHZ			1000UL
 
-
-uint32_t rcc_ahb_frequency = 96000000;
-
 /* Local private copy of the clock configuration for providing user with clock tree data. */
 static struct {
 	uint32_t sysclk;
@@ -189,7 +186,7 @@ static void rcc_clock_setup_cfgr(uint8_t sysclock_src, uint8_t sysclock_sws)
 {
 	uint32_t cfgr_sws = ((RCC_CFGR >> RCC_CFGR_SWS_SHIFT) & RCC_CFGR_SWS_MASK);
 	if (cfgr_sws != sysclock_sws) {
-		/* Domains dividers are all configured, now we can switchover to PLL. */
+		/* Switch to the requested system clock and monitor for the switch-over to complete. */
 		RCC_CFGR = (RCC_CFGR & ~(RCC_CFGR_SW_MASK << RCC_CFGR_SW_SHIFT)) | (sysclock_src << RCC_CFGR_SW_SHIFT);
 		while (cfgr_sws != sysclock_sws) {
 			cfgr_sws = ((RCC_CFGR >> RCC_CFGR_SWS_SHIFT) & RCC_CFGR_SWS_MASK);
@@ -244,6 +241,9 @@ void rcc_clock_setup_pll(const struct rcc_pll_config *config)
 		break;
 	case RCC_HSE:
 		rcc_clock_setup_cfgr(RCC_CFGR_SW_HSE, RCC_CFGR_SWS_HSE);
+		break;
+	case RCC_HSI:
+		rcc_clock_setup_cfgr(RCC_CFGR_SW_HSI, RCC_CFGR_SWS_HSI);
 		break;
 	default:
 		cm3_assert_not_reached();


### PR DESCRIPTION
An initial set of changes to be able to compile libopencm3 with USB support on STM32 Nucleo H753ZI (for BlackMagic).