### PR TITLE
exti: fix wrong SYSCFG_EXTICR value for GPIOH on parts without port G (#796)

### DIFF
--- a/lib/stm32/common/exti_common_all.c
+++ b/lib/stm32/common/exti_common_all.c
@@ -149,7 +149,15 @@ void exti_select_source(uint32_t exti, uint32_t gpioport)
 #endif
 #if defined(GPIOH) && defined(GPIO_PORT_H_BASE)
 		case GPIOH:
+#if defined(GPIOG) && defined(GPIO_PORT_G_BASE)
 			bits = 7U;
+#else
+			/* Some parts (e.g. STM32L0) have no port F or G, and
+			 * port H takes SYSCFG_EXTICRx value 5, not 7 - see
+			 * RM0376 "10.2.4 SYSCFG external interrupt
+			 * configuration register 1". */
+			bits = 5U;
+#endif
 			break;
 #endif
 #if defined(GPIOI) && defined(GPIO_PORT_I_BASE)


### PR DESCRIPTION
Fixes #796.

## Problem

`exti_select_source()` hardcodes GPIOH's SYSCFG_EXTICRx field value as 7, assuming ports are numbered contiguously A=0, B=1, ..., H=7. This holds for parts with a full A-H (or beyond) port range, but not for STM32L0, which has no port F or G - only A, B, C, D, and H. Per RM0376 "10.2.4 SYSCFG external interrupt configuration register 1", GPIOH's correct EXTICR value on these parts is **5**, not 7 (this correct value is already defined for STM32L0 specifically as `SYSCFG_EXTICR_GPIOH` in `include/libopencm3/stm32/l0/syscfg.h`, but this shared/common function never used it).

Confirmed by @karlp in the issue thread ("yuk. Confirmed. Thanks again ST :(").

## Fix

Select 7 only when `GPIOG` (and thus, by construction, GPIOF/E too) is defined for the target part; otherwise use 5. I checked every STM32 family's `memorymap.h` in this tree and STM32L0 is the only one with `GPIO_PORT_H_BASE` defined but not `GPIO_PORT_G_BASE`, so this change is scoped precisely to STM32L0 and cannot affect any other currently supported part.

## Verification

I don't have STM32L0 hardware to test the EXTI interrupt routing end-to-end, so I verified the conditional-compilation logic itself with a standalone C reproduction mirroring the exact `GPIOG`/`GPIO_PORT_G_BASE` guard structure:

- Without `GPIOG` defined (simulating STM32L0): before the fix, computes `bits = 7` (wrong per RM0376). After the fix, computes `bits = 5` (correct).
- With `GPIOG` defined (simulating F4/F7/etc., a regression check): after the fix, still computes `bits = 7` (unchanged), confirming no impact on parts that do have port G.

## Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.