### PR TITLE
Add ICACHE support

### DIFF
--- a/include/libopencm3/stm32/common/icache_common_all.h
+++ b/include/libopencm3/stm32/common/icache_common_all.h
@@ -1,0 +1,93 @@
+/** @addtogroup icache_defines
+ *
+ * @author @htmlonly &copy; @endhtmlonly
+ * 2026 ALTracer <11005378+ALTracer@users.noreply.github.com>
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2026 ALTracer <11005378+ALTracer@users.noreply.github.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+/* THIS FILE SHOULD NOT BE INCLUDED DIRECTLY, BUT ONLY VIA ICACHE.H
+The order of header inclusion is important. icache.h includes the device
+specific memorymap.h header before including this header file.*/
+
+/** @cond */
+#ifdef LIBOPENCM3_ICACHE_H
+/** @endcond */
+#ifndef LIBOPENCM3_ICACHE_COMMON_H
+#define LIBOPENCM3_ICACHE_COMMON_H
+
+/** @defgroup icache_registers ICACHE registers
+ * @ingroup icache_defines
+@{*/
+/** ICACHE control register */
+#define ICACHE_CR	MMIO32(ICACHE_BASE + 0x000U)
+/** ICACHE status register */
+#define ICACHE_SR	MMIO32(ICACHE_BASE + 0x004U)
+/**@}*/
+
+/** @defgroup icache_cr CR ICACHE control register
+ * @ingroup icache_defines
+@{*/
+/** EN: enable */
+#define ICACHE_CR_EN		(1U << 0U)
+/** CACHEINV: cache invalidation */
+#define ICACHE_CR_CACHEINV	(1U << 1U)
+/** WAYSEL: cache associativity mode selection. Defaults to 1, or 0x4, i.e. 2-way set associative */
+#define ICACHE_CR_WAYSEL	(1U << 2U)
+/**@}*/
+
+/** @defgroup icache_sr SR ICACHE status register
+ * @ingroup icache_defines
+@{*/
+/** BUSYF: busy flag, high during a CACHEINV operation */
+#define ICACHE_SR_BUSYF		(1U << 0U)
+/** BUSYENDF: busy-end flag, asserted by hardware after CACHEINV finishes */
+#define ICACHE_SR_BUSYENDF	(1U << 1U)
+/** ERRF: error flag (cacheable write detected) */
+#define ICACHE_SR_ERRF		(1U << 2U)
+/**@}*/
+
+BEGIN_DECLS
+
+/** Enable the Instruction Cache */
+void icache_enable(void);
+
+/** Disable the Instruction Cache */
+void icache_disable(void);
+
+/** Invalidate the Instruction Cache.
+ * During invalidation ICACHE is busy and will simply
+ * forward any reads to Flash as if non-cacheable.
+ */
+void icache_reset(void);
+
+END_DECLS
+
+#endif
+/** @cond */
+#else
+#warning "icache_common_all.h should not be included explicitly, only via icache.h"
+#endif
+/** @endcond */
+/**@}*/

--- a/include/libopencm3/stm32/icache.h
+++ b/include/libopencm3/stm32/icache.h
@@ -1,0 +1,35 @@
+/* This provides unification of code over STM32 subfamilies */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/stm32/memorymap.h>
+
+#if defined(STM32L5)
+#       include <libopencm3/stm32/l5/icache.h>
+#elif defined(STM32H5)
+#       include <libopencm3/stm32/h5/icache.h>
+#elif defined(STM32U5)
+#       include <libopencm3/stm32/u5/icache.h>
+#elif defined(STM32C5)
+#       include <libopencm3/stm32/c5/icache.h>
+#elif defined(STM32U3)
+#       include <libopencm3/stm32/u3/icache.h>
+#else
+#       error "stm32 family not defined or not supported for this peripheral"
+#endif

--- a/include/libopencm3/stm32/u5/icache.h
+++ b/include/libopencm3/stm32/u5/icache.h
@@ -1,0 +1,31 @@
+/** @defgroup icache_defines ICACHE Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32U5xx Instruction Cache </b>
+ *
+ * @ingroup STM32U5xx_defines
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_ICACHE_H
+#define LIBOPENCM3_ICACHE_H
+
+#include <libopencm3/stm32/common/icache_common_all.h>
+
+#endif

--- a/lib/stm32/common/icache_common_all.c
+++ b/lib/stm32/common/icache_common_all.c
@@ -1,0 +1,44 @@
+/** @addtogroup icache_file
+ *
+ */
+
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@{*/
+
+#include <libopencm3/stm32/icache.h>
+
+void icache_enable(void)
+{
+	/* Wait for potential invalidation still undergoing */
+	while (ICACHE_SR & ICACHE_SR_BUSYF)
+		continue;
+	ICACHE_CR |= ICACHE_CR_EN;
+}
+
+void icache_disable(void)
+{
+	ICACHE_CR &= ~ICACHE_CR_EN;
+}
+
+void icache_reset(void)
+{
+	ICACHE_CR |= ICACHE_CR_CACHEINV;
+}
+
+/**@}*/

--- a/lib/stm32/common/meson.build
+++ b/lib/stm32/common/meson.build
@@ -98,6 +98,7 @@ libstm32_gpio_f0234_sources = [
 	files('gpio_common_f0234.c'),
 ]
 libstm32_hash_f24_sources = files('hash_common_f24.c')
+libstm32_icache_sources = files('icache_common_all.c')
 libstm32_iwdg_sources = files('iwdg_common_all.c')
 libstm32_i2c_v1_sources = files('i2c_common_v1.c')
 libstm32_i2c_v2_sources = files('i2c_common_v2.c')

--- a/lib/stm32/u5/Makefile
+++ b/lib/stm32/u5/Makefile
@@ -42,6 +42,7 @@ OBJS += desig_common_v1.o
 OBJS += exti_common_all.o
 OBJS += flash_common_all.o flash.o
 OBJS += gpio_common_all.o gpio_common_f0234.o
+OBJS += icache_common_all.o
 OBJS += iwdg_common_all.o
 OBJS += i2c_common_v2.o
 OBJS += pwr.o

--- a/lib/stm32/u5/meson.build
+++ b/lib/stm32/u5/meson.build
@@ -65,6 +65,7 @@ libstm32u5 = static_library(
 		libstm32_exti_sources,
 		libstm32_flash_sources,
 		libstm32_gpio_f0234_sources,
+		libstm32_icache_sources,
 		libstm32_i2c_v2_sources,
 		libstm32_iwdg_sources,
 		libstm32_rcc_sources,


### PR DESCRIPTION
* All modern STM32 SoC based on Cortex-M33 contain an ICACHE peripheral (Instruction Cache), disabled by default. To improve performance at high ratios of System-to-Flash clock, ICACHE should be enabled.
* This PR provides basic functions to enable, disable, and invalidate instruction cache, as well as macros for registers and bits.
* Currently enabled for U5 only, but written in such a way that other family chips (L5, H5, C5, U3) can leverage this support easily when added to libopencm3. Enabled in Makefiles and Meson.

DCACHE support is out of scope, because internal SRAM caching does not improve latency, and only bigger U5 & H5 (not H503) have FMC, OCTOSPI external memory where data load/store could be cached.