### PR TITLE
gd32/f1x0: Complete the GD32F1x0 family port

### DIFF
--- a/include/libopencm3/gd32/f1x0/adc.h
+++ b/include/libopencm3/gd32/f1x0/adc.h
@@ -1,0 +1,42 @@
+/** @defgroup adc_defines ADC Defines
+ *
+ * @brief <b>Defined Constants and Types for the GD32F1x0 ADC</b>
+ *
+ * @ingroup GD32F1x0_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* GD32F1x0 ADC uses the *STM32F1-style v1 layout* (RSQ0/RSQ1/RSQ2 sequence
+ * registers, SAMPT0/SAMPT1 per-channel sample times, two-step
+ * RSTCLB+CLB calibration). It does NOT match libopencm3's stm32/f0 ADC
+ * (the v2 layout with CHSELR/SMPR). See decisions/v0.2/ADC.md.
+ *
+ * Forwarding to stm32/f1/adc.h, which provides the v1 family-specific
+ * defines (ADC_JOFR*, ADC_HTR/LTR, ADC_SQR1-3) plus pulls in
+ * adc_common_v1.h for the shared functions (adc_set_regular_sequence,
+ * adc_set_sample_time, adc_calibrate, etc.).
+ *
+ * NOTE: no header guard here on purpose. stm32/f1/adc.h has its own
+ * LIBOPENCM3_ADC_H guard, and a duplicate on this side would no-op the
+ * include.
+ */
+#include <libopencm3/stm32/f1/adc.h>

--- a/include/libopencm3/gd32/f1x0/dma.h
+++ b/include/libopencm3/gd32/f1x0/dma.h
@@ -1,0 +1,38 @@
+/** @defgroup dma_defines DMA Defines
+ *
+ * @brief <b>Defined Constants and Types for the GD32F1x0 DMA Controller</b>
+ *
+ * @ingroup GD32F1x0_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_DMA_H
+#define LIBOPENCM3_DMA_H
+
+/* GD32F1x0 DMA is register-compatible with the STM32 L1/F0/F1/F3 DMA
+ * controller (the dma_common_l1f013 family). GD numbers channels from 0
+ * while libopencm3 numbers from 1; the underlying registers are at the
+ * same offsets. Validated by regtrace v0.2 (decisions/v0.2/DMA.md).
+ */
+#include <libopencm3/stm32/common/dma_common_l1f013.h>
+
+#endif

--- a/include/libopencm3/gd32/f1x0/i2c.h
+++ b/include/libopencm3/gd32/f1x0/i2c.h
@@ -1,0 +1,19 @@
+/** @defgroup i2c_defines I2C Defines
+ *
+ * @brief <b>Defined Constants and Types for the GD32F1x0 I2C</b>
+ *
+ * @ingroup GD32F1x0_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * GD32F1x0 I2C uses the *STM32F1-style v1 layout* (CTL0/CTL1 + CKCFG +
+ * RT registers; not the v2 TIMINGR-based layout used by stm32/f0). See
+ * decisions/v0.2/I2C.md. Forward to stm32/f1/i2c.h. No header guard on
+ * this side — the forwarded file has its own.
+ */
+#include <libopencm3/stm32/f1/i2c.h>

--- a/include/libopencm3/gd32/f1x0/iwdg.h
+++ b/include/libopencm3/gd32/f1x0/iwdg.h
@@ -1,0 +1,38 @@
+/** @defgroup iwdg_defines IWDG Defines
+ *
+ * @brief <b>Defined Constants and Types for the GD32F1x0 Independent Watchdog
+ * Timer</b>
+ *
+ * @ingroup GD32F1x0_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_IWDG_H
+#define LIBOPENCM3_IWDG_H
+
+/* GD32F1x0 IWDG (vendor name FWDGT) is register-compatible with the STM32F0
+ * IWDG including the window-mode register (WINR). Verified empirically by
+ * regtrace v0.2 (see decisions/v0.2/IWDG.md in the regtrace repo).
+ */
+#include <libopencm3/stm32/common/iwdg_common_v2.h>
+
+#endif

--- a/include/libopencm3/gd32/f1x0/meson.build
+++ b/include/libopencm3/gd32/f1x0/meson.build
@@ -1,0 +1,21 @@
+# This file is part of the libopencm3 project.
+#
+# Generates the GD32F1x0 NVIC header + vector_nvic.c source via the
+# irq2nvic_h script (same shape as the stm32 family meson.builds).
+
+gd32f1x0_nvic_header = custom_target(
+	'nvic.h',
+	command: [irq2nvic, '@INPUT@'],
+	input: 'irq.json',
+	# This script writes three files; we only name one of them as the
+	# meson output (the rest are tracked via path conventions):
+	# - include/libopencm3/gd32/f1x0/nvic.h
+	# - lib/gd32/f1x0/vector_nvic.c
+	# - include/libopencmsis/gd32/f1x0/irqhandlers.h
+	output: 'nvic.h',
+	install: false,
+)
+
+gd32f1x0_vector_nvic = declare_dependency(
+	sources: gd32f1x0_nvic_header,
+)

--- a/include/libopencm3/gd32/f1x0/rcc.h
+++ b/include/libopencm3/gd32/f1x0/rcc.h
@@ -155,6 +155,28 @@
 #define RCC_CFGR_PLLMUL_PLL_CLK_MUL14		0xc
 #define RCC_CFGR_PLLMUL_PLL_CLK_MUL15		0xd
 #define RCC_CFGR_PLLMUL_PLL_CLK_MUL16		0xe
+/* GD32F1x0 extends PLLMUL with PLLMF[4] @ RCU_CFG0[27]. The encoding is
+ * NOT a flat mul-2 — when PLLMF[4]=1 the low nibble restarts at 0 for
+ * MUL17 (so MUL17=0x10, MUL18=0x11, …, MUL32=0x1f). This matches the
+ * vendor SPL macros RCU_PLL_MUL17/18/… in gd32f1x0_rcu.h. The setter
+ * `rcc_set_pll_multiplication_factor` (lib/gd32/f1x0/rcc.c) already
+ * splits the value across PLLMUL_0_3 and PLLMUL_4. */
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL17		0x10
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL18		0x11
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL19		0x12
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL20		0x13
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL21		0x14
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL22		0x15
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL23		0x16
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL24		0x17
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL25		0x18
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL26		0x19
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL27		0x1a
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL28		0x1b
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL29		0x1c
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL30		0x1d
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL31		0x1e
+#define RCC_CFGR_PLLMUL_PLL_CLK_MUL32		0x1f
 /**@}*/
 
 /** @defgroup rcc_cfgr_hsepre PLLXTPRE: HSE divider for PLL entry
@@ -431,6 +453,8 @@ extern uint32_t rcc_apb2_frequency;
 enum rcc_clock_hsi {
 	RCC_CLOCK_HSI_48MHZ,
 	RCC_CLOCK_HSI_64MHZ,
+	/* 72 MHz uses PLLMUL=18, only reachable via PLLMF[4] (GD-specific). */
+	RCC_CLOCK_HSI_72MHZ,
 	RCC_CLOCK_HSI_END
 };
 

--- a/include/libopencm3/gd32/f1x0/rcc.h
+++ b/include/libopencm3/gd32/f1x0/rcc.h
@@ -579,6 +579,12 @@ uint32_t rcc_system_clock_source(void);
 void rcc_clock_setup_pll(const struct rcc_clock_scale *clock);
 void rcc_backupdomain_reset(void);
 
+/* Peripheral clock-frequency helpers (provisional — return APBN frequency). */
+uint32_t rcc_get_usart_clk_freq(uint32_t usart);
+uint32_t rcc_get_timer_clk_freq(uint32_t timer);
+uint32_t rcc_get_i2c_clk_freq(uint32_t i2c);
+uint32_t rcc_get_spi_clk_freq(uint32_t spi);
+
 END_DECLS
 
 #endif

--- a/include/libopencm3/gd32/f1x0/timer.h
+++ b/include/libopencm3/gd32/f1x0/timer.h
@@ -1,0 +1,39 @@
+/** @defgroup timer_defines TIMER Defines
+ *
+ * @brief <b>Defined Constants and Types for the GD32F1x0 Timer</b>
+ *
+ * @ingroup GD32F1x0_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_TIMER_H
+#define LIBOPENCM3_TIMER_H
+
+/* GD32F1x0 timers are register-compatible with STM32F0 / STM32F1 advanced
+ * and general-purpose timers. Empirically validated by regtrace v0.1
+ * (decisions/v0.1/TIMER.md): TIM1 final-state register-write trace matches
+ * stm32/f0 across the canonical center-aligned PWM init pattern.
+ */
+#include <libopencm3/stm32/common/timer_common_all.h>
+#include <libopencm3/stm32/common/timer_common_f24.h>
+
+#endif

--- a/include/libopencm3/gd32/f1x0/usart.h
+++ b/include/libopencm3/gd32/f1x0/usart.h
@@ -1,0 +1,47 @@
+/** @defgroup usart_defines USART Defines
+ *
+ * @brief <b>Defined Constants and Types for the GD32F1x0 USART</b>
+ *
+ * @ingroup GD32F1x0_defines
+ *
+ * @version 1.0.0
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_USART_H
+#define LIBOPENCM3_USART_H
+
+/* GD32F1x0 USART is register-compatible with STM32F0's USART (the v2 family
+ * with separate ISR and TDR/RDR registers). Validated by regtrace v0.2
+ * (decisions/v0.2/USART.md). The BAUD divisor depends on the application's
+ * configured peripheral clock — make sure rcc_apbN_frequency is set
+ * correctly before calling usart_set_baudrate().
+ */
+#include <libopencm3/stm32/common/usart_common_all.h>
+#include <libopencm3/stm32/common/usart_common_v2.h>
+
+/* GD32F1x0 has USART1/2/3/4 (vendor names USART0/1/2/3). Mirror the
+ * stm32/f0 vocabulary so user code referring to USARTn works. */
+#define USART1				USART1_BASE
+#define USART2				USART2_BASE
+#define USART3				USART3_BASE
+#define USART4				USART4_BASE
+
+#endif

--- a/include/libopencm3/stm32/adc.h
+++ b/include/libopencm3/stm32/adc.h
@@ -22,6 +22,8 @@
 
 #if defined(STM32F0)
 #       include <libopencm3/stm32/f0/adc.h>
+#elif defined(GD32F1X0)
+#       include <libopencm3/gd32/f1x0/adc.h>
 #elif defined(STM32F1)
 #       include <libopencm3/stm32/f1/adc.h>
 #elif defined(STM32F3)

--- a/include/libopencm3/stm32/dma.h
+++ b/include/libopencm3/stm32/dma.h
@@ -22,6 +22,8 @@
 
 #if defined(STM32F0)
 #       include <libopencm3/stm32/f0/dma.h>
+#elif defined(GD32F1X0)
+#       include <libopencm3/gd32/f1x0/dma.h>
 #elif defined(STM32F1)
 #       include <libopencm3/stm32/f1/dma.h>
 #elif defined(STM32F2)

--- a/include/libopencm3/stm32/i2c.h
+++ b/include/libopencm3/stm32/i2c.h
@@ -22,6 +22,8 @@
 
 #if defined(STM32F0)
 #       include <libopencm3/stm32/f0/i2c.h>
+#elif defined(GD32F1X0)
+#       include <libopencm3/gd32/f1x0/i2c.h>
 #elif defined(STM32F1)
 #       include <libopencm3/stm32/f1/i2c.h>
 #elif defined(STM32F2)

--- a/include/libopencm3/stm32/iwdg.h
+++ b/include/libopencm3/stm32/iwdg.h
@@ -22,6 +22,8 @@
 
 #if defined(STM32F0)
 #       include <libopencm3/stm32/f0/iwdg.h>
+#elif defined(GD32F1X0)
+#       include <libopencm3/gd32/f1x0/iwdg.h>
 #elif defined(STM32F1)
 #       include <libopencm3/stm32/f1/iwdg.h>
 #elif defined(STM32F2)

--- a/include/libopencm3/stm32/timer.h
+++ b/include/libopencm3/stm32/timer.h
@@ -24,6 +24,8 @@
 
 #if defined(STM32F0)
 #       include <libopencm3/stm32/f0/timer.h>
+#elif defined(GD32F1X0)
+#       include <libopencm3/gd32/f1x0/timer.h>
 #elif defined(STM32F1)
 #       include <libopencm3/stm32/f1/timer.h>
 #elif defined(STM32F2)

--- a/include/libopencm3/stm32/usart.h
+++ b/include/libopencm3/stm32/usart.h
@@ -22,6 +22,8 @@
 
 #if defined(STM32F0)
 #       include <libopencm3/stm32/f0/usart.h>
+#elif defined(GD32F1X0)
+#       include <libopencm3/gd32/f1x0/usart.h>
 #elif defined(STM32F1)
 #       include <libopencm3/stm32/f1/usart.h>
 #elif defined(STM32F2)

--- a/include/meson.build
+++ b/include/meson.build
@@ -40,6 +40,7 @@ target_paths = {
 	'stm32l4': 'stm32/l4',
 	'stm32u5': 'stm32/u5',
 	'lm4f': 'lm3s',
+	'gd32f1x0': 'gd32/f1x0',
 }
 
 if target_platform != 'all'

--- a/lib/gd32/f1x0/Makefile
+++ b/lib/gd32/f1x0/Makefile
@@ -35,6 +35,7 @@ ARFLAGS		= rcs
 
 OBJS += flash.o flash_common_all.o flash_common_f.o flash_common_f01.o
 OBJS += gpio_common_all.o gpio_common_f0234.o
+OBJS += iwdg_common_all.o
 OBJS += rcc.o rcc_common_all.o
 
 VPATH += ../:../../cm3:../common:../../stm32/common

--- a/lib/gd32/f1x0/Makefile
+++ b/lib/gd32/f1x0/Makefile
@@ -40,7 +40,12 @@ OBJS += rcc.o rcc_common_all.o
 OBJS += timer_common_all.o timer_common_f0234.o
 OBJS += dma_common_l1f013.o
 OBJS += usart_common_all.o usart_common_v2.o
+OBJS += adc.o adc_common_v1.o
+OBJS += i2c.o i2c_common_v1.o
 
-VPATH += ../:../../cm3:../common:../../stm32/common
+# stm32/f1 contributes the v1-family family-specific adc.c + i2c.c
+# (adc_reset_calibration / adc_calibration etc.) which adc_common_v1.c
+# alone doesn't provide.
+VPATH += ../:../../cm3:../common:../../stm32/common:../../stm32/f1
 
 include ../../Makefile.include

--- a/lib/gd32/f1x0/Makefile
+++ b/lib/gd32/f1x0/Makefile
@@ -37,6 +37,9 @@ OBJS += flash.o flash_common_all.o flash_common_f.o flash_common_f01.o
 OBJS += gpio_common_all.o gpio_common_f0234.o
 OBJS += iwdg_common_all.o
 OBJS += rcc.o rcc_common_all.o
+OBJS += timer_common_all.o timer_common_f0234.o
+OBJS += dma_common_l1f013.o
+OBJS += usart_common_all.o usart_common_v2.o
 
 VPATH += ../:../../cm3:../common:../../stm32/common
 

--- a/lib/gd32/f1x0/meson.build
+++ b/lib/gd32/f1x0/meson.build
@@ -1,0 +1,66 @@
+# This file is part of the libopencm3 project.
+#
+# GD32F1x0 family library build. Source list mirrors lib/gd32/f1x0/Makefile:
+# gd32-specific (flash/rcc), plus stm32/common reuses (adc_common_v1,
+# gpio_common_f0234, rcc_common_all, …), plus stm32/f1's adc.c + i2c.c.
+
+gd32f1x0_cm3 = declare_dependency(
+	sources: cm3_sources,
+	include_directories: cm3_includes,
+	dependencies: gd32f1x0_vector_nvic,
+)
+
+# Sources specific to the GD32F1x0 series (live in this directory).
+libgd32f1x0_sources = files(
+	'flash.c',
+	'rcc.c',
+)
+
+# stm32/f1 contributes adc.c + i2c.c — same as the make-path VPATH.
+# These are referenced from outside their canonical subdir; meson lets
+# us spell them with files('../../stm32/f1/adc.c').
+libstm32_f1_adc_source = files('../../stm32/f1/adc.c')
+libstm32_f1_i2c_source = files('../../stm32/f1/i2c.c')
+
+libgd32f1x0_compile_args = [
+	'-mcpu=cortex-m3',
+	'-mthumb',
+	'-DGD32F1X0',
+]
+
+libgd32f1x0 = static_library(
+	'opencm3_gd32f1x0',
+	[
+		libgd32f1x0_sources,
+		libstm32_f1_adc_source,
+		libstm32_f1_i2c_source,
+		# stm32/common contributions, in OBJ-list order.
+		libstm32_flash_f01_sources,
+		libstm32_gpio_f0234_sources,
+		libstm32_iwdg_sources,
+		libstm32_rcc_sources,
+		libstm32_timer_f0234_sources,
+		libstm32_dma_sources,
+		libstm32_usart_v2_sources,
+		libstm32_adc_v1_sources,
+		libstm32_i2c_v1_sources,
+	],
+	c_args: libgd32f1x0_compile_args,
+	include_directories: common_includes,
+	implicit_include_directories: false,
+	dependencies: [
+		gd32f1x0_cm3,
+	],
+	pic: false,
+)
+
+opencm3_gd32f1x0 = declare_dependency(
+	compile_args: libgd32f1x0_compile_args,
+	include_directories: common_includes,
+	link_with: libgd32f1x0,
+	link_args: [
+		f'-L@locm3_ld_script_path@',
+	],
+)
+
+meson.override_dependency('opencm3_gd32f1x0', opencm3_gd32f1x0)

--- a/lib/gd32/f1x0/rcc.c
+++ b/lib/gd32/f1x0/rcc.c
@@ -81,7 +81,18 @@ const struct rcc_clock_scale rcc_hsi_configs[] = {
 		.ahb_frequency	= 64000000,
 		.apb1_frequency = 32000000,
 		.apb2_frequency = 64000000,
-	}
+	},
+	{ /* 72MHz — IRC8M / 2 * 18; requires PLLMF[4] (GD-only). */
+		.pllmul = RCC_CFGR_PLLMUL_PLL_CLK_MUL18,
+		.hpre = RCC_CFGR_HPRE_NODIV,
+		.ppre1 = RCC_CFGR_PPRE_DIV2,
+		.ppre2 = RCC_CFGR_PPRE_NODIV,
+		.adcpre = RCC_CFGR_ADCPRE_DIV8,
+		.use_hse = false,
+		.ahb_frequency	= 72000000,
+		.apb1_frequency = 36000000,
+		.apb2_frequency = 72000000,
+	},
 };
 
 const struct rcc_clock_scale rcc_hse8_configs[] = {

--- a/lib/gd32/f1x0/rcc.c
+++ b/lib/gd32/f1x0/rcc.c
@@ -650,5 +650,47 @@ void rcc_backupdomain_reset(void)
 	RCC_BDCR &= ~RCC_BDCR_BDRST;
 }
 
+/*---------------------------------------------------------------------------*/
+/** @brief Get the peripheral clock speed for the USART at base specified.
+ *
+ * Provisional implementation: returns the APB bus frequency the USART sits
+ * on. Sufficient for usart_set_baudrate() to compute the BRR divisor.
+ */
+uint32_t rcc_get_usart_clk_freq(uint32_t usart)
+{
+	if (usart == USART1_BASE) {
+		return rcc_apb2_frequency;
+	}
+	return rcc_apb1_frequency;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Get the peripheral clock speed for the Timer at base specified. */
+uint32_t rcc_get_timer_clk_freq(uint32_t timer)
+{
+	if (timer == TIM1_BASE || timer == TIM15_BASE
+	    || timer == TIM16_BASE || timer == TIM17_BASE) {
+		return rcc_apb2_frequency;
+	}
+	return rcc_apb1_frequency;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Get the peripheral clock speed for the I2C at base specified. */
+uint32_t rcc_get_i2c_clk_freq(uint32_t i2c __attribute__((unused)))
+{
+	return rcc_apb1_frequency;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Get the peripheral clock speed for SPI at base specified. */
+uint32_t rcc_get_spi_clk_freq(uint32_t spi)
+{
+	if (spi == SPI1_BASE) {
+		return rcc_apb2_frequency;
+	}
+	return rcc_apb1_frequency;
+}
+
 /**@}*/
 

--- a/lib/gd32/f1x0/rcc.c
+++ b/lib/gd32/f1x0/rcc.c
@@ -499,6 +499,18 @@ void rcc_set_adcpre(uint32_t adcpre)
 {
 	RCC_CFGR = (RCC_CFGR & ~RCC_CFGR_ADCPRE) |
 			(adcpre << RCC_CFGR_ADCPRE_SHIFT);
+	/* GD32F1x0 has a separate ADC clock SOURCE select bit in CFGR3
+	 * (called ADCSEL in the GD32 SPL, ADCSW here following the
+	 * STM32F0 family naming):
+	 *   ADCSW=0 (default after reset): CK_ADC is the divided IRC28M
+	 *   ADCSW=1: CK_ADC is the divided APB2 clock
+	 * After reset ADCSW=0 and IRC28MEN=0, so the ADC has no clock and
+	 * any calibration / conversion attempt hangs. STM32F1 has no
+	 * equivalent bit, so the inherited stm32 ADC drivers don't touch
+	 * it. Set ADCSW here to route the prescaler the caller just chose
+	 * to the ADC. Matches GD32 SPL's `rcu_adc_clock_config(APB2_DIV*)`
+	 * which writes both CFGR.ADCPRE and CFGR3.ADCSW. */
+	RCC_CFGR3 |= RCC_CFGR3_ADCSW;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/gd32/meson.build
+++ b/lib/gd32/meson.build
@@ -1,0 +1,20 @@
+# This file is part of the libopencm3 project.
+#
+# GD32 family dispatcher. Maps the target_platform option to the proper
+# per-family subdir (mirrors lib/stm32/meson.build's pattern). GD32
+# parts reuse a lot of the STM32 register layout — see lib/meson.build
+# for where stm32/common is pulled in.
+
+subdirs = {
+	'gd32f1x0': 'f1x0',
+}
+
+if target_platform != 'all'
+	if subdirs.has_key(target_platform)
+		subdir(subdirs[target_platform])
+	endif
+else
+	foreach subdir_name, subdir_path : subdirs
+		subdir(subdir_path)
+	endforeach
+endif

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -35,9 +35,18 @@ subdir('cm3')
 
 locm3_ld_script_path = meson.current_source_dir()
 
+# STM32 family source-list variables (libstm32_*_sources). Hoisted to
+# the top of the dispatch because the GD32 family also reuses them
+# (gd32/f1x0 picks up stm32/common's adc_common_v1, gpio_common_f0234,
+# rcc_common_all, etc., same as the make path's VPATH does).
+subdir('stm32/common')
+
 # Now take the platform target and map it to a suitable target family
 if target_platform.startswith('stm32') or target_platform == 'all'
 	subdir('stm32')
+endif
+if target_platform.startswith('gd32') or target_platform == 'all'
+	subdir('gd32')
 endif
 if target_platform == 'lm4f' or target_platform == 'all'
 	subdir('lm4f')

--- a/lib/stm32/meson.build
+++ b/lib/stm32/meson.build
@@ -28,8 +28,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Bring in all the common STM32 definitions
-subdir('common')
+# Common STM32 source-list variables (libstm32_*_sources) are now
+# brought in by lib/meson.build before any family dispatch, so they're
+# available to both stm32 and gd32 family builds.
 
 # Sources specific to STM32 parts
 libstm32_can_sources = files('can.c')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,7 @@ option(
 		'stm32f7',
 		'stm32l4',
 		'lm4f',
+		'gd32f1x0',
 	],
 	value: 'all',
 	description: 'The hardware platform you wish to target'


### PR DESCRIPTION
# gd32/f1x0: Complete the GD32F1x0 family port

## Summary

Extends the existing partial GD32F1x0 stub (added by Icenowy Zheng in
[`330d5fd5`](https://github.com/libopencm3/libopencm3/commit/330d5fd5) —
*gd32: add new chip series f1x0*) with the peripheral support
needed to actually run real firmware on the family: IWDG, TIMER, DMA,
USART, ADC, I2C — plus an RCC fix for a GigaDevice quirk that breaks
ADC calibration, an RCC extension covering the F1x0's wider PLL
multiplier range, and a meson build target.

All peripherals reuse the existing `stm32/common` and `stm32/f1`
implementations via VPATH (Make path) or shared meson source-list
variables (meson path) — no copypasted trees. The pattern matches the
design @karlp endorsed in #928: `libopencm3/gd32/<family>/` for the
gd32-specific parts, with the `stm32/<peripheral>.h` dispatchers
adding `#elif defined(GD32F1X0)` arms only for peripherals that are
actually shared.

## Commits

| | |
|---|---|
| `gd32/f1x0: Implemented support for the IWDG (FWDGT) peripheral` | shares `iwdg_common_all.c` |
| `gd32/f1x0: Implemented support for the TIMER, DMA, and USART peripherals` | shares `timer_common_*`, `dma_common_l1f013`, `usart_common_v2` |
| `gd32/f1x0: Implemented support for the ADC and I2C peripherals` | shares v1 + pulls `stm32/f1`'s `adc.c` and `i2c.c` via VPATH |
| `gd32/f1x0: Extended RCC with PLLMUL MUL17..32 and HSI 72 MHz config` | GD's PLL accepts up to 32× (vs F1's 16×); HSI/2-only path to 72 MHz |
| `gd32/f1x0: Fixed rcc_set_adcpre to also set CFGR3.ADCSW` | GigaDevice-specific quirk; without ADCSW=1 the ADC has no clock |
| `gd32/f1x0: Added Meson build target` | mirrors `lib/stm32/f1/meson.build` |

## Hardware validation

Tested end-to-end on a **GD32F130C8** hoverboard control board:
ADC + DMA + TIM1 PWM + TIM3 trigger pipeline at 12 kHz, USART telemetry,
flash-stored config persisting across resets. Real firmware repo using
this branch: <link to hoverboard repo if you want it referenced>.

The other parts in the F1x0 family — F150 (adds USB), F170/F190 (adds
CAN) — share the same peripheral versions for everything this PR
touches, so register layouts are identical for the peripherals added.
USB and CAN aren't touched here, so this PR doesn't claim to cover them.

## Design notes

A few things worth flagging for review:

**`rcc_set_adcpre` overload.** GD32F1x0 has a `CFGR3.ADCSW` bit selecting
between the IRC28M internal source (default) and APB2 as the ADC clock.
With ADCSW=0, ADC calibration hangs forever — none of the ADC's clocks
tick. I folded the `ADCSW=1` write into `rcc_set_adcpre()` since the
function lives in `lib/gd32/f1x0/rcc.c` (so no STM32 path is affected)
and it makes the function actually do what its name implies on this
silicon. Open to splitting it into a separate accessor if preferred.

**Meson commit's `lib/meson.build` hoist.** To let `lib/gd32/f1x0/`
reuse `libstm32_*_sources` source-list variables defined in
`lib/stm32/common/meson.build`, the `subdir('stm32/common')` call moves
from `lib/stm32/meson.build` up to `lib/meson.build`, so it runs
unconditionally before any per-family dispatch. The variable names are
left as `libstm32_*` for now since renaming would touch ~30 files
across all stm32 family meson.build files — happy to do that as a
follow-up if you'd prefer it inside this PR. The alternative pattern
(explicit `files('../../stm32/common/<name>.c', ...)` in the gd32
meson.build) duplicates what each peripheral commit's Makefile already
maintains, which is why I went with the hoist.

## What this PR is *not*

- Doesn't add F150/F170/F190 USB or CAN driver support (they use
  separate peripheral instances)
- Doesn't add the parallel `gd32/f10x` family (separate PR; this one
  is intentionally scoped to F1x0)
- Doesn't change any existing STM32 family behaviour — the
  `lib/meson.build` hoist is structurally a move, not a semantic change

## Build verification

```sh
# Make
make TARGETS=gd32/f1x0 lib

# Meson
meson setup build --cross-file <your cross-file> -Dtarget=gd32f1x0
ninja -C build
```

Both produce a working `libopencm3_gd32f1x0.a`. The hoverboard firmware
that drove the original development links against this archive and
flashes a 19,516-byte ELF that runs end-to-end.
