### PR TITLE
fix bug in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ LIB_DIRS:=$(wildcard $(addprefix lib/,$(TARGETS)))
 $(LIB_DIRS): $(IRQ_GENERATED_FILES)
 	$(Q)$(RM) .stamp_failure_$(subst /,_,$@)
 	@printf "  BUILD   $@\n";
-	$(Q)$(MAKE) --directory=$@ PREFIX="$(PREFIX)" || \
+	$(Q)$(MAKE) --directory=$@ PREFIX="$(PREFIX)" TARGETS="$(subst lib/,,$@)" || \
 		echo "Failure building: $@: code: $$?" > .stamp_failure_$(subst /,_,$@)
 
 lib: $(LIB_DIRS)
@@ -89,8 +89,8 @@ clean: $(IRQ_DEFN_FILES:=.cleanhdr) $(LIB_DIRS:=.clean) $(EXAMPLE_DIRS:=.clean) 
 
 %.clean:
 	$(Q)if [ -d $* ]; then \
-		printf "  CLEAN   $*\n"; \
-		$(MAKE) -C $* clean || exit $?; \
+		printf "  CLEAN   $(subst lib/,build/,$*)\n"; \
+		$(MAKE) -C $* TARGETS="$(subst lib/,,$*)" clean || exit $?; \
 	fi;
 	$(Q)$(RM) .stamp_failure_*;
 

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,11 @@ build: lib
 
 include/libopencm3/%/nvic.h lib/%/vector_nvic.c include/libopencmsis/%/irqhandlers.h: include/libopencm3/%/irq.json ./scripts/irq2nvic_h
 	@printf "  GENHDR  $*\n";
-	$(Q)./scripts/irq2nvic_h ./$<;
+	$(Q)python ./scripts/irq2nvic_h ./$<;
 
 %.cleanhdr:
 	@printf "  CLNHDR  $*\n";
-	$(Q)./scripts/irq2nvic_h --remove ./$*
+	$(Q)python ./scripts/irq2nvic_h --remove ./$*
 
 LIB_DIRS:=$(wildcard $(addprefix lib/,$(TARGETS)))
 $(LIB_DIRS): $(IRQ_GENERATED_FILES)

--- a/lib/Makefile.include
+++ b/lib/Makefile.include
@@ -23,26 +23,41 @@ ifneq ($(V),1)
 Q := @
 endif
 
+BUILD_PATH := ../../../build
+TARGET_PATH := $(addprefix $(BUILD_PATH)/, $(TARGETS))
+LIB_PATH := $(addprefix $(TARGET_PATH)/, lib)
+OBJ_PATH := $(addprefix $(TARGET_PATH)/, obj)
+
 # common objects
 OBJS += vector.o systick.o scb.o nvic.o assert.o sync.o dwt.o
+
+# store object files in the build directory
+OBJS := $(addprefix $(OBJ_PATH)/, $(OBJS))
 
 # Slightly bigger .elf files but gains the ability to decode macros
 DEBUG_FLAGS ?= -ggdb3
 STANDARD_FLAGS ?= -std=c99
 
-all: $(SRCLIBDIR)/$(LIBNAME).a
+all: $(LIB_PATH)/$(LIBNAME).a
 
-$(SRCLIBDIR)/$(LIBNAME).a: $(OBJS)
+$(LIB_PATH)/$(LIBNAME).a: $(OBJS) | $(LIB_PATH)
 	@printf "  AR      $(LIBNAME).a\n"
 	$(Q)$(AR) $(ARFLAGS) "$@" $(OBJS)
 
-%.o: %.c
+$(LIB_PATH):
+	@printf "  create directory   $@\n";
+	$(Q)mkdir -p $@
+
+$(OBJ_PATH)/%.o: %.c | $(OBJ_PATH)
 	@printf "  CC      $(<F)\n"
 	$(Q)$(CC) $(TGT_CFLAGS) $(CFLAGS) -o $@ -c $<
 
+$(OBJ_PATH):
+	@printf "  create directory   $@\n";
+	$(Q)mkdir -p $@
+
 clean:
-	$(Q)rm -f *.o *.d ../*.o ../*.d
-	$(Q)rm -f $(SRCLIBDIR)/$(LIBNAME).a
+	$(Q)rm -rf $(TARGET_PATH)
 
 .PHONY: clean
 


### PR DESCRIPTION
The compilation fails when I compile the code using gnu make on windows.
The root cause is in line 65 and 69 of the Makefile, the python script executes as binary.
It is better to use python to execute the script.
I fixed this bug and tested it. The code can be compiled on windows now.