### PR TITLE
Enable CRCv2 for STM32U5

### DIFF
--- a/include/libopencm3/stm32/crc.h
+++ b/include/libopencm3/stm32/crc.h
@@ -44,6 +44,8 @@
 #       include <libopencm3/stm32/g4/crc.h>
 #elif defined(STM32H7)
 #       include <libopencm3/stm32/h7/crc.h>
+#elif defined(STM32U5)
+#       include <libopencm3/stm32/u5/crc.h>
 #else
 #       error "stm32 family not defined."
 #endif

--- a/include/libopencm3/stm32/u5/crc.h
+++ b/include/libopencm3/stm32/u5/crc.h
@@ -1,0 +1,31 @@
+/** @defgroup crc_defines CRC Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32U5xx CRC Generator </b>
+ *
+ * @ingroup STM32U5xx_defines
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_CRC_H
+#define LIBOPENCM3_CRC_H
+
+#include <libopencm3/stm32/common/crc_v2.h>
+
+#endif

--- a/lib/stm32/u5/Makefile
+++ b/lib/stm32/u5/Makefile
@@ -36,6 +36,7 @@ TGT_CFLAGS	+= $(STANDARD_FLAGS)
 ARFLAGS		= rcs
 
 OBJS += adc_common_v2.o adc_common_v2_multi.o adc.o
+OBJS += crc_common_all.o crc_v2.o
 OBJS += dma.o
 OBJS += desig_common_v1.o
 OBJS += exti_common_all.o

--- a/lib/stm32/u5/meson.build
+++ b/lib/stm32/u5/meson.build
@@ -59,6 +59,7 @@ libstm32u5 = static_library(
 	[
 		libstm32u5_sources,
 		libstm32_adc_v2_multi_sources,
+		libstm32_crc_v2_sources,
 		libstm32_crs_sources,
 		libstm32_desig_v1_sources,
 		libstm32_exti_sources,


### PR DESCRIPTION
* STM32U585 contains a CRC peripheral (v2, with support for bit-reverse, 8/16/32 size, modifiable polynomial)
* Copy the boilerplate header (from STM32L4) to enable existing support in libopencm3 for that

Tested on https://github.com/WeActStudio/WeActStudio.STM32U585Cx_CoreBoard , like PR1612